### PR TITLE
feat: add immutable bitcoin network profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ funds.
 - **Blinded paths on invoices (default on).** Invoices use encrypted route data instead of plain hop hints. Senders can pay you without learning your node's pubkey, channel partners, or channel funding UTXOs.
 - **Coin control for channel opens.** You choose which UTXOs fund each channel. One UTXO in, one channel out. No silent coin consolidation linking your channels on-chain.
 - **Taproot channels (default on).** Cooperative channel closes produce a MuSig2 key-path spend, which looks identical to a regular single-sig transaction on-chain. Requires peer support.
-- **Consistent P2TR address type.** All addresses (receive, change, close delivery, sweep) use the same bc1p format. P2TR has a smaller anonymity set than P2WPKH today, but matching LND's internal address type prevents change-detection fingerprints that would link your outputs regardless of anonymity set size.
+- **Consistent P2TR address type.** All addresses (receive, change, close delivery, sweep) use the same P2TR format: `bc1p` on mainnet and `tb1p` on the testing profiles. P2TR has a smaller anonymity set than P2WPKH today, but matching LND's internal address type prevents change-detection fingerprints that would link your outputs regardless of anonymity set size.
 - **No node alias.** Your node appears in the network graph with only its pubkey. No identifying name broadcast.
 - **Tor-only by default.** All LND connections route through Tor hidden services. Your server IP is never published to the Lightning Network unless you explicitly upgrade to hybrid P2P mode.
 
@@ -77,8 +77,50 @@ straight into the TUI. If a step fails or you interrupt, run it
 again — when the installer can prove that it is resuming the same recognizable
 fresh-install lifecycle, it continues from the incomplete work. A completed
 base installation reports already installed and stops; optional add-ons and
-later settings remain available through the TUI. Mainnet and testnet4 are both
-supported.
+later settings remain available through the TUI. Mainnet and testnet4 remain
+supported. This unreleased candidate adds default public signet as the third
+immutable profile described below; it is not release-certified until the exact
+candidate passes the required disposable Debian 13 amd64 validation.
+
+### Bitcoin network profiles
+
+Mainnet remains the default. Testnet4 remains the public proof-of-work test
+network. The default public-signet candidate is testing-only and uses Bitcoin
+Core and LND's pinned built-in public-signet parameters; VPN does not override
+its challenge or seed nodes. Generated configuration and unit tests alone do
+not certify this profile; disposable Debian 13 amd64 operational evidence is
+required before release support is claimed.
+
+| VPN profile | Installer selector | Core/LND state directory | Address HRP | BOLT11 prefix |
+| --- | --- | --- | --- | --- |
+| `mainnet` | none (default) | `mainnet` conventions | `bc` | `lnbc` |
+| `testnet4` | `--testnet4` | `testnet4` | `tb` | `lntb` |
+| `public-signet` | `--signet` | `signet` | `tb` | `lntbs` |
+
+(VPS)
+
+```bash
+# Default mainnet
+sudo vpn install
+
+# Public proof-of-work testnet4
+sudo vpn install --testnet4
+
+# Default public signet (testing only)
+sudo vpn install --signet
+```
+
+The chosen profile is recorded before installation work begins and cannot be
+changed. A node will not reuse another profile's Core data, LND wallet,
+macaroons, channel state, lifecycle authorization, or channel-backup source.
+Reusing the machine for another profile requires a new disposable machine;
+there is no in-place profile migration or switch.
+
+`controlled-signet-v1`, raw `signet`, custom challenges, and custom seed-node
+inputs are rejected and unsupported. VPN also does not install a faucet,
+explorer, miner, block signer, second Lightning node, or scenario controller.
+Testing profiles remain visibly marked in the TUI, and their coins have no
+mainnet value.
 
 **Access setup.** The installer creates a `vpn` admin user and
 shows every SSH key it finds on the box — with fingerprints and
@@ -225,7 +267,7 @@ For the full setup guide, see
 - SSH hardening: challenge-response, keyboard-interactive, and X11 forwarding disabled; password auth carried over exactly as OBSERVED on your box at install (toggle from System → SSH Keys once you've verified key auth works); login password changeable from the TUI
 - Bitcoin Core, LND, and Syncthing run as separate, non-login system users; `vpn` has no direct access to their private data directories
 - Tor control-cookie access is granted only inside `bitcoind.service` and `lnd.service`; Syncthing and the backup exporter receive none
-- LND authenticates to Bitcoin Core with its own `rpcauth` identity instead of reading Bitcoin Core's cookie or data directory
+- VPN and LND authenticate to Bitcoin Core with separate `rpcauth` identities. Bitcoin Core RPC-cookie generation is disabled for fresh v0.7 installations, and neither client reads a Core cookie or data directory. Unsupported legacy layouts are refused rather than modified, so VPN does not delete their historical cookie files
 - Channel backups cross through a dedicated `lnd` publisher into the project-owned `/var/lib/vpn/exports` boundary; Syncthing can read only the completed `channel.backup`, cannot write the export, and cannot read `/var/lib/lnd` or private staging
 - GPG signature verification for all software, any bad signature is a hard stop
 - Unattended security upgrades with auto-reboot
@@ -319,7 +361,7 @@ For manual binary verification before installation, see
 | /etc/syncthing/ | Syncthing configuration |
 | /etc/vpn/config.json | Root-owned, non-secret desired node configuration; root:vpn mode 0640 |
 | /home/vpn/.config/vpn/preferences.json | User-owned TUI preferences (theme); vpn:vpn mode 0600 |
-| /var/lib/vpn-install-bootstrap-service-layout-1-{mainnet,testnet4}-tor | Short-lived root-only indication while initial lifecycle authority is published |
+| /var/lib/vpn-install-bootstrap-service-layout-1-{mainnet,testnet4,public-signet}-tor | Short-lived root-only indication while initial lifecycle authority is published |
 | /var/lib/vpn/private/layout-version | Root-only supported-layout generation record |
 | /var/lib/vpn/private/install-state.json | Root-only bounded base-install progress and completion ledger |
 | /var/lib/vpn/private/password-pending | Root-only interrupted unattended-password delivery marker, present only while needed |
@@ -327,8 +369,8 @@ For manual binary verification before installation, see
 | /run/vpn/install.lock | Stable root-only runtime lock for one active base installer |
 | /var/lib/vpn/state/ | Root-written facts and credentials deliberately staged read-only for the TUI, including the Syncthing web password |
 | /var/lib/vpn/exports/lnd-backup/ | Read-only Syncthing export of the completed `channel.backup` |
-| /var/lib/bitcoin/ | Blockchain data |
-| /var/lib/lnd/ | LND data and wallet |
+| /var/lib/bitcoin/ | Mainnet Core data at the root; testnet4 under `testnet4/`; public signet under `signet/` |
+| /var/lib/lnd/data/chain/bitcoin/{mainnet,testnet4,signet}/ | Profile-specific LND wallet, macaroon, and channel state; `signet/` is default public signet only |
 | /var/lib/syncthing/ | Syncthing's private data |
 | /var/log/vpn.log | Application log (install, verification, status) |
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,10 +185,23 @@ func parseArgs(
 	}
 	switch args[0] {
 	case "install":
+		var networkFlag string
 		for _, a := range args[1:] {
 			switch a {
 			case "--testnet4":
-				opts.Network = "testnet4"
+				opts.Network = config.NetworkTestnet4
+				if networkFlag != "" && networkFlag != a {
+					return 0, opts, fmt.Errorf(
+						"install network flags %s and %s conflict", networkFlag, a)
+				}
+				networkFlag = a
+			case "--signet":
+				opts.Network = config.NetworkPublicSignet
+				if networkFlag != "" && networkFlag != a {
+					return 0, opts, fmt.Errorf(
+						"install network flags %s and %s conflict", networkFlag, a)
+				}
+				networkFlag = a
 			case "--unattended":
 				opts.Unattended = true
 			case "--until=bake":
@@ -241,6 +254,7 @@ Usage:
 		paths.AdminUser + ` user)
   sudo vpn install   start a fresh install or resume a recognized interruption
       --testnet4     use testnet4 instead of mainnet
+      --signet       use default public signet (testing only)
       --unattended   no prompts (keys auto-copied from the box,
                      login password generated and printed once)
       --allow-console-only

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -34,6 +34,15 @@ func TestParseArgs(t *testing.T) {
 	if opts.Network != "testnet4" || !opts.Unattended {
 		t.Errorf("install flags: got %+v", opts)
 	}
+	cmd, opts, err = parseArgs([]string{"install", "--signet"})
+	if err != nil || cmd != cmdInstall ||
+		opts.Network != config.NetworkPublicSignet {
+		t.Errorf("signet install: got (%v,%+v,%v)", cmd, opts, err)
+	}
+	if _, _, err := parseArgs(
+		[]string{"install", "--testnet4", "--signet"}); err == nil {
+		t.Error("conflicting install network flags accepted")
+	}
 
 	if _, _, err := parseArgs(
 		[]string{"install", "--bogus"}); err == nil {
@@ -75,7 +84,7 @@ func TestParseArgs(t *testing.T) {
 		t.Error("stage-lnd-cert with arguments accepted")
 	}
 
-	for _, network := range []string{"mainnet", "testnet4"} {
+	for _, network := range config.SupportedNetworks() {
 		cmd, opts, err = parseArgs(
 			[]string{"publish-lnd-backup", network})
 		if err != nil || cmd != cmdPublishLNDBackup ||
@@ -87,6 +96,7 @@ func TestParseArgs(t *testing.T) {
 	for _, args := range [][]string{
 		{"publish-lnd-backup"},
 		{"publish-lnd-backup", "signet"},
+		{"publish-lnd-backup", "controlled-signet-v1"},
 		{"publish-lnd-backup", "mainnet", "/tmp/destination"},
 	} {
 		if _, _, err := parseArgs(args); err == nil {
@@ -137,5 +147,9 @@ func TestUsageDescribesFreshInstallAndResume(t *testing.T) {
 	}
 	if !strings.Contains(text, "resume a recognized interruption") {
 		t.Fatal("usage does not describe supported resume")
+	}
+	if !strings.Contains(text, "--signet") ||
+		!strings.Contains(text, "testing only") {
+		t.Fatal("usage does not describe public signet as testing-only")
 	}
 }

--- a/internal/bitcoin/client.go
+++ b/internal/bitcoin/client.go
@@ -41,11 +41,39 @@ type BlockchainInfo struct {
 }
 
 type blockchainInfoResponse struct {
+	Chain                string  `json:"chain"`
 	Blocks               int     `json:"blocks"`
 	Headers              int     `json:"headers"`
 	VerificationProgress float64 `json:"verificationprogress"`
 	InitialBlockDownload bool    `json:"initialblockdownload"`
 	SizeOnDisk           int64   `json:"size_on_disk"`
+	SignetChallenge      string  `json:"signet_challenge"`
+}
+
+// BlockchainIdentity is the minimum live evidence needed to prove that the
+// running Core instance matches the immutable installed profile. Chain alone
+// is insufficient for signet because public and custom signets both report
+// "signet" and share the genesis block.
+type BlockchainIdentity struct {
+	Chain           string
+	Genesis         string
+	SignetChallenge string
+}
+
+func GetBlockchainIdentity(rpcPort int) (BlockchainIdentity, error) {
+	var info blockchainInfoResponse
+	if err := rpcCall(rpcPort, "getblockchaininfo", nil, &info); err != nil {
+		return BlockchainIdentity{}, err
+	}
+	var genesis string
+	if err := rpcCall(rpcPort, "getblockhash", []any{0}, &genesis); err != nil {
+		return BlockchainIdentity{}, err
+	}
+	return BlockchainIdentity{
+		Chain:           info.Chain,
+		Genesis:         genesis,
+		SignetChallenge: info.SignetChallenge,
+	}, nil
 }
 
 // rpcCall performs one JSON-RPC call against loopback. The

--- a/internal/bitcoin/client_test.go
+++ b/internal/bitcoin/client_test.go
@@ -98,6 +98,17 @@ func TestBlockchainInfoExtraFields(t *testing.T) {
 	}
 }
 
+func TestSignetIdentityFieldsParsing(t *testing.T) {
+	raw := `{"chain":"signet","signet_challenge":"5121","blocks":1}`
+	var resp blockchainInfoResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Chain != "signet" || resp.SignetChallenge != "5121" {
+		t.Fatalf("identity fields: %+v", resp)
+	}
+}
+
 func TestFormatProgress(t *testing.T) {
 	tests := []struct {
 		input float64

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,8 +347,6 @@ func (c *AppConfig) HasLND() bool { return true }
 
 func (c *AppConfig) DbCacheMB() int { return c.DbCache }
 
-func (c *AppConfig) IsMainnet() bool { return c.Network == "mainnet" }
-
-func (c *AppConfig) NetworkConfig() *NetworkConfig {
+func (c *AppConfig) NetworkConfig() (*NetworkConfig, error) {
 	return NetworkConfigFromName(c.Network)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,6 +94,17 @@ func TestDecodeSystemStrict(t *testing.T) {
 	}
 }
 
+func TestDecodeSystemAcceptsPublicSignetProfile(t *testing.T) {
+	data := []byte(`{"schema":1,"network":"public-signet","prune_size_gb":25,"db_cache_mb":512,"p2p_mode":"tor","auto_unlock_enabled":false,"syncthing_enabled":false}`)
+	cfg, err := decodeSystem(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Network != NetworkPublicSignet {
+		t.Fatalf("network = %q", cfg.Network)
+	}
+}
+
 func TestStoreSaveLoadAndMetadata(t *testing.T) {
 	store := testStore(t)
 	cfg := Default()
@@ -215,12 +226,20 @@ func TestStoreRefusesInvalidConfigBeforeMutation(t *testing.T) {
 
 func TestNetworkConfigRouting(t *testing.T) {
 	mainnet := Default()
-	if mainnet.NetworkConfig().RPCPort != 8332 {
-		t.Fatalf("mainnet RPC port %d", mainnet.NetworkConfig().RPCPort)
+	mainProfile, err := mainnet.NetworkConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mainProfile.RPCPort != 8332 {
+		t.Fatalf("mainnet RPC port %d", mainProfile.RPCPort)
 	}
 	testnet := Default()
-	testnet.Network = "testnet4"
-	if testnet.NetworkConfig().RPCPort != 48332 {
-		t.Fatalf("testnet4 RPC port %d", testnet.NetworkConfig().RPCPort)
+	testnet.Network = NetworkTestnet4
+	testProfile, err := testnet.NetworkConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if testProfile.RPCPort != 48332 {
+		t.Fatalf("testnet4 RPC port %d", testProfile.RPCPort)
 	}
 }

--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -2,64 +2,162 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
+const (
+	NetworkMainnet      = "mainnet"
+	NetworkTestnet4     = "testnet4"
+	NetworkPublicSignet = "public-signet"
+)
+
+// The public signet identity is part of the installation contract, not merely
+// a command-line selector. A custom challenge must never be substituted here:
+// any future controlled signet is a separate immutable profile.
+const (
+	PublicSignetGenesis   = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"
+	PublicSignetChallenge = "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae"
+)
+
+// NetworkConfig is the closed, durable deployment profile shared by the
+// installer, lifecycle authority, helpers, wrappers, and TUI. Name is VPN's
+// immutable profile identifier. CoreNetwork and LNDNetwork are deliberately
+// separate upstream identifiers: public-signet maps to "signet" in both
+// daemons and must never use a /public-signet daemon-state directory.
 type NetworkConfig struct {
-	Name           string
-	BitcoinFlag    string
-	LNDBitcoinFlag string
-	RPCPort        int
-	P2PPort        int
-	ZMQBlockPort   int
-	ZMQTxPort      int
-	LNCLINetwork   string
-	CookiePath     string
+	Name                    string
+	DisplayName             string
+	TestingOnly             bool
+	BitcoinFlag             string
+	BitcoinCLIFlag          string
+	CoreNetwork             string
+	CoreDataDir             string
+	ExpectedGenesis         string
+	ExpectedSignetChallenge string
+	LNDBitcoinFlag          string
+	LNDNetwork              string
+	RPCPort                 int
+	P2PPort                 int
+	ZMQBlockPort            int
+	ZMQTxPort               int
+	Bech32HRP               string
+	Base58Prefixes          string
+	InvoicePrefix           string
+	AddressPlaceholder      string
+	InvoicePlaceholder      string
 }
 
-func Mainnet() *NetworkConfig {
-	return &NetworkConfig{
-		Name:           "mainnet",
-		BitcoinFlag:    "",
-		LNDBitcoinFlag: "bitcoin.mainnet=true",
-		RPCPort:        8332,
-		P2PPort:        8333,
-		ZMQBlockPort:   28332,
-		ZMQTxPort:      28333,
-		LNCLINetwork:   "mainnet",
-		CookiePath:     ".cookie",
-	}
+var networkConfigs = map[string]NetworkConfig{
+	NetworkMainnet: {
+		Name:               NetworkMainnet,
+		DisplayName:        "Mainnet",
+		CoreNetwork:        "main",
+		ExpectedGenesis:    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+		LNDBitcoinFlag:     "bitcoin.mainnet=true",
+		LNDNetwork:         "mainnet",
+		RPCPort:            8332,
+		P2PPort:            8333,
+		ZMQBlockPort:       28332,
+		ZMQTxPort:          28333,
+		Bech32HRP:          "bc",
+		Base58Prefixes:     "13",
+		InvoicePrefix:      "lnbc",
+		AddressPlaceholder: "bc1p...",
+		InvoicePlaceholder: "lnbc...",
+	},
+	NetworkTestnet4: {
+		Name:               NetworkTestnet4,
+		DisplayName:        "Testnet4",
+		TestingOnly:        true,
+		BitcoinFlag:        "testnet4=1",
+		BitcoinCLIFlag:     "-testnet4",
+		CoreNetwork:        "testnet4",
+		CoreDataDir:        "testnet4",
+		ExpectedGenesis:    "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
+		LNDBitcoinFlag:     "bitcoin.testnet4=true",
+		LNDNetwork:         "testnet4",
+		RPCPort:            48332,
+		P2PPort:            48333,
+		ZMQBlockPort:       28334,
+		ZMQTxPort:          28335,
+		Bech32HRP:          "tb",
+		Base58Prefixes:     "2mn",
+		InvoicePrefix:      "lntb",
+		AddressPlaceholder: "tb1p...",
+		InvoicePlaceholder: "lntb...",
+	},
+	NetworkPublicSignet: {
+		Name:                    NetworkPublicSignet,
+		DisplayName:             "Public signet",
+		TestingOnly:             true,
+		BitcoinFlag:             "signet=1",
+		BitcoinCLIFlag:          "-signet",
+		CoreNetwork:             "signet",
+		CoreDataDir:             "signet",
+		ExpectedGenesis:         PublicSignetGenesis,
+		ExpectedSignetChallenge: PublicSignetChallenge,
+		LNDBitcoinFlag:          "bitcoin.signet=true",
+		LNDNetwork:              "signet",
+		RPCPort:                 38332,
+		P2PPort:                 38333,
+		ZMQBlockPort:            28336,
+		ZMQTxPort:               28337,
+		Bech32HRP:               "tb",
+		Base58Prefixes:          "2mn",
+		InvoicePrefix:           "lntbs",
+		AddressPlaceholder:      "tb1p...",
+		InvoicePlaceholder:      "lntbs...",
+	},
 }
 
-func Testnet4() *NetworkConfig {
-	return &NetworkConfig{
-		Name:           "testnet4",
-		BitcoinFlag:    "testnet4=1",
-		LNDBitcoinFlag: "bitcoin.testnet4=true",
-		RPCPort:        48332,
-		P2PPort:        48333,
-		ZMQBlockPort:   28334,
-		ZMQTxPort:      28335,
-		LNCLINetwork:   "testnet4",
-		CookiePath:     "testnet4/.cookie",
-	}
+// SupportedNetworks returns the immutable profile identifiers in stable
+// product order. The returned slice is a new value and may be modified by the
+// caller without changing the profile table.
+func SupportedNetworks() []string {
+	return []string{NetworkMainnet, NetworkTestnet4, NetworkPublicSignet}
 }
 
-func NetworkConfigFromName(name string) *NetworkConfig {
-	switch name {
-	case "mainnet":
-		return Mainnet()
-	case "testnet4":
-		return Testnet4()
-	default:
-		return Mainnet()
+func NetworkConfigFromName(name string) (*NetworkConfig, error) {
+	net, ok := networkConfigs[name]
+	if !ok {
+		return nil, fmt.Errorf(
+			"unknown network %q: must be %s",
+			name, strings.Join(SupportedNetworks(), ", "))
 	}
+	copy := net
+	return &copy, nil
 }
 
 func ValidateNetwork(name string) error {
-	switch name {
-	case "mainnet", "testnet4":
-		return nil
-	default:
-		return fmt.Errorf("unknown network %q: must be mainnet or testnet4", name)
+	_, err := NetworkConfigFromName(name)
+	return err
+}
+
+// AcceptsOnChainAddress performs the TUI's deliberately shallow network
+// prefix check. LND remains the authoritative full decoder. Unknown profiles
+// cannot reach this method because lookup fails closed.
+func (n *NetworkConfig) AcceptsOnChainAddress(address string) bool {
+	if strings.HasPrefix(strings.ToLower(address), n.Bech32HRP+"1") {
+		return true
 	}
+	if address == "" || !strings.ContainsRune(n.Base58Prefixes, rune(address[0])) {
+		return false
+	}
+	return true
+}
+
+// AcceptsInvoicePrefix distinguishes testnet4's lntb HRP from public signet's
+// lntbs HRP. A plain HasPrefix check is unsafe because every lntbs invoice also
+// begins with lntb. After the network prefix, BOLT11 permits either the bech32
+// separator (amountless invoice) or a decimal amount.
+func (n *NetworkConfig) AcceptsInvoicePrefix(invoice string) bool {
+	invoice = strings.ToLower(invoice)
+	if !strings.HasPrefix(invoice, n.InvoicePrefix) ||
+		len(invoice) == len(n.InvoicePrefix) {
+		return false
+	}
+	next := invoice[len(n.InvoicePrefix)]
+	return next == '1' || (next >= '0' && next <= '9')
 }

--- a/internal/config/network_test.go
+++ b/internal/config/network_test.go
@@ -4,96 +4,125 @@ package config
 
 import "testing"
 
-func TestMainnetConfig(t *testing.T) {
-	net := Mainnet()
-
+func TestNetworkProfiles(t *testing.T) {
 	tests := []struct {
-		field string
-		got   interface{}
-		want  interface{}
+		name       string
+		core       string
+		lnd        string
+		invoice    string
+		rpc, p2p   int
+		zmqB, zmqT int
+		testing    bool
 	}{
-		{"Name", net.Name, "mainnet"},
-		{"BitcoinFlag", net.BitcoinFlag, ""},
-		{"LNDBitcoinFlag", net.LNDBitcoinFlag, "bitcoin.mainnet=true"},
-		{"RPCPort", net.RPCPort, 8332},
-		{"P2PPort", net.P2PPort, 8333},
-		{"ZMQBlockPort", net.ZMQBlockPort, 28332},
-		{"ZMQTxPort", net.ZMQTxPort, 28333},
-		{"LNCLINetwork", net.LNCLINetwork, "mainnet"},
-		{"CookiePath", net.CookiePath, ".cookie"},
+		{NetworkMainnet, "main", "mainnet", "lnbc", 8332, 8333, 28332, 28333, false},
+		{NetworkTestnet4, "testnet4", "testnet4", "lntb", 48332, 48333, 28334, 28335, true},
+		{NetworkPublicSignet, "signet", "signet", "lntbs", 38332, 38333, 28336, 28337, true},
 	}
 	for _, tt := range tests {
-		if tt.got != tt.want {
-			t.Errorf("%s: got %v, want %v", tt.field, tt.got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			net, err := NetworkConfigFromName(tt.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if net.Name != tt.name || net.CoreNetwork != tt.core ||
+				net.LNDNetwork != tt.lnd || net.InvoicePrefix != tt.invoice ||
+				net.RPCPort != tt.rpc || net.P2PPort != tt.p2p ||
+				net.ZMQBlockPort != tt.zmqB || net.ZMQTxPort != tt.zmqT ||
+				net.TestingOnly != tt.testing {
+				t.Fatalf("unexpected profile: %+v", net)
+			}
+			if net.ExpectedGenesis == "" || net.LNDBitcoinFlag == "" ||
+				net.Bech32HRP == "" || net.AddressPlaceholder == "" ||
+				net.InvoicePlaceholder == "" {
+				t.Fatalf("incomplete profile: %+v", net)
+			}
+		})
+	}
+}
+
+func TestNetworkLookupFailsClosed(t *testing.T) {
+	for _, name := range []string{"", "bogus", "testnet", "signet", "controlled-signet-v1"} {
+		if net, err := NetworkConfigFromName(name); err == nil || net != nil {
+			t.Errorf("NetworkConfigFromName(%q) = %+v, %v; want nil plus error", name, net, err)
 		}
-	}
-}
-
-func TestTestnet4Config(t *testing.T) {
-	net := Testnet4()
-
-	tests := []struct {
-		field string
-		got   interface{}
-		want  interface{}
-	}{
-		{"Name", net.Name, "testnet4"},
-		{"BitcoinFlag", net.BitcoinFlag, "testnet4=1"},
-		{"LNDBitcoinFlag", net.LNDBitcoinFlag, "bitcoin.testnet4=true"},
-		{"RPCPort", net.RPCPort, 48332},
-		{"P2PPort", net.P2PPort, 48333},
-		{"ZMQBlockPort", net.ZMQBlockPort, 28334},
-		{"ZMQTxPort", net.ZMQTxPort, 28335},
-		{"LNCLINetwork", net.LNCLINetwork, "testnet4"},
-		{"CookiePath", net.CookiePath, "testnet4/.cookie"},
-	}
-	for _, tt := range tests {
-		if tt.got != tt.want {
-			t.Errorf("%s: got %v, want %v", tt.field, tt.got, tt.want)
-		}
-	}
-}
-
-func TestNetworkConfigFromNameMainnet(t *testing.T) {
-	net := NetworkConfigFromName("mainnet")
-	if net.Name != "mainnet" {
-		t.Errorf("got %q, want mainnet", net.Name)
-	}
-}
-
-func TestNetworkConfigFromNameTestnet4(t *testing.T) {
-	net := NetworkConfigFromName("testnet4")
-	if net.Name != "testnet4" {
-		t.Errorf("got %q, want testnet4", net.Name)
-	}
-}
-
-func TestNetworkConfigFromNameUnknown(t *testing.T) {
-	net := NetworkConfigFromName("bogus")
-	if net.Name != "mainnet" {
-		t.Errorf("got %q, want mainnet (default fallback)", net.Name)
-	}
-}
-
-func TestNetworkConfigFromNameEmpty(t *testing.T) {
-	net := NetworkConfigFromName("")
-	if net.Name != "mainnet" {
-		t.Errorf("got %q, want mainnet (default fallback)", net.Name)
-	}
-}
-
-func TestValidateNetworkValid(t *testing.T) {
-	for _, name := range []string{"mainnet", "testnet4"} {
-		if err := ValidateNetwork(name); err != nil {
-			t.Errorf("ValidateNetwork(%q) returned error: %v", name, err)
-		}
-	}
-}
-
-func TestValidateNetworkInvalid(t *testing.T) {
-	for _, name := range []string{"", "bogus", "testnet3", "signet"} {
 		if err := ValidateNetwork(name); err == nil {
-			t.Errorf("ValidateNetwork(%q) should return error", name)
+			t.Errorf("ValidateNetwork(%q) succeeded", name)
+		}
+	}
+}
+
+func TestSupportedNetworksReturnsCopy(t *testing.T) {
+	one := SupportedNetworks()
+	one[0] = "changed"
+	two := SupportedNetworks()
+	if two[0] != NetworkMainnet {
+		t.Fatalf("profile order mutated: %v", two)
+	}
+}
+
+func TestPublicSignetIdentityIsPinned(t *testing.T) {
+	net, err := NetworkConfigFromName(NetworkPublicSignet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if net.ExpectedGenesis != PublicSignetGenesis ||
+		net.ExpectedSignetChallenge != PublicSignetChallenge ||
+		net.BitcoinFlag != "signet=1" || net.BitcoinCLIFlag != "-signet" ||
+		net.LNDBitcoinFlag != "bitcoin.signet=true" {
+		t.Fatalf("public signet identity drifted: %+v", net)
+	}
+}
+
+func TestNetworkAddressPrefixes(t *testing.T) {
+	tests := []struct {
+		network string
+		accept  []string
+		reject  []string
+	}{
+		{NetworkMainnet, []string{"bc1qexample000", "1example000000", "3example000000"}, []string{"tb1qexample000", "mexample000000"}},
+		{NetworkTestnet4, []string{"tb1qexample000", "mexample000000", "nexample000000", "2example000000"}, []string{"bc1qexample000", "sb1qexample000"}},
+		{NetworkPublicSignet, []string{"tb1qexample000", "mexample000000", "nexample000000", "2example000000"}, []string{"bc1qexample000", "sb1qexample000"}},
+	}
+	for _, tt := range tests {
+		net, err := NetworkConfigFromName(tt.network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, address := range tt.accept {
+			if !net.AcceptsOnChainAddress(address) {
+				t.Errorf("%s rejected %q", tt.network, address)
+			}
+		}
+		for _, address := range tt.reject {
+			if net.AcceptsOnChainAddress(address) {
+				t.Errorf("%s accepted %q", tt.network, address)
+			}
+		}
+	}
+}
+
+func TestInvoicePrefixesDoNotAlias(t *testing.T) {
+	tests := []struct {
+		network string
+		accept  string
+		reject  []string
+	}{
+		{NetworkMainnet, "lnbc1example", []string{"lntb1example", "lntbs1example"}},
+		{NetworkTestnet4, "lntb10u1example", []string{"lnbc1example", "lntbs1example"}},
+		{NetworkPublicSignet, "lntbs1example", []string{"lnbc1example", "lntb1example"}},
+	}
+	for _, tt := range tests {
+		profile, err := NetworkConfigFromName(tt.network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !profile.AcceptsInvoicePrefix(tt.accept) {
+			t.Errorf("%s rejected %q", tt.network, tt.accept)
+		}
+		for _, invoice := range tt.reject {
+			if profile.AcceptsInvoicePrefix(invoice) {
+				t.Errorf("%s accepted %q", tt.network, invoice)
+			}
 		}
 	}
 }

--- a/internal/installer/bitcoin.go
+++ b/internal/installer/bitcoin.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/system"
@@ -63,8 +66,11 @@ func extractAndInstallBitcoin(version, workDir string) error {
 // [testnet4] section.
 func BuildBitcoinConfig(
 	cfg *config.AppConfig, rpcauthLines ...string,
-) string {
-	net := cfg.NetworkConfig()
+) (string, error) {
+	net, err := cfg.NetworkConfig()
+	if err != nil {
+		return "", err
+	}
 	pruneMB := cfg.PruneSize * 1000
 
 	var auth string
@@ -74,47 +80,34 @@ func BuildBitcoinConfig(
 		}
 	}
 
-	if net.Name == "testnet4" {
-		return fmt.Sprintf(`# Virtual Private Node — Bitcoin Core
-server=1
-disablewallet=1
-%s
-prune=%d
-dbcache=%d
-maxmempool=300
-proxy=127.0.0.1:9050
-listen=1
-listenonion=1
-%s
-[testnet4]
-bind=127.0.0.1
-rpcbind=127.0.0.1
-rpcport=%d
-rpcallowip=127.0.0.1
-zmqpubrawblock=tcp://127.0.0.1:%d
-zmqpubrawtx=tcp://127.0.0.1:%d
-`, net.BitcoinFlag, pruneMB, cfg.DbCacheMB(), auth,
-			net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
+	var b strings.Builder
+	b.WriteString("# Virtual Private Node — Bitcoin Core\n")
+	b.WriteString("server=1\n")
+	b.WriteString("disablewallet=1\n")
+	// VPN has two explicit rpcauth identities. Keeping Core's independent
+	// session cookie would add a third credential that no supported client
+	// consumes.
+	b.WriteString("norpccookiefile=1\n")
+	if net.BitcoinFlag != "" {
+		b.WriteString(net.BitcoinFlag + "\n")
 	}
-
-	return fmt.Sprintf(`# Virtual Private Node — Bitcoin Core
-server=1
-disablewallet=1
-prune=%d
-dbcache=%d
-maxmempool=300
-proxy=127.0.0.1:9050
-listen=1
-listenonion=1
-%s
-bind=127.0.0.1
-rpcbind=127.0.0.1
-rpcport=%d
-rpcallowip=127.0.0.1
-zmqpubrawblock=tcp://127.0.0.1:%d
-zmqpubrawtx=tcp://127.0.0.1:%d
-`, pruneMB, cfg.DbCacheMB(), auth,
-		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
+	fmt.Fprintf(&b, "prune=%d\n", pruneMB)
+	fmt.Fprintf(&b, "dbcache=%d\n", cfg.DbCacheMB())
+	b.WriteString("maxmempool=300\n")
+	b.WriteString("proxy=127.0.0.1:9050\n")
+	b.WriteString("listen=1\n")
+	b.WriteString("listenonion=1\n")
+	b.WriteString(auth)
+	if net.CoreNetwork != "main" {
+		fmt.Fprintf(&b, "\n[%s]\n", net.CoreNetwork)
+	}
+	b.WriteString("bind=127.0.0.1\n")
+	b.WriteString("rpcbind=127.0.0.1\n")
+	fmt.Fprintf(&b, "rpcport=%d\n", net.RPCPort)
+	b.WriteString("rpcallowip=127.0.0.1\n")
+	fmt.Fprintf(&b, "zmqpubrawblock=tcp://127.0.0.1:%d\n", net.ZMQBlockPort)
+	fmt.Fprintf(&b, "zmqpubrawtx=tcp://127.0.0.1:%d\n", net.ZMQTxPort)
+	return b.String(), nil
 }
 
 // writeBitcoinConfig rotates both local RPC identities and
@@ -128,7 +121,10 @@ func writeBitcoinConfig(cfg *config.AppConfig) error {
 	if err != nil {
 		return err
 	}
-	content := BuildBitcoinConfig(cfg, creds.lines...)
+	content, err := BuildBitcoinConfig(cfg, creds.lines...)
+	if err != nil {
+		return err
+	}
 	if err := system.SudoWriteFile(paths.BitcoinConf, []byte(content), 0640); err != nil {
 		return err
 	}
@@ -174,12 +170,67 @@ func writeBitcoindService(username string) error {
 // on a service that is already running during an interrupted-install resume.
 // Restart makes the unit and config already written by this lifecycle the ones
 // actually in effect; on a fresh pass the two commands are equivalent.
-func startBitcoind() error {
+func startBitcoind(cfg *config.AppConfig) error {
 	if err := system.SudoRun("systemctl", "daemon-reload"); err != nil {
 		return err
 	}
 	if err := system.SudoRun("systemctl", "enable", "bitcoind"); err != nil {
 		return err
 	}
-	return system.SudoRun("systemctl", "restart", "bitcoind")
+	if err := system.SudoRun("systemctl", "restart", "bitcoind"); err != nil {
+		return err
+	}
+	profile, err := cfg.NetworkConfig()
+	if err != nil {
+		return err
+	}
+	return waitForBitcoinIdentity(
+		profile, bitcoin.GetBlockchainIdentity, time.Sleep, 60, 2*time.Second)
+}
+
+func validateBitcoinIdentity(
+	profile *config.NetworkConfig, identity bitcoin.BlockchainIdentity,
+) error {
+	if identity.Chain != profile.CoreNetwork {
+		return fmt.Errorf("Bitcoin Core reports chain %q, want %q for profile %q",
+			identity.Chain, profile.CoreNetwork, profile.Name)
+	}
+	if identity.Genesis != profile.ExpectedGenesis {
+		return fmt.Errorf("Bitcoin Core genesis is %q, want %q for profile %q",
+			identity.Genesis, profile.ExpectedGenesis, profile.Name)
+	}
+	if identity.SignetChallenge != profile.ExpectedSignetChallenge {
+		return fmt.Errorf(
+			"Bitcoin Core signet challenge is %q, want %q for profile %q",
+			identity.SignetChallenge, profile.ExpectedSignetChallenge,
+			profile.Name)
+	}
+	return nil
+}
+
+func waitForBitcoinIdentity(
+	profile *config.NetworkConfig,
+	probe func(int) (bitcoin.BlockchainIdentity, error),
+	sleep func(time.Duration), attempts int, interval time.Duration,
+) error {
+	if attempts < 1 {
+		return fmt.Errorf("Bitcoin Core identity verification has no attempts")
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		identity, err := probe(profile.RPCPort)
+		if err == nil {
+			if err := validateBitcoinIdentity(profile, identity); err != nil {
+				return err
+			}
+			return nil
+		}
+		lastErr = err
+		if i+1 < attempts {
+			sleep(interval)
+		}
+	}
+	return fmt.Errorf(
+		"Bitcoin Core did not expose verifiable %s identity on RPC port %d: %w",
+		profile.Name, profile.RPCPort, lastErr)
 }

--- a/internal/installer/bitcoin_test.go
+++ b/internal/installer/bitcoin_test.go
@@ -282,3 +282,55 @@ func TestWaitForBitcoinIdentityRetriesOnlyUnavailability(t *testing.T) {
 		t.Fatalf("wait result calls=%d err=%v", calls, err)
 	}
 }
+
+func TestWaitForBitcoinIdentityRejectsWrongChainWithoutRetry(t *testing.T) {
+	profile, err := config.NetworkConfigFromName(config.NetworkPublicSignet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	sleeps := 0
+	err = waitForBitcoinIdentity(profile,
+		func(port int) (bitcoin.BlockchainIdentity, error) {
+			calls++
+			if port != profile.RPCPort {
+				t.Fatalf("probe port %d, want %d", port, profile.RPCPort)
+			}
+			return bitcoin.BlockchainIdentity{
+				Chain: "main", Genesis: profile.ExpectedGenesis,
+				SignetChallenge: profile.ExpectedSignetChallenge,
+			}, nil
+		}, func(time.Duration) { sleeps++ }, 3, time.Second)
+	if err == nil || !strings.Contains(err.Error(),
+		`Bitcoin Core reports chain "main", want "signet"`) {
+		t.Fatalf("wrong-chain result: %v", err)
+	}
+	if calls != 1 || sleeps != 0 {
+		t.Fatalf("wrong-chain calls=%d sleeps=%d, want 1 and 0", calls, sleeps)
+	}
+}
+
+func TestWaitForBitcoinIdentityFailsAfterRPCUnavailable(t *testing.T) {
+	profile, err := config.NetworkConfigFromName(config.NetworkPublicSignet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	sleeps := 0
+	err = waitForBitcoinIdentity(profile,
+		func(port int) (bitcoin.BlockchainIdentity, error) {
+			calls++
+			if port != profile.RPCPort {
+				t.Fatalf("probe port %d, want %d", port, profile.RPCPort)
+			}
+			return bitcoin.BlockchainIdentity{}, fmt.Errorf("connection refused")
+		}, func(time.Duration) { sleeps++ }, 3, time.Second)
+	if err == nil || !strings.Contains(err.Error(),
+		"did not expose verifiable public-signet identity on RPC port 38332") ||
+		!strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("unavailable result: %v", err)
+	}
+	if calls != 3 || sleeps != 2 {
+		t.Fatalf("unavailable calls=%d sleeps=%d, want 3 and 2", calls, sleeps)
+	}
+}

--- a/internal/installer/bitcoin_test.go
+++ b/internal/installer/bitcoin_test.go
@@ -3,20 +3,34 @@
 package installer
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/virtualprivatenode/vpn/internal/bitcoin"
 	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
+func mustBuildBitcoinConfig(
+	t *testing.T, cfg *config.AppConfig, lines ...string,
+) string {
+	t.Helper()
+	content, err := BuildBitcoinConfig(cfg, lines...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
 func TestBitcoinConfigMainnet(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 
 	required := []string{
 		"server=1",
 		"disablewallet=1",
+		"norpccookiefile=1",
 		"prune=25000",
 		"proxy=127.0.0.1:9050",
 		"rpcport=8332",
@@ -47,7 +61,7 @@ func TestBitcoinConfigTestnet4(t *testing.T) {
 		PruneSize: 25,
 		P2PMode:   "tor",
 	}
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 
 	required := []string{
 		"testnet4=1",
@@ -64,9 +78,62 @@ func TestBitcoinConfigTestnet4(t *testing.T) {
 	}
 }
 
+func TestBitcoinConfigPublicSignet(t *testing.T) {
+	cfg := config.Default()
+	cfg.Network = config.NetworkPublicSignet
+	content := mustBuildBitcoinConfig(t, cfg,
+		"rpcauth=vpn:aabb$ccdd", "rpcauth=lnd:eeff$0011")
+	for _, want := range []string{
+		"signet=1", "[signet]", "rpcport=38332",
+		"zmqpubrawblock=tcp://127.0.0.1:28336",
+		"zmqpubrawtx=tcp://127.0.0.1:28337",
+		"norpccookiefile=1",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("public-signet config missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"signetchallenge=", "signetseednode=", "testnet4=1",
+		".cookie",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("public-signet config contains %q", forbidden)
+		}
+	}
+}
+
+func TestBitcoinConfigDisablesUnusedCookieForEveryProfile(t *testing.T) {
+	for _, network := range config.SupportedNetworks() {
+		cfg := config.Default()
+		cfg.Network = network
+		content := mustBuildBitcoinConfig(t, cfg)
+		if strings.Count(content, "norpccookiefile=1") != 1 {
+			t.Errorf("%s cookie disable count is %d", network,
+				strings.Count(content, "norpccookiefile=1"))
+		}
+		if strings.Contains("\n"+content, "\nrpccookiefile=") {
+			t.Errorf("%s config enables an RPC cookie path", network)
+		}
+		for _, forbidden := range []string{".cookie"} {
+			if strings.Contains(content, forbidden) {
+				t.Errorf("%s config contains %q", network, forbidden)
+			}
+		}
+	}
+}
+
+func TestBitcoinConfigRejectsUnknownProfile(t *testing.T) {
+	cfg := config.Default()
+	cfg.Network = "signet"
+	if _, err := BuildBitcoinConfig(cfg); err == nil {
+		t.Fatal("raw signet profile generated a Bitcoin config")
+	}
+}
+
 func TestBitcoinConfigAlwaysHasProxy(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 	if !strings.Contains(content, "proxy=127.0.0.1:9050") {
 		t.Error("bitcoin config must always have Tor proxy")
 	}
@@ -74,7 +141,7 @@ func TestBitcoinConfigAlwaysHasProxy(t *testing.T) {
 
 func TestBitcoinConfigAlwaysHasServer(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 	if !strings.Contains(content, "server=1") {
 		t.Error("bitcoin config must always have server=1")
 	}
@@ -82,7 +149,7 @@ func TestBitcoinConfigAlwaysHasServer(t *testing.T) {
 
 func TestBitcoinConfigHeader(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 	if !strings.Contains(content, "Virtual Private Node") {
 		t.Error("bitcoin config should have VPN header comment")
 	}
@@ -90,7 +157,7 @@ func TestBitcoinConfigHeader(t *testing.T) {
 
 func TestBitcoinConfigWalletDisabled(t *testing.T) {
 	cfg := config.Default()
-	content := BuildBitcoinConfig(cfg, "")
+	content := mustBuildBitcoinConfig(t, cfg, "")
 	if !strings.Contains(content, "disablewallet=1") {
 		t.Error("bitcoin config must have disablewallet=1")
 	}
@@ -104,7 +171,7 @@ func TestBitcoinConfigRPCAuthPlacement(t *testing.T) {
 	lndLine := "rpcauth=lnd:eeff$0011"
 
 	cfg := config.Default()
-	if got := BuildBitcoinConfig(cfg, line, lndLine); !strings.Contains(
+	if got := mustBuildBitcoinConfig(t, cfg, line, lndLine); !strings.Contains(
 		got, line+"\n") || !strings.Contains(got, lndLine+"\n") {
 		t.Error("mainnet config missing an rpcauth line")
 	}
@@ -112,7 +179,7 @@ func TestBitcoinConfigRPCAuthPlacement(t *testing.T) {
 	tn := &config.AppConfig{
 		Network: "testnet4", PruneSize: 25, P2PMode: "tor",
 	}
-	got := BuildBitcoinConfig(tn, line, lndLine)
+	got := mustBuildBitcoinConfig(t, tn, line, lndLine)
 	authIdx := strings.Index(got, line)
 	lndAuthIdx := strings.Index(got, lndLine)
 	sectIdx := strings.Index(got, "[testnet4]")
@@ -153,5 +220,65 @@ func TestBitcoindRPCUserAgreesWithClient(t *testing.T) {
 	if BitcoindRPCUser != bitcoin.RPCUser {
 		t.Errorf("installer says RPC user %q, client says %q",
 			BitcoindRPCUser, bitcoin.RPCUser)
+	}
+}
+
+func TestValidateBitcoinIdentityForEveryProfile(t *testing.T) {
+	for _, network := range config.SupportedNetworks() {
+		profile, err := config.NetworkConfigFromName(network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		identity := bitcoin.BlockchainIdentity{
+			Chain:           profile.CoreNetwork,
+			Genesis:         profile.ExpectedGenesis,
+			SignetChallenge: profile.ExpectedSignetChallenge,
+		}
+		if err := validateBitcoinIdentity(profile, identity); err != nil {
+			t.Errorf("%s identity rejected: %v", network, err)
+		}
+		wrong := identity
+		wrong.Genesis = "wrong"
+		if err := validateBitcoinIdentity(profile, wrong); err == nil {
+			t.Errorf("%s wrong genesis accepted", network)
+		}
+	}
+}
+
+func TestPublicSignetIdentityRejectsCustomChallenge(t *testing.T) {
+	profile, err := config.NetworkConfigFromName(config.NetworkPublicSignet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := bitcoin.BlockchainIdentity{
+		Chain: "signet", Genesis: config.PublicSignetGenesis,
+		SignetChallenge: "51",
+	}
+	if err := validateBitcoinIdentity(profile, identity); err == nil {
+		t.Fatal("custom signet challenge accepted as public signet")
+	}
+}
+
+func TestWaitForBitcoinIdentityRetriesOnlyUnavailability(t *testing.T) {
+	profile, err := config.NetworkConfigFromName(config.NetworkMainnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	err = waitForBitcoinIdentity(profile,
+		func(port int) (bitcoin.BlockchainIdentity, error) {
+			calls++
+			if port != profile.RPCPort {
+				t.Fatalf("probe port %d, want %d", port, profile.RPCPort)
+			}
+			if calls < 3 {
+				return bitcoin.BlockchainIdentity{}, fmt.Errorf("starting")
+			}
+			return bitcoin.BlockchainIdentity{
+				Chain: profile.CoreNetwork, Genesis: profile.ExpectedGenesis,
+			}, nil
+		}, func(time.Duration) {}, 3, time.Second)
+	if err != nil || calls != 3 {
+		t.Fatalf("wait result calls=%d err=%v", calls, err)
 	}
 }

--- a/internal/installer/ledger.go
+++ b/internal/installer/ledger.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 // The ledger is root-private historical authority for exactly one bounded
@@ -156,7 +158,7 @@ func validateLedger(l *installLedger) error {
 	if l.Status != ledgerInProgress && l.Status != ledgerComplete {
 		return fmt.Errorf("invalid ledger status %q", l.Status)
 	}
-	if l.Context.Network != "mainnet" && l.Context.Network != "testnet4" {
+	if err := config.ValidateNetwork(l.Context.Network); err != nil {
 		return fmt.Errorf("invalid install network %q", l.Context.Network)
 	}
 	if l.Context.InitialP2PMode != "tor" &&

--- a/internal/installer/ledger_test.go
+++ b/internal/installer/ledger_test.go
@@ -47,6 +47,7 @@ func TestParseLedgerRefusesAmbiguousOrInvalidState(t *testing.T) {
 		"unknown status":         `{"schema":1,"status":"done","context":{"network":"mainnet","initial_p2p_mode":"tor"},"steps":{}}`,
 		"missing context":        `{"schema":1,"status":"in_progress","steps":{}}`,
 		"bad network":            `{"schema":1,"status":"in_progress","context":{"network":"signet","initial_p2p_mode":"tor"},"steps":{}}`,
+		"controlled signet":      `{"schema":1,"status":"in_progress","context":{"network":"controlled-signet-v1","initial_p2p_mode":"tor"},"steps":{}}`,
 		"bad p2p":                `{"schema":1,"status":"in_progress","context":{"network":"mainnet","initial_p2p_mode":"open"},"steps":{}}`,
 		"bad dbcache":            `{"schema":1,"status":"in_progress","context":{"network":"mainnet","initial_p2p_mode":"tor","db_cache_mb":999},"steps":{}}`,
 		"null steps":             `{"schema":1,"status":"in_progress","context":{"network":"mainnet","initial_p2p_mode":"tor"},"steps":null}`,
@@ -70,6 +71,21 @@ func TestParseLedgerRefusesAmbiguousOrInvalidState(t *testing.T) {
 				t.Fatal("invalid ledger accepted")
 			}
 		})
+	}
+}
+
+func TestLedgerAcceptsEverySupportedImmutableProfile(t *testing.T) {
+	for _, network := range []string{"mainnet", "testnet4", "public-signet"} {
+		ledger, err := newLedger(installContext{
+			Network: network, InitialP2PMode: "tor",
+		})
+		if err != nil {
+			t.Errorf("%s ledger rejected: %v", network, err)
+			continue
+		}
+		if ledger.Context.Network != network {
+			t.Errorf("%s ledger recorded %q", network, ledger.Context.Network)
+		}
 	}
 }
 

--- a/internal/installer/lifecycle.go
+++ b/internal/installer/lifecycle.go
@@ -88,6 +88,12 @@ func productionLifecycleFS() lifecycleFS {
 					Network: "testnet4", InitialP2PMode: "tor",
 				},
 			},
+			{
+				path: paths.InstallBootstrapPublicSignet,
+				context: installContext{
+					Network: "public-signet", InitialP2PMode: "tor",
+				},
+			},
 		},
 		ancestors: []lifecycleDir{
 			{path: "/var", mode: 0o755},

--- a/internal/installer/lifecycle_test.go
+++ b/internal/installer/lifecycle_test.go
@@ -50,6 +50,12 @@ func newLifecycleFixture(t *testing.T) *lifecycleFixture {
 					Network: "testnet4", InitialP2PMode: "tor",
 				},
 			},
+			{
+				path: filepath.Join(root, "bootstrap-public-signet-tor"),
+				context: installContext{
+					Network: "public-signet", InitialP2PMode: "tor",
+				},
+			},
 		},
 		ancestors: []lifecycleDir{{path: root, mode: rootInfo.Mode().Perm()}},
 		unmarkedPaths: []string{
@@ -374,12 +380,13 @@ func TestProductionLifecycleEvidenceInventory(t *testing.T) {
 			t.Errorf("bootstrap/diagnostic path would make fresh install impossible: %s", allowed)
 		}
 	}
-	if len(fs.bootstraps) != 2 {
-		t.Fatalf("production bootstrap contexts=%d, want 2", len(fs.bootstraps))
+	if len(fs.bootstraps) != 3 {
+		t.Fatalf("production bootstrap contexts=%d, want 3", len(fs.bootstraps))
 	}
 	wantBootstrap := map[string]string{
-		"mainnet":  paths.InstallBootstrapMainnet,
-		"testnet4": paths.InstallBootstrapTestnet4,
+		"mainnet":       paths.InstallBootstrapMainnet,
+		"testnet4":      paths.InstallBootstrapTestnet4,
+		"public-signet": paths.InstallBootstrapPublicSignet,
 	}
 	for _, bootstrap := range fs.bootstraps {
 		if got := wantBootstrap[bootstrap.context.Network]; got != bootstrap.path {

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -94,8 +94,11 @@ func createLNDDirs(username string) error {
 func BuildLNDConfig(
 	cfg *config.AppConfig, publicIPv4, restOnion,
 	bitcoindRPCUser, bitcoindRPCPass string,
-) string {
-	net := cfg.NetworkConfig()
+) (string, error) {
+	net, err := cfg.NetworkConfig()
+	if err != nil {
+		return "", err
+	}
 
 	listenLine := "listen=" + paths.LNDP2PBind
 	restListenLine := "restlisten=" + paths.LNDRESTEndpoint
@@ -192,7 +195,7 @@ healthcheck.diskspace.interval=12h
 `, listenLine, paths.LNDGRPCEndpoint, restListenLine, externalLine,
 		tlsExtraDomain, tlsExtraIP,
 		net.LNDBitcoinFlag, bitcoindRPCUser, bitcoindRPCPass,
-		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort)
+		net.RPCPort, net.ZMQBlockPort, net.ZMQTxPort), nil
 }
 
 func writeLNDConfig(cfg *config.AppConfig, publicIPv4 string) error {
@@ -214,8 +217,11 @@ func writeLNDConfigWithRPCPassword(
 	if err != nil {
 		return err
 	}
-	content := BuildLNDConfig(cfg, publicIPv4, restOnion,
+	content, err := BuildLNDConfig(cfg, publicIPv4, restOnion,
 		LNDBitcoindRPCUser, password)
+	if err != nil {
+		return err
+	}
 	if err := system.SudoWriteFile(paths.LNDConf, []byte(content), 0640); err != nil {
 		return err
 	}

--- a/internal/installer/lnd_auto_unlock.go
+++ b/internal/installer/lnd_auto_unlock.go
@@ -1161,12 +1161,16 @@ func readLNDWalletState() (lnrpc.WalletState, error) {
 }
 
 func authenticatedLNDGetInfo(network string) error {
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
+		return err
+	}
 	conn, err := directLNDConn()
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
-	macaroon, err := os.ReadFile(paths.LNDMacaroon(network))
+	macaroon, err := os.ReadFile(paths.LNDMacaroon(profile.LNDNetwork))
 	if err != nil {
 		return fmt.Errorf("read LND admin macaroon: %w", err)
 	}

--- a/internal/installer/lnd_backup_export_linux.go
+++ b/internal/installer/lnd_backup_export_linux.go
@@ -33,7 +33,8 @@ const (
 // fixed here. The process must already be the lnd service user
 // with the unit-local vpn-lnd-backup supplementary group.
 func PublishLNDBackup(network string) error {
-	if err := config.ValidateNetwork(network); err != nil {
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
 		return err
 	}
 	ids, err := resolveBackupPublisherIdentity()
@@ -44,7 +45,7 @@ func PublishLNDBackup(network string) error {
 		return err
 	}
 	return publishLNDBackup(
-		productionBackupPublisherSpec(network, ids), ids,
+		productionBackupPublisherSpec(profile.LNDNetwork, ids), ids,
 		publisherHooks{},
 	)
 }

--- a/internal/installer/lnd_backup_export_linux_test.go
+++ b/internal/installer/lnd_backup_export_linux_test.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
@@ -171,11 +172,15 @@ func assertPublished(t *testing.T, f publisherFixture, want []byte) {
 
 func TestProductionBackupPublisherPathsAreFixed(t *testing.T) {
 	ids := backupPublisherIdentity{lndUID: 11, lndGID: 12, backupGID: 13}
-	for _, network := range []string{"mainnet", "testnet4"} {
-		spec := productionBackupPublisherSpec(network, ids)
-		if got := "/" + spec.sourceDir + "/" + backupFileName; got != paths.ChannelBackup(network) {
+	for _, network := range config.SupportedNetworks() {
+		profile, err := config.NetworkConfigFromName(network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		spec := productionBackupPublisherSpec(profile.LNDNetwork, ids)
+		if got := "/" + spec.sourceDir + "/" + backupFileName; got != paths.ChannelBackup(profile.LNDNetwork) {
 			t.Errorf("%s source %q, want %q",
-				network, got, paths.ChannelBackup(network))
+				network, got, paths.ChannelBackup(profile.LNDNetwork))
 		}
 		if got := "/" + spec.stageDir; got != paths.LNDBackupStage {
 			t.Errorf("stage %q, want %q", got, paths.LNDBackupStage)

--- a/internal/installer/lnd_test.go
+++ b/internal/installer/lnd_test.go
@@ -18,6 +18,19 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
+func mustBuildLNDConfig(
+	t *testing.T, cfg *config.AppConfig, publicIPv4, restOnion,
+	user, password string,
+) string {
+	t.Helper()
+	content, err := BuildLNDConfig(
+		cfg, publicIPv4, restOnion, user, password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
 // The generated lnd.conf binds by the literal loopback
 // addresses defined once in paths — the same constants every
 // client dials — and carries no host name anywhere. On this
@@ -26,7 +39,7 @@ import (
 func TestBuildLNDConfigBindsByAddress(t *testing.T) {
 	// Tor-only: every listener on the loopback constants.
 	cfg := config.Default()
-	torOnly := BuildLNDConfig(cfg, "", "", "lnd", "secret")
+	torOnly := mustBuildLNDConfig(t, cfg, "", "", "lnd", "secret")
 	for _, want := range []string{
 		"listen=" + paths.LNDP2PBind,
 		"restlisten=" + paths.LNDRESTEndpoint,
@@ -41,8 +54,8 @@ func TestBuildLNDConfigBindsByAddress(t *testing.T) {
 	// gRPC stays on the loopback constant.
 	hybrid := config.Default()
 	hybrid.P2PMode = "hybrid"
-	hybridConf := BuildLNDConfig(
-		hybrid, "203.0.113.7", "", "lnd", "secret")
+	hybridConf := mustBuildLNDConfig(
+		t, hybrid, "203.0.113.7", "", "lnd", "secret")
 	for _, want := range []string{
 		"listen=0.0.0.0:9735",
 		"restlisten=0.0.0.0:8080",
@@ -57,7 +70,7 @@ func TestBuildLNDConfigBindsByAddress(t *testing.T) {
 
 	// No host name in either variant, with or without a REST
 	// onion for tlsextradomain.
-	withOnion := BuildLNDConfig(cfg, "",
+	withOnion := mustBuildLNDConfig(t, cfg, "",
 		"exampleonionaddress.onion", "lnd", "secret")
 	for name, conf := range map[string]string{
 		"tor-only": torOnly,
@@ -135,8 +148,8 @@ func TestVerifyCertificateDNSName(t *testing.T) {
 }
 
 func TestBuildLNDConfigUsesIndependentBitcoindRPCIdentity(t *testing.T) {
-	content := BuildLNDConfig(
-		config.Default(), "", "", "lnd", "secret")
+	content := mustBuildLNDConfig(
+		t, config.Default(), "", "", "lnd", "secret")
 	for _, want := range []string{
 		"bitcoind.rpcuser=lnd",
 		"bitcoind.rpcpass=secret",
@@ -153,6 +166,60 @@ func TestBuildLNDConfigUsesIndependentBitcoindRPCIdentity(t *testing.T) {
 		if strings.Contains(content, forbidden) {
 			t.Errorf("LND config still carries %q", forbidden)
 		}
+	}
+}
+
+func TestBuildLNDConfigNetworkProfiles(t *testing.T) {
+	tests := []struct {
+		network string
+		flag    string
+		rpc     string
+		zmqB    string
+		zmqT    string
+	}{
+		{config.NetworkMainnet, "bitcoin.mainnet=true", "8332", "28332", "28333"},
+		{config.NetworkTestnet4, "bitcoin.testnet4=true", "48332", "28334", "28335"},
+		{config.NetworkPublicSignet, "bitcoin.signet=true", "38332", "28336", "28337"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Network = tt.network
+			content := mustBuildLNDConfig(t, cfg, "", "", "lnd", "secret")
+			for _, want := range []string{
+				tt.flag,
+				"bitcoind.rpchost=127.0.0.1:" + tt.rpc,
+				"bitcoind.zmqpubrawblock=tcp://127.0.0.1:" + tt.zmqB,
+				"bitcoind.zmqpubrawtx=tcp://127.0.0.1:" + tt.zmqT,
+			} {
+				if !strings.Contains(content, want) {
+					t.Errorf("config missing %q", want)
+				}
+			}
+			for _, other := range []string{
+				"bitcoin.mainnet=true", "bitcoin.testnet4=true", "bitcoin.signet=true",
+			} {
+				if other != tt.flag && strings.Contains(content, other) {
+					t.Errorf("config contains foreign selector %q", other)
+				}
+			}
+			for _, forbidden := range []string{
+				"bitcoin.signetchallenge=", "bitcoin.signetseednode=",
+				"bitcoind.rpccookie=", "/public-signet/",
+			} {
+				if strings.Contains(content, forbidden) {
+					t.Errorf("config contains %q", forbidden)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildLNDConfigRejectsUnknownProfile(t *testing.T) {
+	cfg := config.Default()
+	cfg.Network = "signet"
+	if _, err := BuildLNDConfig(cfg, "", "", "lnd", "secret"); err == nil {
+		t.Fatal("raw signet profile generated an LND config")
 	}
 }
 

--- a/internal/installer/runtime_state.go
+++ b/internal/installer/runtime_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
@@ -11,7 +12,11 @@ import (
 // duplicated TUI-written boolean. A non-regular or symlinked object is an
 // error, not evidence that a wallet exists.
 func WalletExists(network string) (bool, error) {
-	return walletExistsAt(paths.LNDWalletDB(network))
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
+		return false, err
+	}
+	return walletExistsAt(paths.LNDWalletDB(profile.LNDNetwork))
 }
 
 func walletExistsAt(path string) (bool, error) {

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -49,7 +49,7 @@ func SyncthingVersionStr() string { return syncthingVersion }
 
 // InstallOptions carries the `vpn install` command line.
 type InstallOptions struct {
-	// Network from --testnet4 ("" = mainnet for a pristine host,
+	// Network from --testnet4 or --signet ("" = mainnet for a pristine host,
 	// or keep the interrupted lifecycle's recorded answer).
 	Network string
 	// Unattended runs with no TUI and no prompts (ruling iv/vii:
@@ -678,7 +678,7 @@ func buildInstallSteps(
 				return writeBitcoindService(bitcoinUser)
 			}},
 		{Key: "btc.start", Name: "Starting Bitcoin Core",
-			Fn: startBitcoind},
+			Fn: func() error { return startBitcoind(cfg) }},
 		{Key: "security", Name: "Configuring security",
 			Fn: func() error {
 				if err := installUnattendedUpgrades(); err != nil {
@@ -1084,16 +1084,16 @@ func setupShellEnvironment(cfg *config.AppConfig) error {
 	bashrc := paths.AdminBashrc
 	data, _ := os.ReadFile(bashrc)
 	existing := string(data)
+	net, err := cfg.NetworkConfig()
+	if err != nil {
+		return err
+	}
 
 	var content string
 
 	// bitcoin-cli wrapper
 	if !strings.Contains(existing, "bitcoin-cli()") {
-		net := cfg.NetworkConfig()
-		btcNetFlag := ""
-		if net.Name == "testnet4" {
-			btcNetFlag = "\n        -testnet4 \\"
-		}
+		btcNetFlag := bitcoinCLINetworkFlag(net)
 		content += fmt.Sprintf(`
 # -- Virtual Private Node --
 # RPC password comes from the staged credential file on stdin;
@@ -1116,12 +1116,7 @@ export -f bitcoin-cli
 	// the initial install
 	if cfg.HasLND() &&
 		!strings.Contains(existing, "lncli()") {
-		net := cfg.NetworkConfig()
-		lndNetFlag := ""
-		if net.Name != "mainnet" {
-			lndNetFlag = fmt.Sprintf(
-				"\n        --network=%s \\", net.LNCLINetwork)
-		}
+		lndNetFlag := lncliNetworkFlag(net)
 		content += fmt.Sprintf(`
 lncli() {
     /usr/local/bin/lncli \
@@ -1147,6 +1142,20 @@ export -f lncli
 	defer f.Close()
 	_, err = f.WriteString(content)
 	return err
+}
+
+func bitcoinCLINetworkFlag(net *config.NetworkConfig) string {
+	if net.BitcoinCLIFlag == "" {
+		return ""
+	}
+	return "\n        " + net.BitcoinCLIFlag + " \\"
+}
+
+func lncliNetworkFlag(net *config.NetworkConfig) string {
+	if net.Name == config.NetworkMainnet {
+		return ""
+	}
+	return fmt.Sprintf("\n        --network=%s \\", net.LNDNetwork)
 }
 
 func randRead(b []byte) (int, error) {

--- a/internal/installer/setup_test.go
+++ b/internal/installer/setup_test.go
@@ -395,6 +395,32 @@ func TestVersionCacheFileConsistency(t *testing.T) {
 	}
 }
 
+func TestShellWrapperNetworkFlags(t *testing.T) {
+	tests := []struct {
+		network string
+		bitcoin string
+		lnd     string
+	}{
+		{config.NetworkMainnet, "", ""},
+		{config.NetworkTestnet4, "\n        -testnet4 \\", "\n        --network=testnet4 \\"},
+		{config.NetworkPublicSignet, "\n        -signet \\", "\n        --network=signet \\"},
+	}
+	for _, tt := range tests {
+		profile, err := config.NetworkConfigFromName(tt.network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := bitcoinCLINetworkFlag(profile); got != tt.bitcoin {
+			t.Errorf("%s bitcoin wrapper flag %q, want %q",
+				tt.network, got, tt.bitcoin)
+		}
+		if got := lncliNetworkFlag(profile); got != tt.lnd {
+			t.Errorf("%s lncli wrapper flag %q, want %q",
+				tt.network, got, tt.lnd)
+		}
+	}
+}
+
 // The checkOS tests formerly here moved to preflight_test.go
 // (TestCheckOSRelease*), against the preflight's exactly-13 rule.
 // The NeedsInstall tests died with NeedsInstall itself: commit 6

--- a/internal/installer/staging.go
+++ b/internal/installer/staging.go
@@ -97,10 +97,11 @@ func macaroonNetworkDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read node config: %w", err)
 	}
-	if cfg.IsMainnet() {
-		return "mainnet", nil
+	profile, err := cfg.NetworkConfig()
+	if err != nil {
+		return "", fmt.Errorf("resolve node network profile: %w", err)
 	}
-	return cfg.Network, nil
+	return profile.LNDNetwork, nil
 }
 
 // StageSyncthingAPIKey extracts the GUI API key from

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -369,7 +369,8 @@ func verifySyncthingConfig() error {
 
 func setupChannelBackupWatcher(cfg *config.AppConfig) error {
 	network := cfg.Network
-	if err := config.ValidateNetwork(network); err != nil {
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
 		return fmt.Errorf("configure LND backup publisher: %w", err)
 	}
 
@@ -402,7 +403,7 @@ func setupChannelBackupWatcher(cfg *config.AppConfig) error {
 	// If a backup already exists, copy it through the same
 	// least-privilege unit that handles future changes. A node
 	// without a wallet/channel backup yet is a normal no-op.
-	if _, err := os.Stat(paths.ChannelBackup(network)); err == nil {
+	if _, err := os.Stat(paths.ChannelBackup(profile.LNDNetwork)); err == nil {
 		if err := system.SudoRun("systemctl", "start",
 			"lnd-backup-export.service"); err != nil {
 			return err
@@ -422,11 +423,12 @@ func setupChannelBackupWatcher(cfg *config.AppConfig) error {
 func channelBackupUnits(network string) (
 	pathUnit, exportService string, err error,
 ) {
-	if err := config.ValidateNetwork(network); err != nil {
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
 		return "", "", fmt.Errorf(
 			"render LND backup units: %w", err)
 	}
-	backupSource := paths.ChannelBackup(network)
+	backupSource := paths.ChannelBackup(profile.LNDNetwork)
 	pathUnit = fmt.Sprintf(`[Unit]
 Description=Watch LND channel backup
 

--- a/internal/installer/syncthing_test.go
+++ b/internal/installer/syncthing_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
@@ -203,6 +204,32 @@ func TestChannelBackupUnitIdentityBoundary(t *testing.T) {
 	}
 	if _, _, err := channelBackupUnits("mainnet /tmp/source"); err == nil {
 		t.Error("backup unit accepted a caller-supplied path as a network")
+	}
+}
+
+func TestChannelBackupUnitsMapProfileToLNDState(t *testing.T) {
+	for _, network := range config.SupportedNetworks() {
+		profile, err := config.NetworkConfigFromName(network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pathUnit, exportUnit, err := channelBackupUnits(network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(pathUnit,
+			"PathChanged="+paths.ChannelBackup(profile.LNDNetwork)) {
+			t.Errorf("%s watcher does not use LND %s directory",
+				network, profile.LNDNetwork)
+		}
+		if !strings.Contains(exportUnit,
+			"publish-lnd-backup "+network) {
+			t.Errorf("%s publisher loses immutable profile ID", network)
+		}
+		if network == config.NetworkPublicSignet &&
+			strings.Contains(pathUnit, "/public-signet/") {
+			t.Fatal("public-signet profile used a non-existent LND directory")
+		}
 	}
 }
 

--- a/internal/installer/tor.go
+++ b/internal/installer/tor.go
@@ -23,8 +23,11 @@ func installTor() error {
 // Pure logic — no side effects.
 // Note: HiddenServiceDir paths are hardcoded strings because they are
 // torrc config content read by Tor, not Go logic paths.
-func BuildTorConfig(cfg *config.AppConfig) string {
-	net := cfg.NetworkConfig()
+func BuildTorConfig(cfg *config.AppConfig) (string, error) {
+	net, err := cfg.NetworkConfig()
+	if err != nil {
+		return "", err
+	}
 
 	var b strings.Builder
 	b.WriteString("# Virtual Private Node — Tor Configuration\n")
@@ -68,12 +71,15 @@ HiddenServicePort 8384 127.0.0.1:8384
 		// with explicit device approval for authentication.
 	}
 
-	return b.String()
+	return b.String(), nil
 }
 
 // RebuildTorConfig writes the torrc to disk.
 func RebuildTorConfig(cfg *config.AppConfig) error {
-	content := BuildTorConfig(cfg)
+	content, err := BuildTorConfig(cfg)
+	if err != nil {
+		return err
+	}
 	if err := system.SudoWriteFile(
 		paths.Torrc, []byte(content), 0640); err != nil {
 		return err
@@ -135,7 +141,11 @@ func verifySyncthingTorPrerequisite(cfg *config.AppConfig) error {
 	if err != nil {
 		return fmt.Errorf("read current Tor configuration: %w", err)
 	}
-	if !bytes.Equal(current, []byte(BuildTorConfig(cfg))) {
+	expected, err := BuildTorConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("build expected Tor configuration: %w", err)
+	}
+	if !bytes.Equal(current, []byte(expected)) {
 		return fmt.Errorf(
 			"Tor configuration does not match the expected base node — " +
 				"refusing Syncthing installation")

--- a/internal/installer/tor_test.go
+++ b/internal/installer/tor_test.go
@@ -12,9 +12,18 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
+func mustBuildTorConfig(t *testing.T, cfg *config.AppConfig) string {
+	t.Helper()
+	content, err := BuildTorConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
 func TestTorConfigWithLND(t *testing.T) {
 	cfg := config.Default()
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	required := []string{
 		"SOCKSPort 9050",
@@ -37,7 +46,7 @@ func TestTorConfigWithLND(t *testing.T) {
 func TestTorConfigWithSyncthing(t *testing.T) {
 	cfg := config.Default()
 	cfg.SyncthingEnabled = true
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	// Web UI still accessible over Tor
 	if !strings.Contains(content, "syncthing") {
@@ -58,7 +67,7 @@ func TestTorConfigWithSyncthing(t *testing.T) {
 
 func TestTorConfigNoSyncthingWithoutInstall(t *testing.T) {
 	cfg := config.Default()
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	if strings.Contains(content, "syncthing") {
 		t.Error("should not have syncthing without install")
@@ -70,7 +79,7 @@ func TestTorConfigFullStack(t *testing.T) {
 		Network:          "mainnet",
 		SyncthingEnabled: true,
 	}
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	required := []string{
 		"SOCKSPort 9050",
@@ -95,7 +104,7 @@ func TestTorConfigFullStack(t *testing.T) {
 
 func TestTorConfigMainnetPorts(t *testing.T) {
 	cfg := config.Default()
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	if !strings.Contains(content, "HiddenServicePort 8333") {
 		t.Error("mainnet torrc should use port 8333 for P2P")
@@ -107,7 +116,7 @@ func TestTorConfigMainnetPorts(t *testing.T) {
 
 func TestTorConfigTestnet4Ports(t *testing.T) {
 	cfg := &config.AppConfig{Network: "testnet4"}
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	if !strings.Contains(content, "HiddenServicePort 48333") {
 		t.Error("testnet4 torrc should use port 48333 for P2P")
@@ -117,12 +126,33 @@ func TestTorConfigTestnet4Ports(t *testing.T) {
 	}
 }
 
+func TestTorConfigPublicSignetPorts(t *testing.T) {
+	cfg := config.Default()
+	cfg.Network = config.NetworkPublicSignet
+	content := mustBuildTorConfig(t, cfg)
+
+	if !strings.Contains(content, "HiddenServicePort 38333 127.0.0.1:38333") {
+		t.Error("public-signet torrc should use port 38333 for P2P")
+	}
+	if strings.Contains(content, "HiddenServicePort 38332") {
+		t.Error("public-signet torrc should not have an RPC hidden service")
+	}
+}
+
+func TestTorConfigRejectsUnknownProfile(t *testing.T) {
+	cfg := config.Default()
+	cfg.Network = "signet"
+	if _, err := BuildTorConfig(cfg); err == nil {
+		t.Fatal("raw signet profile generated a Tor config")
+	}
+}
+
 func TestTorConfigControlPortAlways(t *testing.T) {
 	// The install-path routing gate (torgate.go) reads bootstrap
 	// progress from the control port unconditionally, so every
 	// generated torrc must include it — LND or not.
 	cfg := config.Default()
-	content := BuildTorConfig(cfg)
+	content := mustBuildTorConfig(t, cfg)
 
 	if !strings.Contains(content, "ControlPort 9051") {
 		t.Error("ControlPort must be present in every config (install gate depends on it)")
@@ -159,7 +189,7 @@ func TestSyncthingTorPrerequisiteRequiresExpectedBaseState(t *testing.T) {
 	torServiceEnabledForAddon = func() bool { return true }
 	torServiceActiveForAddon = func() bool { return true }
 	readTorConfigForAddon = func(string) ([]byte, error) {
-		return []byte(BuildTorConfig(cfg)), nil
+		return []byte(mustBuildTorConfig(t, cfg)), nil
 	}
 	if err := verifySyncthingTorPrerequisite(cfg); err != nil {
 		t.Fatal(err)

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -43,7 +43,6 @@ type Client struct {
 	lightning   lnrpc.LightningClient
 	state       lnrpc.StateClient
 	macaroonHex string
-	network     string
 	mu          sync.RWMutex
 }
 
@@ -54,8 +53,8 @@ type Client struct {
 // Returns a client even if LND is not available — RPC methods
 // check for a live connection internally and return
 // errNotConnected if the connection is nil.
-func New(network string) *Client {
-	c := &Client{network: network}
+func New() *Client {
+	c := &Client{}
 	if err := c.connect(); err != nil {
 		logger.Status("LND gRPC not available: %v", err)
 		return c

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -72,6 +72,8 @@ const (
 		"service-layout-1-mainnet-tor"
 	InstallBootstrapTestnet4 = InstallBootstrapPrefix +
 		"service-layout-1-testnet4-tor"
+	InstallBootstrapPublicSignet = InstallBootstrapPrefix +
+		"service-layout-1-public-signet-tor"
 
 	// RuntimeDir and InstallLock are transient serialization
 	// state. The stable lock is deliberately separate from the

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -60,8 +60,9 @@ func TestLifecycleStateUsesPrivateBoundary(t *testing.T) {
 		t.Error("stable lock and replaceable ledger share a path")
 	}
 	for network, path := range map[string]string{
-		"mainnet":  InstallBootstrapMainnet,
-		"testnet4": InstallBootstrapTestnet4,
+		"mainnet":       InstallBootstrapMainnet,
+		"testnet4":      InstallBootstrapTestnet4,
+		"public-signet": InstallBootstrapPublicSignet,
 	} {
 		if !strings.HasPrefix(path, InstallBootstrapPrefix) {
 			t.Errorf("%s bootstrap path %q is outside /var/lib", network, path)
@@ -75,8 +76,10 @@ func TestLifecycleStateUsesPrivateBoundary(t *testing.T) {
 				network, path)
 		}
 	}
-	if InstallBootstrapMainnet == InstallBootstrapTestnet4 {
-		t.Error("mainnet and testnet4 share a bootstrap path")
+	if InstallBootstrapMainnet == InstallBootstrapTestnet4 ||
+		InstallBootstrapMainnet == InstallBootstrapPublicSignet ||
+		InstallBootstrapTestnet4 == InstallBootstrapPublicSignet {
+		t.Error("network profiles share a bootstrap path")
 	}
 	if InstallBootstrapPrefix != "/var/lib/vpn-install-bootstrap-" {
 		t.Errorf("bootstrap prefix is %q", InstallBootstrapPrefix)

--- a/internal/welcome/cmds.go
+++ b/internal/welcome/cmds.go
@@ -436,8 +436,8 @@ func labelTxCmd(
 // wants to select/copy text with their terminal's native
 // mechanism rather than via the TUI's monoWrap/QR overlays.
 
-func showMacaroonCmd(cfg *config.AppConfig) tea.Cmd {
-	mac := readMacaroonHex(cfg)
+func showMacaroonCmd() tea.Cmd {
+	mac := readMacaroonHex()
 	if mac == "" {
 		return nil
 	}

--- a/internal/welcome/helpers.go
+++ b/internal/welcome/helpers.go
@@ -25,7 +25,7 @@ import (
 // root destroyed and recreated — a dead address rendered
 // confidently, with no failure moment to catch it.
 
-func readMacaroonHex(cfg *config.AppConfig) string {
+func readMacaroonHex() string {
 	data, err := helper.ReadBoard(paths.StateLNDMacaroon)
 	if err != nil {
 		logger.Status("Warning: failed to read macaroon: %v", err)
@@ -41,7 +41,11 @@ func fetchFeeTiers(cfg *config.AppConfig) feeTiersMsg {
 	labels := [4]string{"~1 blk", "~3 blk", "~6 blk", "~25 blk"}
 	var tiers [4]feeTier
 
-	rpcPort := cfg.NetworkConfig().RPCPort
+	profile, err := cfg.NetworkConfig()
+	if err != nil {
+		return feeTiersMsg{err: err}
+	}
+	rpcPort := profile.RPCPort
 
 	for i, target := range targets {
 		tiers[i] = feeTier{
@@ -119,23 +123,11 @@ func isValidOnChainAddr(addr string, network string) bool {
 	if len(addr) < 14 {
 		return false
 	}
-	switch network {
-	case "mainnet":
-		return strings.HasPrefix(addr, "bc1") ||
-			strings.HasPrefix(addr, "1") ||
-			strings.HasPrefix(addr, "3")
-	case "testnet":
-		return strings.HasPrefix(addr, "tb1") ||
-			strings.HasPrefix(addr, "2") ||
-			strings.HasPrefix(addr, "m") ||
-			strings.HasPrefix(addr, "n")
-	case "regtest":
-		return strings.HasPrefix(addr, "bcrt1")
-	case "signet":
-		return strings.HasPrefix(addr, "tb1") ||
-			strings.HasPrefix(addr, "sb1")
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
+		return false
 	}
-	return true // unknown network, let LND validate
+	return profile.AcceptsOnChainAddress(addr)
 }
 
 // renderViewport creates a local viewport, sets content,

--- a/internal/welcome/inputs.go
+++ b/internal/welcome/inputs.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
+	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
 // ── Validators ───────────────────────────────────────────
@@ -77,9 +78,12 @@ func applyInputStyles(ti *textinput.Model) {
 
 // ── Factory functions ────────────────────────────────────
 
-func newSendPayReqInput() textinput.Model {
+func newSendPayReqInput(network string) textinput.Model {
 	ti := textinput.New()
-	ti.Placeholder = "lnbc..."
+	ti.Placeholder = "invoice..."
+	if profile, err := config.NetworkConfigFromName(network); err == nil {
+		ti.Placeholder = profile.InvoicePlaceholder
+	}
 	ti.CharLimit = 1500
 	ti.SetWidth(58)
 	ti.Validate = validateBolt11
@@ -135,9 +139,12 @@ func newSyncthingIDInput() textinput.Model {
 	return ti
 }
 
-func newOnChainAddrInput() textinput.Model {
+func newOnChainAddrInput(network string) textinput.Model {
 	ti := textinput.New()
-	ti.Placeholder = "bc1p..."
+	ti.Placeholder = "address..."
+	if profile, err := config.NetworkConfigFromName(network); err == nil {
+		ti.Placeholder = profile.AddressPlaceholder
+	}
 	ti.CharLimit = 90
 	ti.SetWidth(62)
 	ti.Validate = validateOnChainAddr

--- a/internal/welcome/model.go
+++ b/internal/welcome/model.go
@@ -354,7 +354,7 @@ func NewModel(
 	// to be re-audited for the two handlers interleaving.
 	var client *lndrpc.Client
 	if cfg.HasLND() && state.WalletKnown && state.WalletExists {
-		client = lndrpc.New(cfg.Network)
+		client = lndrpc.New()
 	}
 	m := Model{
 		cfg: cfg, prefs: prefs, state: state,

--- a/internal/welcome/network_profile_test.go
+++ b/internal/welcome/network_profile_test.go
@@ -1,0 +1,96 @@
+package welcome
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+)
+
+func TestOnChainPrefixValidationUsesInstalledProfile(t *testing.T) {
+	tests := []struct {
+		network string
+		accept  string
+		reject  string
+	}{
+		{config.NetworkMainnet, "bc1qexample000", "tb1qexample000"},
+		{config.NetworkTestnet4, "tb1qexample000", "bc1qexample000"},
+		{config.NetworkPublicSignet, "tb1qexample000", "sb1qexample000"},
+	}
+	for _, tt := range tests {
+		if !isValidOnChainAddr(tt.accept, tt.network) {
+			t.Errorf("%s rejected %q", tt.network, tt.accept)
+		}
+		if isValidOnChainAddr(tt.reject, tt.network) {
+			t.Errorf("%s accepted %q", tt.network, tt.reject)
+		}
+	}
+	if isValidOnChainAddr("bc1qexample000", "signet") {
+		t.Fatal("unknown raw signet profile accepted an address")
+	}
+}
+
+func TestNetworkSpecificInputPlaceholders(t *testing.T) {
+	tests := []struct {
+		network string
+		address string
+		invoice string
+	}{
+		{config.NetworkMainnet, "bc1p...", "lnbc..."},
+		{config.NetworkTestnet4, "tb1p...", "lntb..."},
+		{config.NetworkPublicSignet, "tb1p...", "lntbs..."},
+	}
+	for _, tt := range tests {
+		if got := newOnChainAddrInput(tt.network).Placeholder; got != tt.address {
+			t.Errorf("%s address placeholder %q, want %q", tt.network, got, tt.address)
+		}
+		if got := newSendPayReqInput(tt.network).Placeholder; got != tt.invoice {
+			t.Errorf("%s invoice placeholder %q, want %q", tt.network, got, tt.invoice)
+		}
+	}
+}
+
+func TestLightningInvoicePrefilterUsesInstalledProfile(t *testing.T) {
+	for _, network := range config.SupportedNetworks() {
+		cfg := config.Default()
+		cfg.Network = network
+		profile, err := cfg.NetworkConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		screen := NewSendScreen(&ScreenContext{Cfg: cfg})
+		screen.sendInput.SetValue(profile.InvoicePrefix + "1example")
+		_, cmd := screen.submitSendPayment()
+		if cmd == nil || screen.inputError != "" {
+			t.Errorf("%s invoice rejected before LND: %q", network, screen.inputError)
+		}
+
+		foreign := "lnbc1example"
+		if network == config.NetworkMainnet {
+			foreign = "lntb1example"
+		}
+		screen.sendInput.SetValue(foreign)
+		_, cmd = screen.submitSendPayment()
+		if cmd != nil || !strings.Contains(screen.inputError, "not for") {
+			t.Errorf("%s foreign invoice result cmd=%v error=%q",
+				network, cmd != nil, screen.inputError)
+		}
+	}
+}
+
+func TestTestingNetworkBanner(t *testing.T) {
+	for _, network := range config.SupportedNetworks() {
+		cfg := config.Default()
+		cfg.Network = network
+		m := Model{cfg: cfg}
+		banner := m.renderNetworkBanner()
+		if network == config.NetworkMainnet && banner != "" {
+			t.Errorf("mainnet banner = %q", banner)
+		}
+		if network != config.NetworkMainnet &&
+			(!strings.Contains(banner, "TESTING NETWORK") ||
+				!strings.Contains(banner, "no mainnet value")) {
+			t.Errorf("%s banner = %q", network, banner)
+		}
+	}
+}

--- a/internal/welcome/screen_offchain_pairing.go
+++ b/internal/welcome/screen_offchain_pairing.go
@@ -93,7 +93,7 @@ func (s *PairingScreen) handleEnter() (Screen, tea.Cmd) {
 	switch btns[s.btnIdx] {
 	case "Show QR (Tor)":
 		restOnion := s.restOnion
-		mac := readMacaroonHex(s.ctx.Cfg)
+		mac := readMacaroonHex()
 		if restOnion != "" && mac != "" {
 			url := fmt.Sprintf(
 				"lndconnect://%s:8080?macaroon=%s",
@@ -109,7 +109,7 @@ func (s *PairingScreen) handleEnter() (Screen, tea.Cmd) {
 		if s.ctx.Cfg.P2PMode == "hybrid" &&
 			s.ctx.Status != nil &&
 			s.ctx.Status.publicIP != "" {
-			mac := readMacaroonHex(s.ctx.Cfg)
+			mac := readMacaroonHex()
 			if mac != "" {
 				url := fmt.Sprintf(
 					"lndconnect://%s:8080"+
@@ -125,7 +125,7 @@ func (s *PairingScreen) handleEnter() (Screen, tea.Cmd) {
 			}
 		}
 	case "Copyable Macaroon":
-		return s, showMacaroonCmd(s.ctx.Cfg)
+		return s, showMacaroonCmd()
 	}
 	return s, nil
 }
@@ -205,7 +205,7 @@ func (s *PairingScreen) View(
 		p.monoWrap("8080")
 	}
 
-	mac := readMacaroonHex(cfg)
+	mac := readMacaroonHex()
 	if mac != "" {
 		p.blank()
 		preview := mac[:min(24, len(mac))] + "..."

--- a/internal/welcome/screen_offchain_send.go
+++ b/internal/welcome/screen_offchain_send.go
@@ -62,7 +62,7 @@ func NewSendScreen(
 	return &SendScreen{
 		ctx:         ctx,
 		step:        sendStepInput,
-		sendInput:   newSendPayReqInput(),
+		sendInput:   newSendPayReqInput(ctx.Cfg.Network),
 		inputBtnIdx: 1, // default to Send
 	}
 }
@@ -230,7 +230,7 @@ func (s *SendScreen) handleInputKey(
 		if s.focusZone == sendZoneButtons {
 			switch s.inputBtnIdx {
 			case 0: // Clear
-				s.sendInput = newSendPayReqInput()
+				s.sendInput = newSendPayReqInput(s.ctx.Cfg.Network)
 				s.inputError = ""
 				s.focusZone = sendZoneInput
 				return s, nil
@@ -269,11 +269,14 @@ func (s *SendScreen) submitSendPayment() (
 	}
 	payReq = cleanPayReq(payReq)
 	s.sendInput.SetValue(payReq)
-	if !strings.HasPrefix(payReq, "lnbc") &&
-		!strings.HasPrefix(payReq, "lntb") &&
-		!strings.HasPrefix(payReq, "lnbcrt") {
+	profile, err := s.ctx.Cfg.NetworkConfig()
+	if err != nil {
+		s.inputError = "Unsupported node network profile"
+		return s, nil
+	}
+	if !profile.AcceptsInvoicePrefix(payReq) {
 		s.inputError =
-			"Not a valid Lightning invoice"
+			"Invoice is not for " + profile.DisplayName
 		return s, nil
 	}
 	s.inputError = ""

--- a/internal/welcome/screen_onchain_send.go
+++ b/internal/welcome/screen_onchain_send.go
@@ -71,7 +71,7 @@ func NewOnChainSendScreen(
 		ctx:        ctx,
 		ocCtx:      ocCtx,
 		step:       ocStepAddr,
-		addrInput:  newOnChainAddrInput(),
+		addrInput:  newOnChainAddrInput(ctx.Cfg.Network),
 		amtInput:   NewAmountInput(),
 		labelInput: newOCSendLabelInput(),
 		feeInput:   NewFeeInput(),
@@ -797,7 +797,7 @@ func (s *OnChainSendScreen) backToInput() {
 // resetInputs creates fresh inputs and resets all
 // input-phase state.
 func (s *OnChainSendScreen) resetInputs() {
-	s.addrInput = newOnChainAddrInput()
+	s.addrInput = newOnChainAddrInput(s.ctx.Cfg.Network)
 	s.amtInput = NewAmountInput()
 	s.labelInput = newOCSendLabelInput()
 	s.feeInput = NewFeeInput()

--- a/internal/welcome/screen_system_wallet_create.go
+++ b/internal/welcome/screen_system_wallet_create.go
@@ -305,7 +305,10 @@ func (s *WalletCreateScreen) HandleMsg(
 // only escape is typing the exact phrase or killing
 // the SSH session.
 func (s *WalletCreateScreen) startExecProcess() tea.Cmd {
-	net := s.ctx.Cfg.NetworkConfig()
+	net, err := s.ctx.Cfg.NetworkConfig()
+	if err != nil {
+		return func() tea.Msg { return walletExecDoneMsg{err: err} }
+	}
 	script := `clear
 echo
 echo "  ==================================================="
@@ -329,7 +332,7 @@ echo
 /usr/local/bin/lncli ` +
 		`--rpcserver=` + paths.LNDGRPCEndpoint + ` ` +
 		`--tlscertpath=` + paths.StateLNDTLSCert + ` ` +
-		`--network=` + net.LNCLINetwork + ` create && {
+		`--network=` + net.LNDNetwork + ` create && {
   trap '' INT
   echo
   echo "  ==================================================="

--- a/internal/welcome/status.go
+++ b/internal/welcome/status.go
@@ -23,6 +23,7 @@ func fetchStatus(
 		s := statusMsg{services: make(map[string]bool)}
 		var wg sync.WaitGroup
 		var mu sync.Mutex
+		profile, profileErr := cfg.NetworkConfig()
 
 		for _, name := range serviceNames(cfg) {
 			wg.Add(1)
@@ -35,27 +36,30 @@ func fetchStatus(
 			}(name)
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			info := bitcoin.GetBlockchainInfo(
-				cfg.NetworkConfig().RPCPort)
-			mu.Lock()
-			s.btcResponding = info.Responding
-			s.btcBlocks = info.Blocks
-			s.btcHeaders = info.Headers
-			s.btcProgress = info.Progress
-			s.btcSynced = info.Synced
-			// bitcoind reports its own data footprint
-			// (size_on_disk) — no privileged measurement of
-			// the data dir is needed for this card.
-			if info.Responding {
-				s.btcSize = bitcoin.FormatSize(info.SizeOnDisk)
-			} else {
-				s.btcSize = "N/A"
-			}
-			mu.Unlock()
-		}()
+		if profileErr == nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				info := bitcoin.GetBlockchainInfo(profile.RPCPort)
+				mu.Lock()
+				s.btcResponding = info.Responding
+				s.btcBlocks = info.Blocks
+				s.btcHeaders = info.Headers
+				s.btcProgress = info.Progress
+				s.btcSynced = info.Synced
+				// bitcoind reports its own data footprint
+				// (size_on_disk) — no privileged measurement of
+				// the data dir is needed for this card.
+				if info.Responding {
+					s.btcSize = bitcoin.FormatSize(info.SizeOnDisk)
+				} else {
+					s.btcSize = "N/A"
+				}
+				mu.Unlock()
+			}()
+		} else {
+			s.btcSize = "N/A"
+		}
 
 		wg.Add(1)
 		go func() {

--- a/internal/welcome/update.go
+++ b/internal/welcome/update.go
@@ -316,7 +316,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state.WalletKnown = true
 		if m.state.WalletExists && m.lndClient == nil &&
 			m.cfg.HasLND() {
-			m.lndClient = lndrpc.New(m.cfg.Network)
+			m.lndClient = lndrpc.New()
 			m.screenCtx.LndClient = m.lndClient
 			return m, fetchStatus(m.cfg, m.state, m.lndClient)
 		}
@@ -520,7 +520,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state.WalletExists = true
 		m.state.WalletKnown = true
 		if m.lndClient == nil && m.cfg.HasLND() {
-			m.lndClient = lndrpc.New(m.cfg.Network)
+			m.lndClient = lndrpc.New()
 			m.screenCtx.LndClient = m.lndClient
 		}
 		// Find the wallet creation tab and transform

--- a/internal/welcome/view_layout.go
+++ b/internal/welcome/view_layout.go
@@ -200,6 +200,9 @@ func (m Model) viewMain() string {
 	helpLine := centerInWidth(helpStr, totalW)
 
 	fullContent := frame + "\n" + helpLine
+	if banner := m.renderNetworkBanner(); banner != "" {
+		fullContent = centerInWidth(banner, totalW) + "\n" + fullContent
+	}
 	// First-run verification banner (ruling xvi): shown until
 	// the journal proves a real sshd login for the admin user.
 	if !m.state.KeyVerificationKnown ||
@@ -214,6 +217,18 @@ func (m Model) viewMain() string {
 		lipgloss.Center, lipgloss.Center,
 		fullContent,
 	)
+}
+
+func (m Model) renderNetworkBanner() string {
+	profile, err := m.cfg.NetworkConfig()
+	if err != nil {
+		return theme.Warning.Render("⚠ Unsupported network profile")
+	}
+	if !profile.TestingOnly {
+		return ""
+	}
+	return theme.Warning.Render("⚠ TESTING NETWORK — "+profile.DisplayName) +
+		theme.Dim.Render(" — coins have no mainnet value")
 }
 
 // renderVerifyBanner is the first-run access-verification

--- a/scripts/validation/verify-lnd-backup-export.sh
+++ b/scripts/validation/verify-lnd-backup-export.sh
@@ -13,9 +13,10 @@ fi
 
 network=${1:-}
 case "${network}" in
-    mainnet|testnet4) ;;
+    mainnet|testnet4) lnd_network=${network} ;;
+    public-signet) lnd_network=signet ;;
     *)
-        echo "Usage: $0 <mainnet|testnet4>" >&2
+        echo "Usage: $0 <mainnet|testnet4|public-signet>" >&2
         exit 2
         ;;
 esac
@@ -152,7 +153,7 @@ stage_dir=${export_root}/lnd-backup-stage
 final_dir=${export_root}/lnd-backup
 marker_name=.vpn-export-ready
 marker_dir=${final_dir}/${marker_name}
-source_file=/var/lib/lnd/data/chain/bitcoin/${network}/channel.backup
+source_file=/var/lib/lnd/data/chain/bitcoin/${lnd_network}/channel.backup
 final_file=${final_dir}/channel.backup
 
 assert_metadata "FS Syncthing config private" /etc/syncthing directory \

--- a/scripts/validation/verify-network-profile.sh
+++ b/scripts/validation/verify-network-profile.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+set -u -o pipefail
+
+# Read-only Debian 13 amd64 validation for one immutable VPN network profile.
+# Run as root on a disposable, freshly installed candidate. This proves the
+# generated daemon configuration and the live Bitcoin Core identity; wallet,
+# address, invoice, payment, channel, backup, reboot, and Tor reachability
+# scenarios remain explicit certification-matrix steps.
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "ERROR: run as root on the disposable Debian fixture" >&2
+    exit 2
+fi
+
+profile=${1:-}
+case "${profile}" in
+    mainnet)
+        core_chain=main
+        core_dir=.
+        lnd_network=mainnet
+        rpc_port=8332
+        p2p_port=8333
+        zmq_block=28332
+        zmq_tx=28333
+        genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+        challenge=
+        core_selector=
+        core_cli_flag=
+        lnd_selector=bitcoin.mainnet=true
+        invoice_prefix=lnbc
+        ;;
+    testnet4)
+        core_chain=testnet4
+        core_dir=testnet4
+        lnd_network=testnet4
+        rpc_port=48332
+        p2p_port=48333
+        zmq_block=28334
+        zmq_tx=28335
+        genesis=00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043
+        challenge=
+        core_selector=testnet4=1
+        core_cli_flag=-testnet4
+        lnd_selector=bitcoin.testnet4=true
+        invoice_prefix=lntb
+        ;;
+    public-signet)
+        core_chain=signet
+        core_dir=signet
+        lnd_network=signet
+        rpc_port=38332
+        p2p_port=38333
+        zmq_block=28336
+        zmq_tx=28337
+        genesis=00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6
+        challenge=512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae
+        core_selector=signet=1
+        core_cli_flag=-signet
+        lnd_selector=bitcoin.signet=true
+        invoice_prefix=lntbs
+        ;;
+    *)
+        echo "Usage: $0 <mainnet|testnet4|public-signet>" >&2
+        exit 2
+        ;;
+esac
+
+passes=0
+failures=0
+
+pass() {
+    passes=$((passes + 1))
+    echo "PASS $1"
+}
+
+fail() {
+    failures=$((failures + 1))
+    echo "FAIL $1: $2"
+}
+
+assert_equal() {
+    local label=$1
+    local got=$2
+    local want=$3
+    if [[ ${got} == "${want}" ]]; then
+        pass "${label}"
+    else
+        fail "${label}" "got '${got}', want '${want}'"
+    fi
+}
+
+assert_file_contains() {
+    local label=$1
+    local file=$2
+    local value=$3
+    if grep -Fqx -- "${value}" "${file}" 2>/dev/null; then
+        pass "${label}"
+    else
+        fail "${label}" "${file} lacks exact line '${value}'"
+    fi
+}
+
+assert_file_excludes() {
+    local label=$1
+    local file=$2
+    local value=$3
+    if ! grep -Fq -- "${value}" "${file}" 2>/dev/null; then
+        pass "${label}"
+    else
+        fail "${label}" "${file} contains '${value}'"
+    fi
+}
+
+assert_file_excludes_line_prefix() {
+    local label=$1
+    local file=$2
+    local value=$3
+    if ! grep -Eq -- "^${value}" "${file}" 2>/dev/null; then
+        pass "${label}"
+    else
+        fail "${label}" "${file} contains a line beginning '${value}'"
+    fi
+}
+
+assert_file_prefix_count() {
+    local label=$1
+    local file=$2
+    local value=$3
+    local want=$4
+    local got
+    got=$(grep -Ec -- "^${value}" "${file}" 2>/dev/null || true)
+    assert_equal "${label}" "${got}" "${want}"
+}
+
+os_id=$(sed -n 's/^ID=//p' /etc/os-release | tr -d '"')
+os_version=$(sed -n 's/^VERSION_ID=//p' /etc/os-release | tr -d '"')
+assert_equal "ENV Debian" "${os_id}" "debian"
+assert_equal "ENV Debian release" "${os_version}" "13"
+assert_equal "ENV architecture" "$(dpkg --print-architecture)" "amd64"
+assert_equal "ENV systemd PID 1" "$(cat /proc/1/comm)" "systemd"
+
+recorded_profile=$(python3 - <<'PY'
+import json
+with open("/etc/vpn/config.json", encoding="utf-8") as handle:
+    print(json.load(handle)["network"])
+PY
+)
+assert_equal "CFG immutable profile" "${recorded_profile}" "${profile}"
+
+ledger_profile=$(python3 - <<'PY'
+import json
+with open("/var/lib/vpn/private/install-state.json", encoding="utf-8") as handle:
+    print(json.load(handle)["context"]["network"])
+PY
+)
+assert_equal "LIFE ledger profile" "${ledger_profile}" "${profile}"
+
+bitcoin_conf=/etc/bitcoin/bitcoin.conf
+lnd_conf=/etc/lnd/lnd.conf
+assert_file_contains "BTC cookie disabled" "${bitcoin_conf}" "norpccookiefile=1"
+assert_file_excludes_line_prefix "BTC no cookie path" "${bitcoin_conf}" \
+    "rpccookiefile="
+assert_file_prefix_count "BTC two rpcauth identities" "${bitcoin_conf}" \
+    "rpcauth=" 2
+assert_file_contains "BTC RPC port" "${bitcoin_conf}" "rpcport=${rpc_port}"
+assert_file_contains "BTC block ZMQ" "${bitcoin_conf}" \
+    "zmqpubrawblock=tcp://127.0.0.1:${zmq_block}"
+assert_file_contains "BTC transaction ZMQ" "${bitcoin_conf}" \
+    "zmqpubrawtx=tcp://127.0.0.1:${zmq_tx}"
+assert_file_excludes "BTC no custom signet challenge" "${bitcoin_conf}" \
+    "signetchallenge="
+assert_file_excludes "BTC no custom signet seed" "${bitcoin_conf}" \
+    "signetseednode="
+if [[ -n ${core_selector} ]]; then
+    assert_file_contains "BTC selected profile" "${bitcoin_conf}" "${core_selector}"
+else
+    assert_file_excludes "BTC mainnet excludes testnet4" "${bitcoin_conf}" "testnet4=1"
+    assert_file_excludes "BTC mainnet excludes signet" "${bitcoin_conf}" "signet=1"
+fi
+
+assert_file_contains "LND selected profile" "${lnd_conf}" "${lnd_selector}"
+assert_file_contains "LND RPC port" "${lnd_conf}" \
+    "bitcoind.rpchost=127.0.0.1:${rpc_port}"
+assert_file_contains "LND block ZMQ" "${lnd_conf}" \
+    "bitcoind.zmqpubrawblock=tcp://127.0.0.1:${zmq_block}"
+assert_file_contains "LND transaction ZMQ" "${lnd_conf}" \
+    "bitcoind.zmqpubrawtx=tcp://127.0.0.1:${zmq_tx}"
+assert_file_excludes "LND no Bitcoin cookie" "${lnd_conf}" "bitcoind.rpccookie="
+assert_file_excludes "LND no custom signet challenge" "${lnd_conf}" \
+    "bitcoin.signetchallenge="
+assert_file_excludes "LND no custom signet seed" "${lnd_conf}" \
+    "bitcoin.signetseednode="
+
+assert_file_contains "TOR Bitcoin P2P port" /etc/tor/torrc \
+    "HiddenServicePort ${p2p_port} 127.0.0.1:${p2p_port}"
+
+declare -a bitcoin_cli
+bitcoin_cli=(/usr/local/bin/bitcoin-cli
+    -rpcconnect=127.0.0.1
+    -rpcport="${rpc_port}"
+    -rpcuser=vpn
+    -stdinrpcpass)
+if [[ -n ${core_cli_flag} ]]; then
+    bitcoin_cli+=("${core_cli_flag}")
+fi
+
+chain_info=$("${bitcoin_cli[@]}" getblockchaininfo \
+    < /var/lib/vpn/state/bitcoind-rpc.pass 2>/dev/null)
+rpc_identity=$(python3 -c '
+import json, sys
+value = json.load(sys.stdin)
+print(value.get("chain", "") + "|" + value.get("signet_challenge", ""))
+' <<<"${chain_info}")
+assert_equal "LIVE Core chain and challenge" "${rpc_identity}" \
+    "${core_chain}|${challenge}"
+
+live_genesis=$("${bitcoin_cli[@]}" getblockhash 0 \
+    < /var/lib/vpn/state/bitcoind-rpc.pass 2>/dev/null)
+assert_equal "LIVE Core genesis" "${live_genesis}" "${genesis}"
+
+if [[ ${core_dir} == . ]]; then
+    cookie_path=/var/lib/bitcoin/.cookie
+else
+    cookie_path=/var/lib/bitcoin/${core_dir}/.cookie
+fi
+for cookie_artifact in "${cookie_path}" "${cookie_path}.tmp"; do
+    if [[ ! -e ${cookie_artifact} && ! -L ${cookie_artifact} ]]; then
+        pass "LIVE no Bitcoin RPC cookie artifact ${cookie_artifact}"
+    else
+        fail "LIVE no Bitcoin RPC cookie artifact ${cookie_artifact}" \
+            "unexpected path exists"
+    fi
+done
+
+if [[ ${profile} == mainnet ]]; then
+    for foreign_dir in testnet4 signet; do
+        if [[ ! -e /var/lib/bitcoin/${foreign_dir} &&
+              ! -L /var/lib/bitcoin/${foreign_dir} ]]; then
+            pass "STATE no ${foreign_dir} Core reuse"
+        else
+            fail "STATE no ${foreign_dir} Core reuse" \
+                "unexpected /var/lib/bitcoin/${foreign_dir} exists"
+        fi
+    done
+else
+    if [[ ! -e /var/lib/bitcoin/chainstate &&
+          ! -L /var/lib/bitcoin/chainstate ]]; then
+        pass "STATE no mainnet Core reuse"
+    else
+        fail "STATE no mainnet Core reuse" \
+            "unexpected /var/lib/bitcoin/chainstate exists"
+    fi
+    foreign_dir=testnet4
+    if [[ ${core_dir} == testnet4 ]]; then
+        foreign_dir=signet
+    fi
+    if [[ ! -e /var/lib/bitcoin/${foreign_dir} &&
+          ! -L /var/lib/bitcoin/${foreign_dir} ]]; then
+        pass "STATE no ${foreign_dir} Core reuse"
+    else
+        fail "STATE no ${foreign_dir} Core reuse" \
+            "unexpected /var/lib/bitcoin/${foreign_dir} exists"
+    fi
+fi
+
+assert_equal "RUN bitcoind active" \
+    "$(systemctl is-active bitcoind.service 2>/dev/null || true)" active
+assert_equal "RUN lnd active" \
+    "$(systemctl is-active lnd.service 2>/dev/null || true)" active
+assert_equal "RUN Tor active" \
+    "$(systemctl is-active tor.service 2>/dev/null || true)" active
+
+if [[ -f /var/lib/lnd/data/chain/bitcoin/${lnd_network}/wallet.db ]]; then
+    pass "STATE wallet uses ${lnd_network}"
+else
+    pass "STATE wallet not created yet"
+fi
+for foreign in mainnet testnet4 signet; do
+    if [[ ${foreign} == "${lnd_network}" ]]; then
+        continue
+    fi
+    foreign_wallet=/var/lib/lnd/data/chain/bitcoin/${foreign}/wallet.db
+    if [[ ! -e ${foreign_wallet} && ! -L ${foreign_wallet} ]]; then
+        pass "STATE no ${foreign} wallet reuse"
+    else
+        fail "STATE no ${foreign} wallet reuse" \
+            "unexpected ${foreign_wallet} exists"
+    fi
+done
+
+assert_file_contains "CLI bitcoin wrapper RPC port" /home/vpn/.bashrc \
+    "        -rpcport=${rpc_port} \\"
+if [[ -n ${core_cli_flag} ]]; then
+    assert_file_contains "CLI bitcoin wrapper profile" /home/vpn/.bashrc \
+        "        ${core_cli_flag} \\"
+fi
+if [[ ${lnd_network} == mainnet ]]; then
+    assert_file_excludes "CLI mainnet lncli has no alternate selector" \
+        /home/vpn/.bashrc "        --network="
+else
+    assert_file_contains "CLI lncli profile" /home/vpn/.bashrc \
+        "        --network=${lnd_network} \\"
+fi
+
+echo "INFO expected BOLT11 prefix=${invoice_prefix}"
+echo "SUMMARY pass=${passes} fail=${failures}"
+if (( failures > 0 )); then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds immutable Bitcoin network profiles while retaining mainnet as the default:

- `mainnet`
- `testnet4`
- `public-signet`

The selected profile is established during installation and cannot later be switched or reused with another network’s state.

## Changes

- Configures Bitcoin Core and LND for the selected network profile.
- Uses profile-specific ports, ZMQ endpoints, state paths, wrappers, and Lightning invoice prefixes.
- Uses separate `rpcauth` credentials for VPN and LND with Bitcoin Core RPC cookies disabled.
- Adds persistent testing-network warnings for Testnet4 and public signet.
- Validates network-specific Lightning invoices and on-chain addresses before sending.
- Rejects conflicting network flags, profile switching, foreign network state, and unsupported custom or controlled signet configurations.
- Adds profile-aware validation scripts and focused network-identity tests.

## Scope

This PR supports the fixed `mainnet`, `testnet4`, and `public-signet` profiles only. Controlled or custom signet configurations remain unsupported.