### PR TITLE
fix: lnd auto-unlock startup proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ The confirmation phrase is required — there is no skip. Once confirmed,
 the flow transitions into auto-unlock configuration so you don't have
 to manually unlock on every reboot. VPN gracefully stops and starts LND
 once to verify the password, and reports success only after LND reaches
-authenticated RPC readiness on the installed Bitcoin network. If
+its native `RPC_ACTIVE` state, or `SERVER_ACTIVE` if it advances between
+checks. Network-profile validation remains an independent installer
+responsibility, and password verification does not wait for blockchain
+synchronization. If
 verification fails, LND is left stably locked instead of entering a
 restart loop, and the same form lets you retry.
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ creation flow:
 
 The confirmation phrase is required — there is no skip. Once confirmed,
 the flow transitions into auto-unlock configuration so you don't have
-to manually unlock on every reboot. VPN restarts LND once to verify the
-password and reports success only after LND is fully ready and an
-authenticated `GetInfo` succeeds. If verification fails, LND is left
-stably locked instead of entering a restart loop, and the same form lets
-you retry.
+to manually unlock on every reboot. VPN gracefully stops and starts LND
+once to verify the password, and reports success only after LND reaches
+authenticated RPC readiness on the installed Bitcoin network. If
+verification fails, LND is left stably locked instead of entering a
+restart loop, and the same form lets you retry.
 
 A note on cancellation: pressing `ctrl+c` during the password prompt is
 a legitimate escape hatch (no seed has been generated yet, nothing is

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -43,13 +43,16 @@ type verbDef struct {
 }
 
 var verbs = map[string]verbDef{
-	helper.VerbServiceAction:   {14 * time.Minute, verbServiceAction},
+	// LND uses its upstream readiness notification and permits up to 20
+	// minutes for an ordinary start. Keep the helper connection above the
+	// longest supported service start plus its graceful-stop allowance.
+	helper.VerbServiceAction:   {30 * time.Minute, verbServiceAction},
 	helper.VerbReboot:          {1 * time.Minute, verbReboot},
 	helper.VerbDirSize:         {2 * time.Minute, verbDirSize},
 	helper.VerbSetUserPassword: {1 * time.Minute, verbSetUserPassword},
 	// LND permits a graceful stop to take up to five minutes. A failed
-	// transition can require a second restart plus a second 120-second proof,
-	// so the helper connection must outlive that bounded recovery path.
+	// transition can require a second stop/start recovery, so the helper
+	// connection must outlive both bounded systemd transactions.
 	helper.VerbStageWalletPassword:  {20 * time.Minute, verbStageWalletPassword},
 	helper.VerbRemoveWalletPassword: {20 * time.Minute, verbRemoveWalletPassword},
 	helper.VerbStageLNDCredentials:  {3 * time.Minute, verbStageLNDCredentials},

--- a/internal/helperd/verbs_test.go
+++ b/internal/helperd/verbs_test.go
@@ -34,6 +34,15 @@ func TestEveryVerbHasDeadline(t *testing.T) {
 	}
 }
 
+func TestServiceActionDeadlineCoversLNDStopAndNotifiedStart(t *testing.T) {
+	// The installed LND unit permits 300 seconds to stop and 1200 seconds
+	// to notify readiness during an ordinary restart. The helper socket must
+	// remain available for that complete systemd transaction.
+	if got := verbs[helper.VerbServiceAction].deadline; got < 25*time.Minute {
+		t.Fatalf("service-action deadline = %s, want at least 25m", got)
+	}
+}
+
 // The menu is closed: exactly the ruled verbs, nothing else.
 // Adding a verb must be a deliberate act that updates this
 // list too.

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -391,7 +391,13 @@ func parseLNDBitcoindRPCPassword(content string) (string, error) {
 // root-staged password file, so the wallet unlocks without an
 // operator on every service start. Everything else about the
 // two variants is identical by construction — they come from
-// this one template. Pure — unit-tested.
+// this one template. Pinned LND natively notifies systemd once
+// locked-wallet RPC is available or an auto-unlocked wallet has
+// reached RPC_ACTIVE, before chain synchronization. The extended
+// normal-start timeout follows LND's upstream unit guidance for
+// occasional database work; auto-unlock verification temporarily
+// overrides it with the product's bounded one-attempt window.
+// Pure — unit-tested.
 func lndServiceUnit(username string, withUnlock bool) string {
 	unlockFlag := ""
 	if withUnlock {
@@ -404,7 +410,7 @@ After=bitcoind.service tor.service
 Wants=bitcoind.service
 
 [Service]
-Type=simple
+Type=notify
 User=%s
 Group=%s
 SupplementaryGroups=debian-tor
@@ -412,6 +418,7 @@ UMask=0077
 ExecStart=/usr/local/bin/lnd --configfile=/etc/lnd/lnd.conf%s
 Restart=on-failure
 RestartSec=30
+TimeoutStartSec=1200
 TimeoutStopSec=300
 PrivateTmp=true
 ProtectSystem=full

--- a/internal/installer/lnd_auto_unlock.go
+++ b/internal/installer/lnd_auto_unlock.go
@@ -59,6 +59,7 @@ type autoUnlockArtifacts struct {
 type lndUnitStatus struct {
 	invocationID     string
 	mainPID          int
+	controlPID       int
 	serviceType      string
 	activeState      string
 	subState         string
@@ -181,8 +182,9 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 	}
 
 	runtimeTransitioned := false
-	fail := func(
-		outcome AutoUnlockOutcome, stage, detail string, cause error,
+	failWithRecoveryStage := func(
+		outcome AutoUnlockOutcome, stage, recoveryStage, detail string,
+		cause error,
 	) AutoUnlockResult {
 		if cause != nil {
 			logger.System("auto-unlock: %s: %v", stage, cause)
@@ -192,10 +194,18 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 		if err := restoreDisabled(
 			ops, cfg, before, runtimeTransitioned,
 		); err != nil {
-			return repairRequired(stage,
+			return repairRequired(recoveryStage,
 				fmt.Errorf("recovery failed: %w", err))
 		}
 		return AutoUnlockResult{Outcome: outcome, Detail: detail}
+	}
+	fail := func(
+		outcome AutoUnlockOutcome, stage, detail string, cause error,
+	) AutoUnlockResult {
+		return failWithRecoveryStage(
+			outcome, stage, "automatic return to locked state", detail,
+			cause,
+		)
 	}
 
 	if err := ops.writePassword(password); err != nil {
@@ -225,8 +235,11 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 		lnrpc.WalletState_RPC_ACTIVE, cfg.Network,
 	)
 	if invocation == invocationExited {
-		return fail(AutoUnlockVerificationFailed,
-			"verify candidate wallet password", "", verifyErr)
+		return failWithRecoveryStage(
+			AutoUnlockVerificationFailed,
+			"verify candidate wallet password",
+			"automatic recovery after password rejection", "", verifyErr,
+		)
 	}
 	if invocation == invocationStartTimedOut {
 		return fail(AutoUnlockVerificationTimedOut,
@@ -407,7 +420,7 @@ func removePasswordDurably(ops autoUnlockOps) error {
 func replaceWithLockedPlainInvocation(
 	ops autoUnlockOps, previousID, network string,
 ) error {
-	if err := stopAndVerifyInactive(ops); err != nil {
+	if err := stopAndVerifyNoProcess(ops); err != nil {
 		return err
 	}
 	removeErr := removePasswordDurably(ops)
@@ -665,14 +678,20 @@ func stopStartAndVerifyInvocation(
 	ops autoUnlockOps, previousID string,
 	withUnlock bool, wantState lnrpc.WalletState, network string,
 ) (error, invocationResult, error) {
-	if err := stopAndVerifyInactive(ops); err != nil {
+	if err := stopAndVerifyNoProcess(ops); err != nil {
 		return err, invocationUnknown, nil
 	}
 	return startAndVerifyInvocation(
 		ops, previousID, withUnlock, wantState, network)
 }
 
-func stopAndVerifyInactive(ops autoUnlockOps) error {
+// stopAndVerifyNoProcess accepts systemd's two quiescent unit states. An
+// inactive unit stopped normally; a failed unit is also inactive but retains
+// the unsuccessful result for diagnosis. Restart=no is required so a failed
+// candidate cannot enter an automatic restart transition between samples.
+// Neither state is sufficient on its own: both the service's main process and
+// any systemd control process must also be absent before credential removal.
+func stopAndVerifyNoProcess(ops autoUnlockOps) error {
 	if err := ops.stopLND(); err != nil {
 		return err
 	}
@@ -680,8 +699,19 @@ func stopAndVerifyInactive(ops autoUnlockOps) error {
 	if err != nil {
 		return err
 	}
-	if status.mainPID != 0 || status.activeState != "inactive" {
-		return errors.New("LND did not stop completely")
+	if status.restart != "no" {
+		return fmt.Errorf(
+			"LND stop proof has Restart=%s, want no", status.restart)
+	}
+	if status.mainPID != 0 || status.controlPID != 0 {
+		return fmt.Errorf(
+			"LND still has a process after stop: MainPID=%d ControlPID=%d",
+			status.mainPID, status.controlPID)
+	}
+	if status.activeState != "inactive" && status.activeState != "failed" {
+		return fmt.Errorf(
+			"LND is not process-free after stop: ActiveState=%s",
+			status.activeState)
 	}
 	return nil
 }
@@ -844,6 +874,7 @@ func verifyStableProcessArgs(
 	ops autoUnlockOps, before lndUnitStatus, withUnlock bool,
 ) error {
 	if before.invocationID == "" || before.mainPID <= 0 ||
+		before.controlPID != 0 ||
 		before.activeState != "active" || before.subState != "running" {
 		return errors.New("LND invocation is not stably running")
 	}
@@ -853,7 +884,8 @@ func verifyStableProcessArgs(
 		return statusErr
 	}
 	if after.invocationID != before.invocationID ||
-		after.mainPID != before.mainPID || after.activeState != "active" ||
+		after.mainPID != before.mainPID || after.controlPID != 0 ||
+		after.activeState != "active" ||
 		after.subState != "running" {
 		return errLNDInvocationChanged
 	}
@@ -1231,8 +1263,8 @@ func validateInstalledLNDUnit() error {
 
 func readLNDUnitStatus() (lndUnitStatus, error) {
 	properties := []string{
-		"InvocationID", "MainPID", "Type", "ActiveState", "SubState", "Result",
-		"ExecMainStatus", "Restart", "FragmentPath", "DropInPaths",
+		"InvocationID", "MainPID", "ControlPID", "Type", "ActiveState",
+		"SubState", "Result", "ExecMainStatus", "Restart", "FragmentPath", "DropInPaths",
 		"NeedDaemonReload", "ExecStart",
 	}
 	args := []string{"show", "lnd.service", "--no-pager"}
@@ -1254,12 +1286,18 @@ func readLNDUnitStatus() (lndUnitStatus, error) {
 	if err != nil {
 		return lndUnitStatus{}, fmt.Errorf("parse LND MainPID %q: %w", values["MainPID"], err)
 	}
+	controlPID, err := strconv.Atoi(values["ControlPID"])
+	if err != nil {
+		return lndUnitStatus{}, fmt.Errorf(
+			"parse LND ControlPID %q: %w", values["ControlPID"], err)
+	}
 	drops := []string(nil)
 	if values["DropInPaths"] != "" {
 		drops = strings.Fields(values["DropInPaths"])
 	}
 	return lndUnitStatus{
 		invocationID: values["InvocationID"], mainPID: pid,
+		controlPID:  controlPID,
 		serviceType: values["Type"],
 		activeState: values["ActiveState"], subState: values["SubState"],
 		result: values["Result"], execMainStatus: values["ExecMainStatus"],

--- a/internal/installer/lnd_auto_unlock.go
+++ b/internal/installer/lnd_auto_unlock.go
@@ -3,7 +3,6 @@ package installer
 import (
 	"context"
 	"crypto/x509"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -17,7 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/helper"
@@ -98,7 +96,6 @@ type autoUnlockOps struct {
 	unitStatus       func() (lndUnitStatus, error)
 	processArgs      func(int) ([]string, error)
 	walletState      func() (lnrpc.WalletState, error)
-	getInfo          func(string) error
 	now              func() time.Time
 	sleep            func(time.Duration)
 }
@@ -166,7 +163,7 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 		// Converge that recognizable shape to a plain locked invocation before
 		// testing the newly supplied password.
 		if err := replaceWithLockedPlainInvocation(
-			ops, before.invocationID, cfg.Network,
+			ops, before.invocationID,
 		); err != nil {
 			return repairRequired("restore disabled LND invocation", err)
 		}
@@ -232,7 +229,7 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 	runtimeTransitioned = true
 	transitionErr, invocation, verifyErr := stopStartAndVerifyInvocation(
 		ops, before.invocationID, true,
-		lnrpc.WalletState_RPC_ACTIVE, cfg.Network,
+		lnrpc.WalletState_RPC_ACTIVE,
 	)
 	if invocation == invocationExited {
 		return failWithRecoveryStage(
@@ -269,7 +266,7 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 			"restore normal restart policy",
 			"VPN verified the password but could not finish auto-unlock safely. LND has been returned to the locked state.", err)
 	}
-	if err := verifySameReadyInvocation(ops, before.invocationID, cfg.Network); err != nil {
+	if err := verifySameReadyInvocation(ops, before.invocationID); err != nil {
 		return fail(AutoUnlockVerificationFailed,
 			"recheck verified LND invocation",
 			"VPN could not prove that LND stayed ready. LND has been returned to the locked state.", err)
@@ -334,7 +331,7 @@ func disableAutoUnlockTransition(ops autoUnlockOps) AutoUnlockResult {
 	}
 	transitionErr, invocation, verifyErr := stopStartAndVerifyInvocation(
 		ops, before.invocationID, false,
-		lnrpc.WalletState_LOCKED, cfg.Network,
+		lnrpc.WalletState_LOCKED,
 	)
 	if transitionErr != nil || invocation != invocationReady || verifyErr != nil {
 		cause := verifyErr
@@ -418,7 +415,7 @@ func removePasswordDurably(ops autoUnlockOps) error {
 }
 
 func replaceWithLockedPlainInvocation(
-	ops autoUnlockOps, previousID, network string,
+	ops autoUnlockOps, previousID string,
 ) error {
 	if err := stopAndVerifyNoProcess(ops); err != nil {
 		return err
@@ -426,7 +423,7 @@ func replaceWithLockedPlainInvocation(
 	removeErr := removePasswordDurably(ops)
 	startErr, outcome, verifyErr := startAndVerifyInvocation(
 		ops, previousID, false,
-		lnrpc.WalletState_LOCKED, network,
+		lnrpc.WalletState_LOCKED,
 	)
 	if startErr != nil || verifyErr != nil || outcome != invocationReady {
 		return errors.Join(removeErr, startErr, verifyErr,
@@ -456,7 +453,7 @@ func restoreDisabled(
 		}
 		lockedPreviousID = current.invocationID
 		if err := replaceWithLockedPlainInvocation(
-			ops, current.invocationID, cfg.Network,
+			ops, current.invocationID,
 		); err != nil {
 			return err
 		}
@@ -536,7 +533,7 @@ func restoreEnabled(ops autoUnlockOps, cfg *config.AppConfig) error {
 	}
 	transitionErr, outcome, verifyErr := stopStartAndVerifyInvocation(
 		ops, before.invocationID, true,
-		lnrpc.WalletState_RPC_ACTIVE, cfg.Network,
+		lnrpc.WalletState_RPC_ACTIVE,
 	)
 	if transitionErr != nil || verifyErr != nil || outcome != invocationReady {
 		return errors.Join(transitionErr, verifyErr,
@@ -548,7 +545,7 @@ func restoreEnabled(ops autoUnlockOps, cfg *config.AppConfig) error {
 	if err := reloadAndVerifyUnit(ops, autoUnlockUnitEnabled, "on-failure", false); err != nil {
 		return err
 	}
-	if err := verifySameReadyInvocation(ops, before.invocationID, cfg.Network); err != nil {
+	if err := verifySameReadyInvocation(ops, before.invocationID); err != nil {
 		return err
 	}
 	cfg.AutoUnlock = true
@@ -576,7 +573,7 @@ func finishDisabledAfterPasswordRemoval(
 	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
 		return err
 	}
-	if err := ensureLockedRuntime(ops, cfg.Network); err != nil {
+	if err := ensureLockedRuntime(ops); err != nil {
 		return err
 	}
 	if err := ops.removeVerifyDrop(); err != nil {
@@ -606,7 +603,7 @@ func finishDisabledAfterPasswordRemoval(
 	return nil
 }
 
-func ensureLockedRuntime(ops autoUnlockOps, network string) error {
+func ensureLockedRuntime(ops autoUnlockOps) error {
 	status, err := ops.unitStatus()
 	if err != nil {
 		return err
@@ -621,7 +618,7 @@ func ensureLockedRuntime(ops autoUnlockOps, network string) error {
 	}
 	transitionErr, outcome, verifyErr := stopStartAndVerifyInvocation(
 		ops, status.invocationID, false,
-		lnrpc.WalletState_LOCKED, network,
+		lnrpc.WalletState_LOCKED,
 	)
 	if transitionErr != nil || verifyErr != nil || outcome != invocationReady {
 		return errors.Join(transitionErr, verifyErr,
@@ -676,13 +673,13 @@ func verifyLoadedUnit(
 // start with the verification drop-in's TimeoutStartSec.
 func stopStartAndVerifyInvocation(
 	ops autoUnlockOps, previousID string,
-	withUnlock bool, wantState lnrpc.WalletState, network string,
+	withUnlock bool, wantState lnrpc.WalletState,
 ) (error, invocationResult, error) {
 	if err := stopAndVerifyNoProcess(ops); err != nil {
 		return err, invocationUnknown, nil
 	}
 	return startAndVerifyInvocation(
-		ops, previousID, withUnlock, wantState, network)
+		ops, previousID, withUnlock, wantState)
 }
 
 // stopAndVerifyNoProcess accepts systemd's two quiescent unit states. An
@@ -717,13 +714,15 @@ func stopAndVerifyNoProcess(ops autoUnlockOps) error {
 }
 
 // startAndVerifyInvocation uses two deliberate, non-overlapping bounds. The
-// loaded Type=notify unit and TimeoutStartSec=120 bound native LND startup to
-// RPC readiness. After systemctl start returns, VPN gets a short independent
-// window to bind the process to the loaded unit and prove authenticated RPC,
-// state, chain, and network postconditions.
+// loaded Type=notify unit and TimeoutStartSec=120 bound native LND startup
+// until it reports RPC_ACTIVE or SERVER_ACTIVE. After systemctl start returns,
+// VPN gets a short independent window to bind the process to the loaded unit
+// and prove that native wallet-state postcondition. Network-profile validation
+// is an installer concern; tying password verification to a chain-dependent
+// RPC would make a valid RPC_ACTIVE state depend on blockchain synchronization.
 func startAndVerifyInvocation(
 	ops autoUnlockOps, previousID string, withUnlock bool,
-	wantState lnrpc.WalletState, network string,
+	wantState lnrpc.WalletState,
 ) (error, invocationResult, error) {
 	started := ops.now()
 	startErr := ops.startLND()
@@ -734,14 +733,14 @@ func startAndVerifyInvocation(
 			startupElapsed, autoUnlockStartupTimeout)
 	}
 	outcome, verifyErr := waitForInvocation(
-		ops, previousID, withUnlock, wantState, network,
+		ops, previousID, withUnlock, wantState,
 		autoUnlockPostconditionTimeout)
 	return startErr, outcome, verifyErr
 }
 
 func waitForInvocation(
 	ops autoUnlockOps, previousID string, withUnlock bool,
-	wantState lnrpc.WalletState, network string, timeout time.Duration,
+	wantState lnrpc.WalletState, timeout time.Duration,
 ) (invocationResult, error) {
 	deadline := ops.now().Add(timeout)
 	var lastErr error
@@ -779,17 +778,7 @@ func waitForInvocation(
 						lastErr = err
 					}
 					if err == nil && walletStateMatches(state, wantState) {
-						if wantState == lnrpc.WalletState_RPC_ACTIVE {
-							if err := ops.getInfo(network); err != nil {
-								lastErr = err
-								// RPC readiness and authenticated GetInfo are one
-								// postcondition. A transient RPC failure keeps polling.
-							} else {
-								return invocationReady, nil
-							}
-						} else {
-							return invocationReady, nil
-						}
+						return invocationReady, nil
 					}
 				}
 			}
@@ -802,7 +791,7 @@ func waitForInvocation(
 }
 
 func verifySameReadyInvocation(
-	ops autoUnlockOps, previousID, network string,
+	ops autoUnlockOps, previousID string,
 ) error {
 	status, err := ops.unitStatus()
 	if err != nil {
@@ -816,14 +805,16 @@ func verifySameReadyInvocation(
 	}
 	state, err := ops.walletState()
 	if err != nil || !walletStateMatches(state, lnrpc.WalletState_RPC_ACTIVE) {
-		return errors.New("verified LND invocation is not RPC ready")
+		return errors.New(
+			"verified LND invocation has not reached RPC_ACTIVE or SERVER_ACTIVE")
 	}
-	return ops.getInfo(network)
+	return nil
 }
 
-// walletStateMatches treats RPC_ACTIVE as the minimum authenticated RPC
-// readiness state. LND always enters RPC_ACTIVE before SERVER_ACTIVE, but an
-// already-synchronized backend can advance between observations.
+// walletStateMatches accepts LND's RPC_ACTIVE or SERVER_ACTIVE startup states.
+// LND always enters RPC_ACTIVE first, but an already-synchronized backend can
+// advance to SERVER_ACTIVE between observations. UNLOCKED is deliberately
+// insufficient because LND has not started its RPC server yet.
 func walletStateMatches(got, want lnrpc.WalletState) bool {
 	if want == lnrpc.WalletState_RPC_ACTIVE {
 		return got == lnrpc.WalletState_RPC_ACTIVE ||
@@ -976,7 +967,6 @@ func productionAutoUnlockOps() (autoUnlockOps, error) {
 		unitStatus:  readLNDUnitStatus,
 		processArgs: readProcessArgs,
 		walletState: readLNDWalletState,
-		getInfo:     authenticatedLNDGetInfo,
 		now:         time.Now,
 		sleep:       time.Sleep,
 	}, nil
@@ -1335,52 +1325,6 @@ func readLNDWalletState() (lnrpc.WalletState, error) {
 		return lnrpc.WalletState_WAITING_TO_START, err
 	}
 	return resp.GetState(), nil
-}
-
-func authenticatedLNDGetInfo(network string) error {
-	if err := config.ValidateNetwork(network); err != nil {
-		return err
-	}
-	profile := config.NetworkConfigFromName(network)
-	conn, err := directLNDConn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	macaroon, err := os.ReadFile(paths.LNDMacaroon(network))
-	if err != nil {
-		return fmt.Errorf("read LND admin macaroon: %w", err)
-	}
-	md := metadata.New(map[string]string{"macaroon": hex.EncodeToString(macaroon)})
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	ctx, cancel := context.WithTimeout(ctx, autoUnlockRPCTimeout)
-	defer cancel()
-	info, err := lnrpc.NewLightningClient(conn).GetInfo(
-		ctx, &lnrpc.GetInfoRequest{})
-	if err != nil {
-		return err
-	}
-	return verifyLNDGetInfoNetwork(info, profile.LNCLINetwork)
-}
-
-func verifyLNDGetInfoNetwork(
-	info *lnrpc.GetInfoResponse, expectedNetwork string,
-) error {
-	if info == nil {
-		return errors.New("LND GetInfo response is missing")
-	}
-	chains := info.GetChains()
-	if len(chains) != 1 || chains[0] == nil {
-		return fmt.Errorf("LND GetInfo returned %d active chains, want one",
-			len(chains))
-	}
-	if chains[0].GetChain() != "bitcoin" ||
-		chains[0].GetNetwork() != expectedNetwork {
-		return fmt.Errorf(
-			"LND GetInfo chain is %q/%q, want bitcoin/%s",
-			chains[0].GetChain(), chains[0].GetNetwork(), expectedNetwork)
-	}
-	return nil
 }
 
 func directLNDConn() (*grpc.ClientConn, error) {

--- a/internal/installer/lnd_auto_unlock.go
+++ b/internal/installer/lnd_auto_unlock.go
@@ -27,14 +27,19 @@ import (
 )
 
 const (
-	autoUnlockVerificationTimeout = 120 * time.Second
-	autoUnlockPollInterval        = time.Second
-	autoUnlockRPCTimeout          = 5 * time.Second
+	autoUnlockStartupTimeout       = 120 * time.Second
+	autoUnlockPostconditionTimeout = 10 * time.Second
+	autoUnlockPollInterval         = time.Second
+	autoUnlockRPCTimeout           = 5 * time.Second
 )
 
 const lndVerificationDropIn = `[Service]
 Restart=no
+TimeoutStartSec=120
 `
+
+var errLNDInvocationChanged = errors.New(
+	"LND invocation changed during process verification")
 
 type autoUnlockUnit int
 
@@ -54,6 +59,7 @@ type autoUnlockArtifacts struct {
 type lndUnitStatus struct {
 	invocationID     string
 	mainPID          int
+	serviceType      string
 	activeState      string
 	subState         string
 	result           string
@@ -68,9 +74,11 @@ type lndUnitStatus struct {
 type invocationResult int
 
 const (
-	invocationReady invocationResult = iota
+	invocationUnknown invocationResult = iota
+	invocationReady
 	invocationExited
-	invocationTimedOut
+	invocationStartTimedOut
+	invocationProofTimedOut
 )
 
 type autoUnlockOps struct {
@@ -84,7 +92,8 @@ type autoUnlockOps struct {
 	removeVerifyDrop func() error
 	validateUnit     func() error
 	daemonReload     func() error
-	restartLND       func() error
+	startLND         func() error
+	stopLND          func() error
 	unitStatus       func() (lndUnitStatus, error)
 	processArgs      func(int) ([]string, error)
 	walletState      func() (lnrpc.WalletState, error)
@@ -139,7 +148,7 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 	if err := ops.writeVerifyDrop(); err != nil {
 		return repairRequired("install one-attempt restart policy", err)
 	}
-	if err := normalizeDisabledDisk(ops); err != nil {
+	if err := normalizeDisabledUnit(ops); err != nil {
 		return repairRequired("restore disabled starting state", err)
 	}
 	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
@@ -150,28 +159,28 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 	if err != nil {
 		return repairRequired("observe current LND invocation", err)
 	}
-	if before.mainPID == 0 || verifyProcessArgs(ops, before.mainPID, false) != nil {
+	if before.mainPID == 0 || verifyStableProcessArgs(ops, before, false) != nil {
 		// An interrupted older enable can leave an auto-unlock process alive
 		// while the still-false desired state has just been normalized on disk.
 		// Converge that recognizable shape to a plain locked invocation before
 		// testing the newly supplied password.
-		if err := ops.restartLND(); err != nil {
+		if err := replaceWithLockedPlainInvocation(
+			ops, before.invocationID, cfg.Network,
+		); err != nil {
 			return repairRequired("restore disabled LND invocation", err)
-		}
-		outcome, err := waitForInvocation(
-			ops, before.invocationID, false, lnrpc.WalletState_LOCKED,
-			cfg.Network, autoUnlockVerificationTimeout,
-		)
-		if err != nil || outcome != invocationReady {
-			return repairRequired("prove disabled LND invocation", err)
 		}
 		before, err = ops.unitStatus()
 		if err != nil {
 			return repairRequired("observe restored LND invocation", err)
 		}
+	} else if err := removePasswordDurably(ops); err != nil {
+		return repairRequired("remove stale wallet password", err)
+	}
+	if err := verifyDisabledDisk(ops); err != nil {
+		return repairRequired("confirm disabled starting state", err)
 	}
 
-	restarted := false
+	runtimeTransitioned := false
 	fail := func(
 		outcome AutoUnlockOutcome, stage, detail string, cause error,
 	) AutoUnlockResult {
@@ -180,7 +189,9 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 		} else {
 			logger.System("auto-unlock: %s", stage)
 		}
-		if err := restoreDisabled(ops, cfg, before, restarted); err != nil {
+		if err := restoreDisabled(
+			ops, cfg, before, runtimeTransitioned,
+		); err != nil {
 			return repairRequired(stage,
 				fmt.Errorf("recovery failed: %w", err))
 		}
@@ -208,27 +219,27 @@ func enableAutoUnlock(password string, ops autoUnlockOps) AutoUnlockResult {
 			"VPN could not load auto-unlock safely. The previous disabled setting was restored.", err)
 	}
 
-	restarted = true
-	restartErr := ops.restartLND()
-	invocation, verifyErr := waitForInvocation(
-		ops, before.invocationID, true, lnrpc.WalletState_SERVER_ACTIVE,
-		cfg.Network, autoUnlockVerificationTimeout,
+	runtimeTransitioned = true
+	transitionErr, invocation, verifyErr := stopStartAndVerifyInvocation(
+		ops, before.invocationID, true,
+		lnrpc.WalletState_RPC_ACTIVE, cfg.Network,
 	)
 	if invocation == invocationExited {
 		return fail(AutoUnlockVerificationFailed,
 			"verify candidate wallet password", "", verifyErr)
 	}
-	if invocation == invocationTimedOut {
+	if invocation == invocationStartTimedOut {
 		return fail(AutoUnlockVerificationTimedOut,
 			"wait for LND to become ready", "", verifyErr)
 	}
-	if restartErr != nil || verifyErr != nil {
+	if transitionErr != nil || verifyErr != nil ||
+		invocation != invocationReady {
 		cause := verifyErr
-		if restartErr != nil {
-			cause = restartErr
+		if transitionErr != nil {
+			cause = transitionErr
 		}
 		return fail(AutoUnlockVerificationFailed,
-			"verify restarted LND",
+			"verify candidate LND",
 			"VPN could not verify auto-unlock because a system operation failed. LND has been returned to the locked state.", cause)
 	}
 
@@ -308,15 +319,14 @@ func disableAutoUnlockTransition(ops autoUnlockOps) AutoUnlockResult {
 	if err != nil {
 		return restoreEnabledResult(ops, cfg, "observe current LND invocation", err)
 	}
-	restartErr := ops.restartLND()
-	invocation, verifyErr := waitForInvocation(
-		ops, before.invocationID, false, lnrpc.WalletState_LOCKED,
-		cfg.Network, autoUnlockVerificationTimeout,
+	transitionErr, invocation, verifyErr := stopStartAndVerifyInvocation(
+		ops, before.invocationID, false,
+		lnrpc.WalletState_LOCKED, cfg.Network,
 	)
-	if restartErr != nil || invocation != invocationReady || verifyErr != nil {
+	if transitionErr != nil || invocation != invocationReady || verifyErr != nil {
 		cause := verifyErr
-		if restartErr != nil {
-			cause = restartErr
+		if transitionErr != nil {
+			cause = transitionErr
 		}
 		return restoreEnabledResult(ops, cfg, "prove locked LND invocation", cause)
 	}
@@ -355,16 +365,14 @@ func disableAutoUnlockTransition(ops autoUnlockOps) AutoUnlockResult {
 	return AutoUnlockResult{Outcome: AutoUnlockDisabled}
 }
 
-func normalizeDisabledDisk(ops autoUnlockOps) error {
+func normalizeDisabledUnit(ops autoUnlockOps) error {
 	if err := ops.writeUnit(autoUnlockUnitPlain); err != nil {
 		return err
 	}
-	if err := ops.validateUnit(); err != nil {
-		return err
-	}
-	if err := ops.removePassword(); err != nil {
-		return err
-	}
+	return ops.validateUnit()
+}
+
+func verifyDisabledDisk(ops autoUnlockOps) error {
 	artifacts, err := ops.artifacts()
 	if err != nil {
 		return err
@@ -376,42 +384,78 @@ func normalizeDisabledDisk(ops autoUnlockOps) error {
 	return nil
 }
 
+func removePasswordDurably(ops autoUnlockOps) error {
+	removeErr := ops.removePassword()
+	artifacts, inspectErr := ops.artifacts()
+	if inspectErr != nil {
+		return inspectErr
+	}
+	if artifacts.password || artifacts.passwordStage {
+		if removeErr != nil {
+			return removeErr
+		}
+		return errors.New("wallet password remains after removal")
+	}
+	if removeErr != nil {
+		// Retry the parent-directory sync after an unlink that succeeded but
+		// reported a durability error. This never recreates credential data.
+		return ops.removePassword()
+	}
+	return nil
+}
+
+func replaceWithLockedPlainInvocation(
+	ops autoUnlockOps, previousID, network string,
+) error {
+	if err := stopAndVerifyInactive(ops); err != nil {
+		return err
+	}
+	removeErr := removePasswordDurably(ops)
+	startErr, outcome, verifyErr := startAndVerifyInvocation(
+		ops, previousID, false,
+		lnrpc.WalletState_LOCKED, network,
+	)
+	if startErr != nil || verifyErr != nil || outcome != invocationReady {
+		return errors.Join(removeErr, startErr, verifyErr,
+			errors.New("could not restore locked LND invocation"))
+	}
+	return removeErr
+}
+
 func restoreDisabled(
 	ops autoUnlockOps, cfg *config.AppConfig, before lndUnitStatus,
-	restarted bool,
+	runtimeTransitioned bool,
 ) error {
 	var lockedPreviousID string
 	if err := ops.writeVerifyDrop(); err != nil {
 		return err
 	}
-	if err := normalizeDisabledDisk(ops); err != nil {
+	if err := normalizeDisabledUnit(ops); err != nil {
 		return err
 	}
 	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "no", true); err != nil {
 		return err
 	}
-	if restarted {
+	if runtimeTransitioned {
 		current, err := ops.unitStatus()
 		if err != nil {
 			return err
 		}
 		lockedPreviousID = current.invocationID
-		if err := ops.restartLND(); err != nil {
+		if err := replaceWithLockedPlainInvocation(
+			ops, current.invocationID, cfg.Network,
+		); err != nil {
 			return err
-		}
-		outcome, err := waitForInvocation(
-			ops, current.invocationID, false, lnrpc.WalletState_LOCKED,
-			cfg.Network, autoUnlockVerificationTimeout,
-		)
-		if err != nil || outcome != invocationReady {
-			return errors.New("could not restore locked LND invocation")
 		}
 	} else if before.mainPID > 0 {
 		current, err := ops.unitStatus()
 		if err != nil || current.invocationID != before.invocationID {
 			return errors.New("original LND invocation changed")
 		}
-		if err := verifyProcessArgs(ops, current.mainPID, false); err != nil {
+		if err := verifyStableProcessArgs(ops, current, false); err != nil {
+			return err
+		}
+		if err := removePasswordDurably(ops); err != nil {
 			return err
 		}
 	}
@@ -421,7 +465,7 @@ func restoreDisabled(
 	if err := reloadAndVerifyUnit(ops, autoUnlockUnitPlain, "on-failure", false); err != nil {
 		return err
 	}
-	if restarted {
+	if runtimeTransitioned {
 		if err := verifySameLockedInvocation(ops, lockedPreviousID); err != nil {
 			return err
 		}
@@ -477,15 +521,13 @@ func restoreEnabled(ops autoUnlockOps, cfg *config.AppConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := ops.restartLND(); err != nil {
-		return err
-	}
-	outcome, err := waitForInvocation(
-		ops, before.invocationID, true, lnrpc.WalletState_SERVER_ACTIVE,
-		cfg.Network, autoUnlockVerificationTimeout,
+	transitionErr, outcome, verifyErr := stopStartAndVerifyInvocation(
+		ops, before.invocationID, true,
+		lnrpc.WalletState_RPC_ACTIVE, cfg.Network,
 	)
-	if err != nil || outcome != invocationReady {
-		return errors.New("previous enabled state did not restart")
+	if transitionErr != nil || verifyErr != nil || outcome != invocationReady {
+		return errors.Join(transitionErr, verifyErr,
+			errors.New("previous enabled state was not restored"))
 	}
 	if err := ops.removeVerifyDrop(); err != nil {
 		return err
@@ -557,22 +599,20 @@ func ensureLockedRuntime(ops autoUnlockOps, network string) error {
 		return err
 	}
 	if status.mainPID > 0 {
-		if err := verifyProcessArgs(ops, status.mainPID, false); err == nil {
+		if err := verifyStableProcessArgs(ops, status, false); err == nil {
 			state, stateErr := ops.walletState()
 			if stateErr == nil && state == lnrpc.WalletState_LOCKED {
 				return nil
 			}
 		}
 	}
-	if err := ops.restartLND(); err != nil {
-		return err
-	}
-	outcome, err := waitForInvocation(
-		ops, status.invocationID, false, lnrpc.WalletState_LOCKED,
-		network, autoUnlockVerificationTimeout,
+	transitionErr, outcome, verifyErr := stopStartAndVerifyInvocation(
+		ops, status.invocationID, false,
+		lnrpc.WalletState_LOCKED, network,
 	)
-	if err != nil || outcome != invocationReady {
-		return errors.New("could not prove a locked LND invocation")
+	if transitionErr != nil || verifyErr != nil || outcome != invocationReady {
+		return errors.Join(transitionErr, verifyErr,
+			errors.New("could not prove a locked LND invocation"))
 	}
 	return nil
 }
@@ -599,6 +639,9 @@ func verifyLoadedUnit(
 	if status.needDaemonReload != "no" {
 		return fmt.Errorf("systemd still requires daemon-reload")
 	}
+	if status.serviceType != "notify" {
+		return fmt.Errorf("loaded Type=%s, want notify", status.serviceType)
+	}
 	if status.restart != restart {
 		return fmt.Errorf("loaded Restart=%s, want %s", status.restart, restart)
 	}
@@ -615,6 +658,57 @@ func verifyLoadedUnit(
 	return nil
 }
 
+// stopStartAndVerifyInvocation keeps graceful shutdown outside the candidate
+// startup window. systemd independently bounds stop with TimeoutStopSec and
+// start with the verification drop-in's TimeoutStartSec.
+func stopStartAndVerifyInvocation(
+	ops autoUnlockOps, previousID string,
+	withUnlock bool, wantState lnrpc.WalletState, network string,
+) (error, invocationResult, error) {
+	if err := stopAndVerifyInactive(ops); err != nil {
+		return err, invocationUnknown, nil
+	}
+	return startAndVerifyInvocation(
+		ops, previousID, withUnlock, wantState, network)
+}
+
+func stopAndVerifyInactive(ops autoUnlockOps) error {
+	if err := ops.stopLND(); err != nil {
+		return err
+	}
+	status, err := ops.unitStatus()
+	if err != nil {
+		return err
+	}
+	if status.mainPID != 0 || status.activeState != "inactive" {
+		return errors.New("LND did not stop completely")
+	}
+	return nil
+}
+
+// startAndVerifyInvocation uses two deliberate, non-overlapping bounds. The
+// loaded Type=notify unit and TimeoutStartSec=120 bound native LND startup to
+// RPC readiness. After systemctl start returns, VPN gets a short independent
+// window to bind the process to the loaded unit and prove authenticated RPC,
+// state, chain, and network postconditions.
+func startAndVerifyInvocation(
+	ops autoUnlockOps, previousID string, withUnlock bool,
+	wantState lnrpc.WalletState, network string,
+) (error, invocationResult, error) {
+	started := ops.now()
+	startErr := ops.startLND()
+	startupElapsed := ops.now().Sub(started)
+	if startupElapsed > autoUnlockStartupTimeout {
+		return startErr, invocationStartTimedOut, fmt.Errorf(
+			"LND startup returned after %s, limit %s",
+			startupElapsed, autoUnlockStartupTimeout)
+	}
+	outcome, verifyErr := waitForInvocation(
+		ops, previousID, withUnlock, wantState, network,
+		autoUnlockPostconditionTimeout)
+	return startErr, outcome, verifyErr
+}
+
 func waitForInvocation(
 	ops autoUnlockOps, previousID string, withUnlock bool,
 	wantState lnrpc.WalletState, network string, timeout time.Duration,
@@ -629,6 +723,12 @@ func waitForInvocation(
 		if statusErr == nil && status.invocationID != "" &&
 			status.invocationID != previousID {
 			if status.mainPID == 0 {
+				if status.result == "timeout" {
+					return invocationStartTimedOut, fmt.Errorf(
+						"new LND invocation timed out: active=%s sub=%s result=%s status=%s",
+						status.activeState, status.subState,
+						status.result, status.execMainStatus)
+				}
 				if status.activeState == "failed" ||
 					status.activeState == "inactive" {
 					return invocationExited, fmt.Errorf(
@@ -637,30 +737,35 @@ func waitForInvocation(
 						status.result, status.execMainStatus)
 				}
 			} else {
-				if err := verifyProcessArgs(ops, status.mainPID, withUnlock); err != nil {
-					return invocationReady, err
-				}
-				state, err := ops.walletState()
-				if err != nil {
-					lastErr = err
-				}
-				if err == nil && state == wantState {
-					if wantState == lnrpc.WalletState_SERVER_ACTIVE {
-						if err := ops.getInfo(network); err != nil {
-							lastErr = err
-							// SERVER_ACTIVE and authenticated GetInfo are one
-							// postcondition. A transient RPC failure keeps polling.
+				if err := verifyStableProcessArgs(ops, status, withUnlock); err != nil {
+					if errors.Is(err, errLNDInvocationChanged) {
+						return invocationExited, err
+					} else {
+						return invocationReady, err
+					}
+				} else {
+					state, err := ops.walletState()
+					if err != nil {
+						lastErr = err
+					}
+					if err == nil && walletStateMatches(state, wantState) {
+						if wantState == lnrpc.WalletState_RPC_ACTIVE {
+							if err := ops.getInfo(network); err != nil {
+								lastErr = err
+								// RPC readiness and authenticated GetInfo are one
+								// postcondition. A transient RPC failure keeps polling.
+							} else {
+								return invocationReady, nil
+							}
 						} else {
 							return invocationReady, nil
 						}
-					} else {
-						return invocationReady, nil
 					}
 				}
 			}
 		}
 		if !ops.now().Before(deadline) {
-			return invocationTimedOut, lastErr
+			return invocationProofTimedOut, lastErr
 		}
 		ops.sleep(autoUnlockPollInterval)
 	}
@@ -676,14 +781,25 @@ func verifySameReadyInvocation(
 	if status.invocationID == "" || status.invocationID == previousID || status.mainPID == 0 {
 		return errors.New("verified LND invocation is not running")
 	}
-	if err := verifyProcessArgs(ops, status.mainPID, true); err != nil {
+	if err := verifyStableProcessArgs(ops, status, true); err != nil {
 		return err
 	}
 	state, err := ops.walletState()
-	if err != nil || state != lnrpc.WalletState_SERVER_ACTIVE {
-		return errors.New("verified LND invocation is not SERVER_ACTIVE")
+	if err != nil || !walletStateMatches(state, lnrpc.WalletState_RPC_ACTIVE) {
+		return errors.New("verified LND invocation is not RPC ready")
 	}
 	return ops.getInfo(network)
+}
+
+// walletStateMatches treats RPC_ACTIVE as the minimum authenticated RPC
+// readiness state. LND always enters RPC_ACTIVE before SERVER_ACTIVE, but an
+// already-synchronized backend can advance between observations.
+func walletStateMatches(got, want lnrpc.WalletState) bool {
+	if want == lnrpc.WalletState_RPC_ACTIVE {
+		return got == lnrpc.WalletState_RPC_ACTIVE ||
+			got == lnrpc.WalletState_SERVER_ACTIVE
+	}
+	return got == want
 }
 
 func verifySameLockedInvocation(ops autoUnlockOps, previousID string) error {
@@ -709,7 +825,7 @@ func verifyCurrentLockedInvocation(ops autoUnlockOps) error {
 }
 
 func verifyLockedStatus(ops autoUnlockOps, status lndUnitStatus) error {
-	if err := verifyProcessArgs(ops, status.mainPID, false); err != nil {
+	if err := verifyStableProcessArgs(ops, status, false); err != nil {
 		return err
 	}
 	state, err := ops.walletState()
@@ -719,14 +835,33 @@ func verifyLockedStatus(ops autoUnlockOps, status lndUnitStatus) error {
 	return nil
 }
 
-func verifyProcessArgs(ops autoUnlockOps, pid int, withUnlock bool) error {
-	args, err := ops.processArgs(pid)
-	if err != nil {
-		return err
+// verifyStableProcessArgs binds the inspected /proc argument vector to one
+// systemd invocation. Type=notify guarantees that the service reached LND's
+// native RPC-readiness notification before a successful start returns; the
+// second status sample proves that the PID did not exit or change while its
+// arguments were being inspected.
+func verifyStableProcessArgs(
+	ops autoUnlockOps, before lndUnitStatus, withUnlock bool,
+) error {
+	if before.invocationID == "" || before.mainPID <= 0 ||
+		before.activeState != "active" || before.subState != "running" {
+		return errors.New("LND invocation is not stably running")
 	}
-	want := expectedLNDArgs(withUnlock)
-	if !equalStrings(args, want) {
-		return fmt.Errorf("LND process arguments do not match the loaded unit")
+	args, processErr := ops.processArgs(before.mainPID)
+	after, statusErr := ops.unitStatus()
+	if statusErr != nil {
+		return statusErr
+	}
+	if after.invocationID != before.invocationID ||
+		after.mainPID != before.mainPID || after.activeState != "active" ||
+		after.subState != "running" {
+		return errLNDInvocationChanged
+	}
+	if processErr != nil {
+		return processErr
+	}
+	if !equalStrings(args, expectedLNDArgs(withUnlock)) {
+		return errors.New("LND process arguments do not match the loaded unit")
 	}
 	return nil
 }
@@ -800,8 +935,11 @@ func productionAutoUnlockOps() (autoUnlockOps, error) {
 		daemonReload: func() error {
 			return system.SudoRun("systemctl", "daemon-reload")
 		},
-		restartLND: func() error {
-			return system.SudoRun("systemctl", "restart", "lnd.service")
+		startLND: func() error {
+			return system.SudoRun("systemctl", "start", "lnd.service")
+		},
+		stopLND: func() error {
+			return system.SudoRun("systemctl", "stop", "lnd.service")
 		},
 		unitStatus:  readLNDUnitStatus,
 		processArgs: readProcessArgs,
@@ -1093,7 +1231,7 @@ func validateInstalledLNDUnit() error {
 
 func readLNDUnitStatus() (lndUnitStatus, error) {
 	properties := []string{
-		"InvocationID", "MainPID", "ActiveState", "SubState", "Result",
+		"InvocationID", "MainPID", "Type", "ActiveState", "SubState", "Result",
 		"ExecMainStatus", "Restart", "FragmentPath", "DropInPaths",
 		"NeedDaemonReload", "ExecStart",
 	}
@@ -1122,6 +1260,7 @@ func readLNDUnitStatus() (lndUnitStatus, error) {
 	}
 	return lndUnitStatus{
 		invocationID: values["InvocationID"], mainPID: pid,
+		serviceType: values["Type"],
 		activeState: values["ActiveState"], subState: values["SubState"],
 		result: values["Result"], execMainStatus: values["ExecMainStatus"],
 		restart: values["Restart"], fragmentPath: values["FragmentPath"],
@@ -1161,6 +1300,10 @@ func readLNDWalletState() (lnrpc.WalletState, error) {
 }
 
 func authenticatedLNDGetInfo(network string) error {
+	if err := config.ValidateNetwork(network); err != nil {
+		return err
+	}
+	profile := config.NetworkConfigFromName(network)
 	conn, err := directLNDConn()
 	if err != nil {
 		return err
@@ -1174,8 +1317,32 @@ func authenticatedLNDGetInfo(network string) error {
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	ctx, cancel := context.WithTimeout(ctx, autoUnlockRPCTimeout)
 	defer cancel()
-	_, err = lnrpc.NewLightningClient(conn).GetInfo(ctx, &lnrpc.GetInfoRequest{})
-	return err
+	info, err := lnrpc.NewLightningClient(conn).GetInfo(
+		ctx, &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return err
+	}
+	return verifyLNDGetInfoNetwork(info, profile.LNCLINetwork)
+}
+
+func verifyLNDGetInfoNetwork(
+	info *lnrpc.GetInfoResponse, expectedNetwork string,
+) error {
+	if info == nil {
+		return errors.New("LND GetInfo response is missing")
+	}
+	chains := info.GetChains()
+	if len(chains) != 1 || chains[0] == nil {
+		return fmt.Errorf("LND GetInfo returned %d active chains, want one",
+			len(chains))
+	}
+	if chains[0].GetChain() != "bitcoin" ||
+		chains[0].GetNetwork() != expectedNetwork {
+		return fmt.Errorf(
+			"LND GetInfo chain is %q/%q, want bitcoin/%s",
+			chains[0].GetChain(), chains[0].GetNetwork(), expectedNetwork)
+	}
+	return nil
 }
 
 func directLNDConn() (*grpc.ClientConn, error) {

--- a/internal/installer/lnd_auto_unlock_test.go
+++ b/internal/installer/lnd_auto_unlock_test.go
@@ -27,24 +27,23 @@ type autoUnlockFixture struct {
 	wallet     lnrpc.WalletState
 	password   string
 
-	now                       time.Time
-	startCount                int
-	stopCount                 int
-	getInfoCount              int
-	holdEnabled               bool
-	rpcOnly                   bool
-	timeoutOnStart            bool
-	enabledStartAdvance       time.Duration
-	stopAdvance               time.Duration
-	stopped                   bool
-	removedWhileUnlockRunning bool
-	changeDuringProcessRead   bool
-	processChangesRemaining   int
-	exitDuringProcessRead     bool
-	getInfoFailuresRemaining  int
-	result                    string
-	execMainStatus            string
-	events                    []string
+	now                          time.Time
+	startCount                   int
+	stopCount                    int
+	holdEnabled                  bool
+	rpcOnly                      bool
+	timeoutOnStart               bool
+	enabledStartAdvance          time.Duration
+	stopAdvance                  time.Duration
+	stopped                      bool
+	removedWhileUnlockRunning    bool
+	changeDuringProcessRead      bool
+	processChangesRemaining      int
+	exitDuringProcessRead        bool
+	walletStateFailuresRemaining int
+	result                       string
+	execMainStatus               string
+	events                       []string
 
 	calls  map[string]int
 	failOn map[string]int
@@ -318,25 +317,15 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			return args, nil
 		},
 		walletState: func() (lnrpc.WalletState, error) {
+			if f.walletStateFailuresRemaining > 0 {
+				f.walletStateFailuresRemaining--
+				return lnrpc.WalletState_WAITING_TO_START,
+					errors.New("injected transient wallet-state failure")
+			}
 			if err := f.fail("wallet-state"); err != nil {
 				return lnrpc.WalletState_WAITING_TO_START, err
 			}
 			return f.wallet, nil
-		},
-		getInfo: func(string) error {
-			f.getInfoCount++
-			if f.getInfoFailuresRemaining > 0 {
-				f.getInfoFailuresRemaining--
-				return errors.New("injected transient GetInfo failure")
-			}
-			if err := f.fail("get-info"); err != nil {
-				return err
-			}
-			if f.wallet != lnrpc.WalletState_RPC_ACTIVE &&
-				f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
-				return errors.New("LND is not ready")
-			}
-			return nil
 		},
 		now: func() time.Time { return f.now },
 		sleep: func(d time.Duration) {
@@ -383,8 +372,9 @@ func TestEnableAutoUnlockProvesAndPublishes(t *testing.T) {
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertEnabled(t, f)
-	if f.startCount != 1 || f.getInfoCount < 2 {
-		t.Fatalf("starts=%d GetInfo=%d", f.startCount, f.getInfoCount)
+	if f.startCount != 1 || f.calls["wallet-state"] < 2 {
+		t.Fatalf("starts=%d wallet-state checks=%d",
+			f.startCount, f.calls["wallet-state"])
 	}
 }
 
@@ -399,9 +389,9 @@ func TestEnableAutoUnlockAcceptsRPCActiveDuringChainSync(t *testing.T) {
 	if f.wallet != lnrpc.WalletState_RPC_ACTIVE {
 		t.Fatalf("wallet state = %s, want RPC_ACTIVE", f.wallet)
 	}
-	if f.getInfoCount < 2 {
-		t.Fatalf("authenticated GetInfo calls = %d, want at least 2",
-			f.getInfoCount)
+	if f.calls["wallet-state"] < 2 {
+		t.Fatalf("wallet-state checks = %d, want at least 2",
+			f.calls["wallet-state"])
 	}
 }
 
@@ -504,7 +494,7 @@ func TestEnableRejectsLateCandidateStartSuccess(t *testing.T) {
 func TestEnableHasSeparateBoundedPostReadinessProof(t *testing.T) {
 	f := newAutoUnlockFixture(false)
 	f.enabledStartAdvance = 119 * time.Second
-	f.getInfoFailuresRemaining = 2
+	f.walletStateFailuresRemaining = 2
 	result := enableAutoUnlock("correct", f.ops())
 	if result.Outcome != AutoUnlockEnabled {
 		t.Fatalf("outcome = %+v", result)
@@ -607,12 +597,10 @@ func TestEnableFailureInjectionConvergesToDisabledState(t *testing.T) {
 		{"stop before candidate", func(f *autoUnlockFixture) { f.failOn["stop-lnd"] = 1 }, AutoUnlockVerificationFailed},
 		{"start candidate", func(f *autoUnlockFixture) { f.failOn["start-lnd"] = 1 }, AutoUnlockVerificationFailed},
 		{"read candidate process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 2 }, AutoUnlockVerificationFailed},
-		{"authenticated GetInfo unavailable", func(f *autoUnlockFixture) { f.always["get-info"] = true }, AutoUnlockVerificationFailed},
 		{"remove verification drop-in", func(f *autoUnlockFixture) { f.failOn["remove-drop"] = 1 }, AutoUnlockVerificationFailed},
 		{"reload final policy", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 3 }, AutoUnlockVerificationFailed},
 		{"recheck process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 3 }, AutoUnlockVerificationFailed},
 		{"recheck state", func(f *autoUnlockFixture) { f.failOn["wallet-state"] = 2 }, AutoUnlockVerificationFailed},
-		{"recheck GetInfo", func(f *autoUnlockFixture) { f.failOn["get-info"] = 2 }, AutoUnlockVerificationFailed},
 		{"publish enabled config", func(f *autoUnlockFixture) { f.failOn["save-enabled"] = 1 }, AutoUnlockVerificationFailed},
 	}
 	for _, test := range tests {
@@ -820,7 +808,7 @@ func TestInvocationWaitRejectsProcessChangeDuringInspection(t *testing.T) {
 	f.changeDuringProcessRead = true
 	outcome, err := waitForInvocation(
 		f.ops(), "older-invocation", true,
-		lnrpc.WalletState_RPC_ACTIVE, "mainnet", 2*time.Second,
+		lnrpc.WalletState_RPC_ACTIVE, 2*time.Second,
 	)
 	if outcome != invocationExited ||
 		!errors.Is(err, errLNDInvocationChanged) {
@@ -833,7 +821,7 @@ func TestInvocationWaitClassifiesProcessExitDuringInspection(t *testing.T) {
 	f.exitDuringProcessRead = true
 	outcome, err := waitForInvocation(
 		f.ops(), "older-invocation", true,
-		lnrpc.WalletState_RPC_ACTIVE, "mainnet", 2*time.Second,
+		lnrpc.WalletState_RPC_ACTIVE, 2*time.Second,
 	)
 	if outcome != invocationExited || err == nil {
 		t.Fatalf("outcome=%v error=%v, want exited", outcome, err)
@@ -935,36 +923,6 @@ func TestLoadedUnitRequiresNativeNotification(t *testing.T) {
 		status, autoUnlockUnitPlain, "on-failure", false,
 	); err == nil || !strings.Contains(err.Error(), "Type=simple") {
 		t.Fatalf("non-notify service type error = %v", err)
-	}
-}
-
-func TestVerifyLNDGetInfoNetwork(t *testing.T) {
-	valid := &lnrpc.GetInfoResponse{Chains: []*lnrpc.Chain{{
-		Chain: "bitcoin", Network: "testnet4",
-	}}}
-	if err := verifyLNDGetInfoNetwork(valid, "testnet4"); err != nil {
-		t.Fatalf("valid chain rejected: %v", err)
-	}
-
-	for name, info := range map[string]*lnrpc.GetInfoResponse{
-		"missing response": nil,
-		"missing chain":    {},
-		"wrong chain": {Chains: []*lnrpc.Chain{{
-			Chain: "litecoin", Network: "testnet4",
-		}}},
-		"wrong network": {Chains: []*lnrpc.Chain{{
-			Chain: "bitcoin", Network: "mainnet",
-		}}},
-		"multiple chains": {Chains: []*lnrpc.Chain{
-			{Chain: "bitcoin", Network: "testnet4"},
-			{Chain: "bitcoin", Network: "mainnet"},
-		}},
-	} {
-		t.Run(name, func(t *testing.T) {
-			if err := verifyLNDGetInfoNetwork(info, "testnet4"); err == nil {
-				t.Fatal("mismatched GetInfo response was accepted")
-			}
-		})
 	}
 }
 

--- a/internal/installer/lnd_auto_unlock_test.go
+++ b/internal/installer/lnd_auto_unlock_test.go
@@ -26,10 +26,24 @@ type autoUnlockFixture struct {
 	wallet     lnrpc.WalletState
 	password   string
 
-	now          time.Time
-	restartCount int
-	getInfoCount int
-	holdEnabled  bool
+	now                       time.Time
+	startCount                int
+	stopCount                 int
+	getInfoCount              int
+	holdEnabled               bool
+	rpcOnly                   bool
+	timeoutOnStart            bool
+	enabledStartAdvance       time.Duration
+	stopAdvance               time.Duration
+	stopped                   bool
+	removedWhileUnlockRunning bool
+	changeDuringProcessRead   bool
+	processChangesRemaining   int
+	exitDuringProcessRead     bool
+	getInfoFailuresRemaining  int
+	result                    string
+	execMainStatus            string
+	events                    []string
 
 	calls  map[string]int
 	failOn map[string]int
@@ -39,13 +53,15 @@ type autoUnlockFixture struct {
 
 func newAutoUnlockFixture(enabled bool) *autoUnlockFixture {
 	f := &autoUnlockFixture{
-		now:        time.Unix(1_700_000_000, 0),
-		pid:        100,
-		invocation: "invocation-1",
-		calls:      map[string]int{},
-		failOn:     map[string]int{},
-		after:      map[string]bool{},
-		always:     map[string]bool{},
+		now:            time.Unix(1_700_000_000, 0),
+		pid:            100,
+		invocation:     "invocation-1",
+		result:         "success",
+		execMainStatus: "0",
+		calls:          map[string]int{},
+		failOn:         map[string]int{},
+		after:          map[string]bool{},
+		always:         map[string]bool{},
 	}
 	f.cfg = *config.Default()
 	if enabled {
@@ -77,6 +93,49 @@ func (f *autoUnlockFixture) fail(name string) error {
 }
 
 func (f *autoUnlockFixture) ops() autoUnlockOps {
+	startInvocation := func(failureName string) error {
+		f.startCount++
+		f.invocation = fmt.Sprintf("invocation-%d", f.startCount+1)
+		f.stopped = false
+		if err := f.fail(failureName); err != nil {
+			return err
+		}
+		f.result = "success"
+		f.execMainStatus = "0"
+		if f.loaded == autoUnlockUnitEnabled {
+			f.now = f.now.Add(f.enabledStartAdvance)
+		}
+		if f.loaded == autoUnlockUnitEnabled && f.timeoutOnStart {
+			f.pid = 0
+			f.args = nil
+			f.wallet = lnrpc.WalletState_WAITING_TO_START
+			f.result = "timeout"
+			f.execMainStatus = "0"
+			return errors.New("injected systemd start timeout")
+		}
+		if f.loaded == autoUnlockUnitEnabled && f.password != "correct" {
+			f.pid = 0
+			f.args = nil
+			f.wallet = lnrpc.WalletState_WAITING_TO_START
+			f.result = "exit-code"
+			f.execMainStatus = "1"
+			return errors.New("injected LND password rejection")
+		}
+		f.pid = 100 + f.startCount
+		f.args = expectedLNDArgs(f.loaded == autoUnlockUnitEnabled)
+		if f.loaded == autoUnlockUnitEnabled {
+			if f.holdEnabled {
+				f.wallet = lnrpc.WalletState_UNLOCKED
+			} else if f.rpcOnly {
+				f.wallet = lnrpc.WalletState_RPC_ACTIVE
+			} else {
+				f.wallet = lnrpc.WalletState_SERVER_ACTIVE
+			}
+		} else {
+			f.wallet = lnrpc.WalletState_LOCKED
+		}
+		return nil
+	}
 	return autoUnlockOps{
 		loadConfig: func() (*config.AppConfig, error) {
 			if err := f.fail("load-config"); err != nil {
@@ -127,6 +186,9 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			return nil
 		},
 		removePassword: func() error {
+			if f.pid > 0 && equalStrings(f.args, expectedLNDArgs(true)) {
+				f.removedWhileUnlockRunning = true
+			}
 			if f.after["remove-password"] {
 				f.after["remove-password"] = false
 				f.art.password = false
@@ -170,29 +232,23 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			}
 			return nil
 		},
-		restartLND: func() error {
-			f.restartCount++
-			f.invocation = fmt.Sprintf("invocation-%d", f.restartCount+1)
-			if err := f.fail("restart-lnd"); err != nil {
+		startLND: func() error {
+			f.events = append(f.events, "start")
+			return startInvocation("start-lnd")
+		},
+		stopLND: func() error {
+			f.stopCount++
+			f.events = append(f.events, "stop")
+			if err := f.fail("stop-lnd"); err != nil {
 				return err
 			}
-			if f.loaded == autoUnlockUnitEnabled && f.password != "correct" {
-				f.pid = 0
-				f.args = nil
-				f.wallet = lnrpc.WalletState_WAITING_TO_START
-				return nil
-			}
-			f.pid = 100 + f.restartCount
-			f.args = expectedLNDArgs(f.loaded == autoUnlockUnitEnabled)
-			if f.loaded == autoUnlockUnitEnabled {
-				if f.holdEnabled {
-					f.wallet = lnrpc.WalletState_UNLOCKED
-				} else {
-					f.wallet = lnrpc.WalletState_SERVER_ACTIVE
-				}
-			} else {
-				f.wallet = lnrpc.WalletState_LOCKED
-			}
+			f.now = f.now.Add(f.stopAdvance)
+			f.pid = 0
+			f.args = nil
+			f.wallet = lnrpc.WalletState_WAITING_TO_START
+			f.stopped = true
+			f.result = "success"
+			f.execMainStatus = "0"
 			return nil
 		},
 		unitStatus: func() (lndUnitStatus, error) {
@@ -201,7 +257,10 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			}
 			active := "active"
 			sub := "running"
-			if f.pid == 0 {
+			if f.stopped {
+				active = "inactive"
+				sub = "dead"
+			} else if f.pid == 0 {
 				active = "failed"
 				sub = "failed"
 			}
@@ -212,8 +271,11 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			return lndUnitStatus{
 				invocationID:     f.invocation,
 				mainPID:          f.pid,
+				serviceType:      "notify",
 				activeState:      active,
 				subState:         sub,
+				result:           f.result,
+				execMainStatus:   f.execMainStatus,
 				restart:          f.restart,
 				fragmentPath:     paths.LNDService,
 				dropInPaths:      drops,
@@ -230,7 +292,23 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			if pid != f.pid || pid == 0 {
 				return nil, errors.New("process does not exist")
 			}
-			return append([]string(nil), f.args...), nil
+			args := append([]string(nil), f.args...)
+			if f.exitDuringProcessRead {
+				f.exitDuringProcessRead = false
+				f.pid = 0
+				f.args = nil
+				f.result = "exit-code"
+				f.execMainStatus = "1"
+			} else if f.changeDuringProcessRead ||
+				f.processChangesRemaining > 0 {
+				f.changeDuringProcessRead = false
+				if f.processChangesRemaining > 0 {
+					f.processChangesRemaining--
+				}
+				f.invocation += "-changed"
+				f.pid++
+			}
+			return args, nil
 		},
 		walletState: func() (lnrpc.WalletState, error) {
 			if err := f.fail("wallet-state"); err != nil {
@@ -240,10 +318,15 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 		},
 		getInfo: func(string) error {
 			f.getInfoCount++
+			if f.getInfoFailuresRemaining > 0 {
+				f.getInfoFailuresRemaining--
+				return errors.New("injected transient GetInfo failure")
+			}
 			if err := f.fail("get-info"); err != nil {
 				return err
 			}
-			if f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
+			if f.wallet != lnrpc.WalletState_RPC_ACTIVE &&
+				f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
 				return errors.New("LND is not ready")
 			}
 			return nil
@@ -280,7 +363,7 @@ func assertEnabled(t *testing.T, f *autoUnlockFixture) {
 	t.Helper()
 	if !f.cfg.AutoUnlock || f.art.unit != autoUnlockUnitEnabled ||
 		!f.art.password || f.art.verifyDrop || f.restart != "on-failure" ||
-		f.wallet != lnrpc.WalletState_SERVER_ACTIVE {
+		!walletStateMatches(f.wallet, lnrpc.WalletState_RPC_ACTIVE) {
 		t.Fatalf("not safely enabled: cfg=%+v art=%+v restart=%s wallet=%s",
 			f.cfg, f.art, f.restart, f.wallet)
 	}
@@ -293,8 +376,25 @@ func TestEnableAutoUnlockProvesAndPublishes(t *testing.T) {
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertEnabled(t, f)
-	if f.restartCount != 1 || f.getInfoCount < 2 {
-		t.Fatalf("restart=%d GetInfo=%d", f.restartCount, f.getInfoCount)
+	if f.startCount != 1 || f.getInfoCount < 2 {
+		t.Fatalf("starts=%d GetInfo=%d", f.startCount, f.getInfoCount)
+	}
+}
+
+func TestEnableAutoUnlockAcceptsRPCActiveDuringChainSync(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.rpcOnly = true
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+	if f.wallet != lnrpc.WalletState_RPC_ACTIVE {
+		t.Fatalf("wallet state = %s, want RPC_ACTIVE", f.wallet)
+	}
+	if f.getInfoCount < 2 {
+		t.Fatalf("authenticated GetInfo calls = %d, want at least 2",
+			f.getInfoCount)
 	}
 }
 
@@ -305,21 +405,114 @@ func TestEnableWrongPasswordReturnsToLockedRetryState(t *testing.T) {
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertDisabled(t, f)
-	if f.restartCount != 2 {
-		t.Fatalf("restarts = %d, want candidate plus locked rollback", f.restartCount)
+	if f.startCount != 2 {
+		t.Fatalf("starts = %d, want candidate plus locked rollback", f.startCount)
 	}
 }
 
-func TestEnableTimeoutIsInconclusiveAndLocked(t *testing.T) {
+func TestEnablePostReadinessProofTimeoutIsInconclusiveAndLocked(t *testing.T) {
 	f := newAutoUnlockFixture(false)
 	f.holdEnabled = true
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockVerificationFailed {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+	if elapsed := f.now.Sub(time.Unix(1_700_000_000, 0)); elapsed < autoUnlockPostconditionTimeout {
+		t.Fatalf("post-readiness proof elapsed only %s", elapsed)
+	}
+	if f.removedWhileUnlockRunning {
+		t.Fatal("rollback removed the password while auto-unlock LND was running")
+	}
+}
+
+func TestEnableClassifiesSystemdReadinessTimeout(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.timeoutOnStart = true
 	result := enableAutoUnlock("correct", f.ops())
 	if result.Outcome != AutoUnlockVerificationTimedOut {
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertDisabled(t, f)
-	if elapsed := f.now.Sub(time.Unix(1_700_000_000, 0)); elapsed < 120*time.Second {
-		t.Fatalf("timeout elapsed only %s", elapsed)
+}
+
+func TestEnableSlowGracefulStopDoesNotConsumeStartupWindow(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.stopAdvance = 299 * time.Second
+	f.enabledStartAdvance = 119 * time.Second
+	started := f.now
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	if elapsed := f.now.Sub(started); elapsed < 418*time.Second {
+		t.Fatalf("elapsed %s, want independent stop and start windows", elapsed)
+	}
+	if f.stopCount != 1 || f.startCount != 1 ||
+		!equalStrings(f.events, []string{"stop", "start"}) {
+		t.Fatalf("service events = %q, stops=%d starts=%d",
+			f.events, f.stopCount, f.startCount)
+	}
+	assertEnabled(t, f)
+}
+
+func TestEnableRejectsLateCandidateStartSuccess(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.enabledStartAdvance = 121 * time.Second
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockVerificationTimedOut {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertDisabled(t, f)
+}
+
+func TestEnableHasSeparateBoundedPostReadinessProof(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.enabledStartAdvance = 119 * time.Second
+	f.getInfoFailuresRemaining = 2
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	if elapsed := f.now.Sub(time.Unix(1_700_000_000, 0)); elapsed != 121*time.Second {
+		t.Fatalf("elapsed = %s, want 119s start plus 2s proof", elapsed)
+	}
+	assertEnabled(t, f)
+}
+
+func TestEnableRollbackStopFailureRetainsCandidatePassword(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.holdEnabled = true
+	f.failOn["stop-lnd"] = 2
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockRepairRequired {
+		t.Fatalf("outcome = %+v", result)
+	}
+	if !f.art.password {
+		t.Fatal("candidate password was removed before LND stopped")
+	}
+	if f.removedWhileUnlockRunning {
+		t.Fatal("rollback removed the password while auto-unlock LND was running")
+	}
+}
+
+func TestEnableRollbackRemovalFailureStillStartsLockedPlainLND(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.holdEnabled = true
+	// The first removal confirms the disabled starting state. The second is
+	// rollback after the candidate invocation has stopped.
+	f.failOn["remove-password"] = 2
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockRepairRequired {
+		t.Fatalf("outcome = %+v", result)
+	}
+	if f.pid == 0 || !equalStrings(f.args, expectedLNDArgs(false)) ||
+		f.wallet != lnrpc.WalletState_LOCKED {
+		t.Fatalf("plain locked recovery did not start: pid=%d args=%q state=%s",
+			f.pid, f.args, f.wallet)
+	}
+	if f.removedWhileUnlockRunning {
+		t.Fatal("rollback removed the password while auto-unlock LND was running")
 	}
 }
 
@@ -351,8 +544,8 @@ func TestEnableRecoversRecognizableInterruptedAttemptWithoutMarker(t *testing.T)
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertEnabled(t, f)
-	if f.restartCount != 2 {
-		t.Fatalf("restarts = %d, want recovery plus candidate", f.restartCount)
+	if f.startCount != 2 {
+		t.Fatalf("starts = %d, want recovery plus candidate", f.startCount)
 	}
 }
 
@@ -375,9 +568,10 @@ func TestEnableFailureInjectionConvergesToDisabledState(t *testing.T) {
 		{"write unit", func(f *autoUnlockFixture) { f.failOn["write-unit-enabled"] = 1 }, AutoUnlockVerificationFailed},
 		{"validate candidate", func(f *autoUnlockFixture) { f.failOn["validate"] = 2 }, AutoUnlockVerificationFailed},
 		{"reload candidate", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 2 }, AutoUnlockVerificationFailed},
-		{"restart candidate", func(f *autoUnlockFixture) { f.failOn["restart-lnd"] = 1 }, AutoUnlockVerificationFailed},
+		{"stop before candidate", func(f *autoUnlockFixture) { f.failOn["stop-lnd"] = 1 }, AutoUnlockVerificationFailed},
+		{"start candidate", func(f *autoUnlockFixture) { f.failOn["start-lnd"] = 1 }, AutoUnlockVerificationFailed},
 		{"read candidate process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 2 }, AutoUnlockVerificationFailed},
-		{"authenticated GetInfo unavailable", func(f *autoUnlockFixture) { f.always["get-info"] = true }, AutoUnlockVerificationTimedOut},
+		{"authenticated GetInfo unavailable", func(f *autoUnlockFixture) { f.always["get-info"] = true }, AutoUnlockVerificationFailed},
 		{"remove verification drop-in", func(f *autoUnlockFixture) { f.failOn["remove-drop"] = 1 }, AutoUnlockVerificationFailed},
 		{"reload final policy", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 3 }, AutoUnlockVerificationFailed},
 		{"recheck process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 3 }, AutoUnlockVerificationFailed},
@@ -405,8 +599,8 @@ func TestDisableAutoUnlockDeletesPasswordAndPublishes(t *testing.T) {
 		t.Fatalf("outcome = %+v", result)
 	}
 	assertDisabled(t, f)
-	if f.restartCount != 1 {
-		t.Fatalf("restarts = %d, want one", f.restartCount)
+	if f.startCount != 1 {
+		t.Fatalf("starts = %d, want one", f.startCount)
 	}
 }
 
@@ -484,7 +678,8 @@ func TestDisableFailureInjectionBeforeDeletionRestoresEnabled(t *testing.T) {
 		{"validate plain unit", func(f *autoUnlockFixture) { f.failOn["validate"] = 1 }},
 		{"reload plain unit", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 1 }},
 		{"inspect loaded plain unit", func(f *autoUnlockFixture) { f.failOn["unit-status"] = 1 }},
-		{"restart plain LND", func(f *autoUnlockFixture) { f.failOn["restart-lnd"] = 1 }},
+		{"stop before plain LND", func(f *autoUnlockFixture) { f.failOn["stop-lnd"] = 1 }},
+		{"start plain LND", func(f *autoUnlockFixture) { f.failOn["start-lnd"] = 1 }},
 		{"inspect plain process", func(f *autoUnlockFixture) { f.failOn["process-args"] = 1 }},
 		{"remove verification drop-in", func(f *autoUnlockFixture) { f.failOn["remove-drop"] = 1 }},
 		{"reload final policy", func(f *autoUnlockFixture) { f.failOn["daemon-reload"] = 2 }},
@@ -548,5 +743,131 @@ func TestLoadedExecMatchesOnlyExactCommand(t *testing.T) {
 		if loadedExecMatches(bad, true) {
 			t.Fatalf("non-exact command accepted: %s", bad)
 		}
+	}
+}
+
+func TestRPCReadinessStateMatching(t *testing.T) {
+	for _, test := range []struct {
+		state lnrpc.WalletState
+		want  bool
+	}{
+		{lnrpc.WalletState_UNLOCKED, false},
+		{lnrpc.WalletState_RPC_ACTIVE, true},
+		{lnrpc.WalletState_SERVER_ACTIVE, true},
+		{lnrpc.WalletState_LOCKED, false},
+	} {
+		if got := walletStateMatches(
+			test.state, lnrpc.WalletState_RPC_ACTIVE,
+		); got != test.want {
+			t.Errorf("state %s match = %v, want %v",
+				test.state, got, test.want)
+		}
+	}
+}
+
+func TestStableProcessProofRejectsInvocationChange(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	ops := f.ops()
+	status, err := ops.unitStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.changeDuringProcessRead = true
+	err = verifyStableProcessArgs(ops, status, false)
+	if !errors.Is(err, errLNDInvocationChanged) {
+		t.Fatalf("unstable process proof error = %v", err)
+	}
+}
+
+func TestInvocationWaitRejectsProcessChangeDuringInspection(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.changeDuringProcessRead = true
+	outcome, err := waitForInvocation(
+		f.ops(), "older-invocation", true,
+		lnrpc.WalletState_RPC_ACTIVE, "mainnet", 2*time.Second,
+	)
+	if outcome != invocationExited ||
+		!errors.Is(err, errLNDInvocationChanged) {
+		t.Fatalf("outcome=%v error=%v, want rejected transition", outcome, err)
+	}
+}
+
+func TestInvocationWaitClassifiesProcessExitDuringInspection(t *testing.T) {
+	f := newAutoUnlockFixture(true)
+	f.exitDuringProcessRead = true
+	outcome, err := waitForInvocation(
+		f.ops(), "older-invocation", true,
+		lnrpc.WalletState_RPC_ACTIVE, "mainnet", 2*time.Second,
+	)
+	if outcome != invocationExited || err == nil {
+		t.Fatalf("outcome=%v error=%v, want exited", outcome, err)
+	}
+}
+
+func TestStableProcessProofRejectsUnexpectedArguments(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.args = append(f.args, "--unexpected")
+	ops := f.ops()
+	status, err := ops.unitStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = verifyStableProcessArgs(ops, status, false)
+	if err == nil || !strings.Contains(err.Error(), "arguments") {
+		t.Fatalf("unexpected process arguments error = %v", err)
+	}
+}
+
+func TestLoadedUnitRequiresNativeNotification(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	ops := f.ops()
+	status, err := ops.unitStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	status.serviceType = "simple"
+	if err := verifyLoadedUnit(
+		status, autoUnlockUnitPlain, "on-failure", false,
+	); err == nil || !strings.Contains(err.Error(), "Type=simple") {
+		t.Fatalf("non-notify service type error = %v", err)
+	}
+}
+
+func TestVerifyLNDGetInfoNetwork(t *testing.T) {
+	valid := &lnrpc.GetInfoResponse{Chains: []*lnrpc.Chain{{
+		Chain: "bitcoin", Network: "testnet4",
+	}}}
+	if err := verifyLNDGetInfoNetwork(valid, "testnet4"); err != nil {
+		t.Fatalf("valid chain rejected: %v", err)
+	}
+
+	for name, info := range map[string]*lnrpc.GetInfoResponse{
+		"missing response": nil,
+		"missing chain":    {},
+		"wrong chain": {Chains: []*lnrpc.Chain{{
+			Chain: "litecoin", Network: "testnet4",
+		}}},
+		"wrong network": {Chains: []*lnrpc.Chain{{
+			Chain: "bitcoin", Network: "mainnet",
+		}}},
+		"multiple chains": {Chains: []*lnrpc.Chain{
+			{Chain: "bitcoin", Network: "testnet4"},
+			{Chain: "bitcoin", Network: "mainnet"},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := verifyLNDGetInfoNetwork(info, "testnet4"); err == nil {
+				t.Fatal("mismatched GetInfo response was accepted")
+			}
+		})
+	}
+}
+
+func TestVerificationDropInBoundsNativeReadiness(t *testing.T) {
+	if lndVerificationDropIn != `[Service]
+Restart=no
+TimeoutStartSec=120
+` {
+		t.Fatalf("unexpected verification drop-in:\n%s", lndVerificationDropIn)
 	}
 }

--- a/internal/installer/lnd_auto_unlock_test.go
+++ b/internal/installer/lnd_auto_unlock_test.go
@@ -22,6 +22,7 @@ type autoUnlockFixture struct {
 
 	invocation string
 	pid        int
+	controlPID int
 	args       []string
 	wallet     lnrpc.WalletState
 	password   string
@@ -242,13 +243,18 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			if err := f.fail("stop-lnd"); err != nil {
 				return err
 			}
+			alreadyFailed := f.pid == 0 && !f.stopped &&
+				f.result != "success"
 			f.now = f.now.Add(f.stopAdvance)
 			f.pid = 0
+			f.controlPID = 0
 			f.args = nil
 			f.wallet = lnrpc.WalletState_WAITING_TO_START
-			f.stopped = true
-			f.result = "success"
-			f.execMainStatus = "0"
+			if !alreadyFailed {
+				f.stopped = true
+				f.result = "success"
+				f.execMainStatus = "0"
+			}
 			return nil
 		},
 		unitStatus: func() (lndUnitStatus, error) {
@@ -271,6 +277,7 @@ func (f *autoUnlockFixture) ops() autoUnlockOps {
 			return lndUnitStatus{
 				invocationID:     f.invocation,
 				mainPID:          f.pid,
+				controlPID:       f.controlPID,
 				serviceType:      "notify",
 				activeState:      active,
 				subState:         sub,
@@ -407,6 +414,34 @@ func TestEnableWrongPasswordReturnsToLockedRetryState(t *testing.T) {
 	assertDisabled(t, f)
 	if f.startCount != 2 {
 		t.Fatalf("starts = %d, want candidate plus locked rollback", f.startCount)
+	}
+}
+
+func TestEnableRecoversFailedPasswordRejectionResidue(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	f.art = autoUnlockArtifacts{
+		unit:       autoUnlockUnitPlain,
+		password:   true,
+		verifyDrop: true,
+	}
+	f.loaded = autoUnlockUnitPlain
+	f.loadedDrop = true
+	f.restart = "no"
+	f.invocation = "failed-password-rejection"
+	f.pid = 0
+	f.args = nil
+	f.wallet = lnrpc.WalletState_WAITING_TO_START
+	f.password = "wrong"
+	f.result = "exit-code"
+	f.execMainStatus = "1"
+
+	result := enableAutoUnlock("correct", f.ops())
+	if result.Outcome != AutoUnlockEnabled {
+		t.Fatalf("outcome = %+v", result)
+	}
+	assertEnabled(t, f)
+	if f.startCount != 2 {
+		t.Fatalf("starts = %d, want locked recovery plus candidate", f.startCount)
 	}
 }
 
@@ -553,7 +588,8 @@ func TestEnableRollbackFailureRequiresRepair(t *testing.T) {
 	f := newAutoUnlockFixture(false)
 	f.failOn["write-unit-plain"] = 2
 	result := enableAutoUnlock("wrong", f.ops())
-	if result.Outcome != AutoUnlockRepairRequired || result.FailedStep == "" {
+	if result.Outcome != AutoUnlockRepairRequired ||
+		result.FailedStep != "automatic recovery after password rejection" {
 		t.Fatalf("outcome = %+v", result)
 	}
 }
@@ -815,6 +851,75 @@ func TestStableProcessProofRejectsUnexpectedArguments(t *testing.T) {
 	err = verifyStableProcessArgs(ops, status, false)
 	if err == nil || !strings.Contains(err.Error(), "arguments") {
 		t.Fatalf("unexpected process arguments error = %v", err)
+	}
+}
+
+func TestStableProcessProofRejectsControlProcess(t *testing.T) {
+	f := newAutoUnlockFixture(false)
+	ops := f.ops()
+	status, err := ops.unitStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	status.controlPID = 42
+	if err := verifyStableProcessArgs(ops, status, false); err == nil {
+		t.Fatal("running invocation with a control process was accepted")
+	}
+}
+
+func TestStopProofAcceptsOnlyProcessFreeQuiescentStates(t *testing.T) {
+	for _, state := range []string{"inactive", "failed"} {
+		t.Run("accept "+state, func(t *testing.T) {
+			ops := autoUnlockOps{
+				stopLND: func() error { return nil },
+				unitStatus: func() (lndUnitStatus, error) {
+					return lndUnitStatus{
+						activeState: state,
+						restart:     "no",
+					}, nil
+				},
+			}
+			if err := stopAndVerifyNoProcess(ops); err != nil {
+				t.Fatalf("process-free %s state rejected: %v", state, err)
+			}
+		})
+	}
+
+	tests := []struct {
+		name   string
+		status lndUnitStatus
+	}{
+		{"main process", lndUnitStatus{
+			activeState: "failed", mainPID: 41, restart: "no",
+		}},
+		{"control process", lndUnitStatus{
+			activeState: "failed", controlPID: 42, restart: "no",
+		}},
+		{"restart policy", lndUnitStatus{
+			activeState: "failed", restart: "on-failure",
+		}},
+		{"active state", lndUnitStatus{
+			activeState: "active", restart: "no",
+		}},
+		{"activating state", lndUnitStatus{
+			activeState: "activating", restart: "no",
+		}},
+		{"deactivating state", lndUnitStatus{
+			activeState: "deactivating", restart: "no",
+		}},
+	}
+	for _, test := range tests {
+		t.Run("reject "+test.name, func(t *testing.T) {
+			ops := autoUnlockOps{
+				stopLND: func() error { return nil },
+				unitStatus: func() (lndUnitStatus, error) {
+					return test.status, nil
+				},
+			}
+			if err := stopAndVerifyNoProcess(ops); err == nil {
+				t.Fatalf("unsafe status accepted: %+v", test.status)
+			}
+		})
 	}
 }
 

--- a/internal/installer/lnd_test.go
+++ b/internal/installer/lnd_test.go
@@ -197,6 +197,7 @@ func TestLNDServiceUnit(t *testing.T) {
 
 	for _, unit := range []string{plain, unlock} {
 		for _, want := range []string{
+			"Type=notify",
 			"User=lnd",
 			"Group=lnd",
 			"SupplementaryGroups=debian-tor",
@@ -204,6 +205,7 @@ func TestLNDServiceUnit(t *testing.T) {
 			"ExecStart=/usr/local/bin/lnd " +
 				"--configfile=/etc/lnd/lnd.conf",
 			"Restart=on-failure",
+			"TimeoutStartSec=1200",
 			"TimeoutStopSec=300",
 			"WantedBy=multi-user.target",
 		} {


### PR DESCRIPTION
## Summary

- use LND's native systemd readiness notification with `Type=notify`
- verify a supplied wallet password once LND reaches `RPC_ACTIVE` or `SERVER_ACTIVE`, without waiting for Bitcoin synchronization
- remove the chain-dependent `GetInfo` postcondition from password verification
- retain stable exact-process and loaded-unit verification
- separately bound graceful shutdown, candidate startup, and post-readiness proof
- stop the candidate LND process before removing its password during rollback
- recover recognizable interrupted password-verification residue into a stable locked retry state
- keep wrong-password, timeout, and ambiguous failures fail-closed

## Why

The existing auto-unlock verification required LND to become fully active and perform a chain-dependent `GetInfo` call. Fast testnet4 synchronization concealed that dependency.

Public-signet and mainnet testing during Bitcoin initial block download reproduced valid wallet passwords being rejected or timing out even though LND had successfully unlocked the wallet.

Pinned LND sends its systemd readiness notification and reports `RPC_ACTIVE` before completing chain-backend synchronization. Password verification should prove that the supplied password started the expected LND process and reached LND's native post-unlock state; it should not wait for Bitcoin synchronization.

Wrong passwords still fail before native readiness and are returned to a stable locked state.