### PR TITLE
feat: configure lnd with sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ funds.
 ### Requirements
 
 - Fresh Debian 13 amd64 machine
-- 2 (v)CPU, 4+ GB RAM, 90+ GB SSD
+- 2 (v)CPU, 4+ GB RAM, 90+ GB total SSD. LND safety-stops at 10% free,
+  leaving about 81 GB of operational usage on a 90 GB filesystem.
 
 ### Privacy
 
@@ -232,11 +233,33 @@ later from **System → Services → LND → P2P Upgrade**:
 The upgrade is one-way — once your IP is published to the network
 gossip, it cannot be retracted.
 
+### LND Database and Recovery
+
+Fresh v0.7.0 installations use LND's local SQLite backend and native SQL
+stores. VPN does not migrate an existing bbolt node, and the database settings
+must not be changed after initialization. SQLite's WAL, checkpoint, locking,
+and durability behavior remains at the pinned LND release's defaults.
+
+LND checks disk space every 12 hours and makes two attempts before gracefully
+stopping when filesystem free space reaches 10%. Because
+`Restart=on-failure` does not restart that successful safety shutdown, free
+space and then start LND explicitly. VPN does not delete, recreate, or repair
+a database automatically.
+
+The seed and `channel.backup` are the supported routine disaster-recovery
+artifacts. An SCB does not restore live channels: it asks reachable peers to
+force-close so settled funds can be swept on-chain. VPN does not synchronize
+the SQLite databases or advertise a live database-copy procedure. See LND's
+[operational safety](https://github.com/lightningnetwork/lnd/blob/master/docs/safety.md)
+and [recovery](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)
+guides before attempting a restore or whole-node move.
+
 ### Syncthing Channel Backups
 
 Syncthing automatically syncs your LND `channel.backup` file to
-your local device. No cloud services. No trust. If your Node dies,
-recover your channels with your seed phrase and the backup file.
+your local device. No cloud services. No trust. If your Node dies, the
+seed phrase and this file can recover settled channel funds through LND's
+emergency channel-closure procedure.
 
 The sync connection is direct between your Node and your device
 over an encrypted channel. Syncthing uses mutual TLS authentication
@@ -373,7 +396,9 @@ For manual binary verification before installation, see
 | /var/lib/vpn/state/ | Root-written facts and credentials deliberately staged read-only for the TUI, including the Syncthing web password |
 | /var/lib/vpn/exports/lnd-backup/ | Read-only Syncthing export of the completed `channel.backup` |
 | /var/lib/bitcoin/ | Mainnet Core data at the root; testnet4 under `testnet4/`; public signet under `signet/` |
-| /var/lib/lnd/data/chain/bitcoin/{mainnet,testnet4,signet}/ | Profile-specific LND wallet, macaroon, and channel state; `signet/` is default public signet only |
+| /var/lib/lnd/data/chain/bitcoin/{mainnet,testnet4,signet}/ | Profile-specific wallet and macaroon state in `chain.sqlite`, plus credentials and `channel.backup`; `signet/` is default public signet only |
+| /var/lib/lnd/data/graph/{mainnet,testnet4,signet}/ | Profile-specific channel/graph KV state in `channel.sqlite` and native invoice, payment, and graph state in `lnd.sqlite` |
+| /var/lib/lnd/data/watchtower/bitcoin/{mainnet,testnet4,signet}/ | Profile-specific `watchtower.sqlite`; LND creates it even when the watchtower server is disabled |
 | /var/lib/syncthing/ | Syncthing's private data |
 | /var/log/vpn.log | Application log (install, verification, status) |
 

--- a/docs/syncthing.md
+++ b/docs/syncthing.md
@@ -2,8 +2,9 @@
 
 Syncthing automatically syncs your LND `channel.backup` file from
 your Virtual Private Node (Node) to your local device. If your Node
-dies, you can recover your channels with your 24-word seed phrase
-and this backup file.
+dies, your 24-word seed phrase and this file can recover settled channel
+funds through LND's emergency recovery procedure. Recovery asks reachable
+peers to force-close the channels; it does not restore them for continued use.
 
 Syncthing encrypts all connections using mutual TLS authentication.
 Only devices you explicitly approve can connect. The `channel.backup`
@@ -89,7 +90,7 @@ to accept a shared folder called `lnd-backup`.
 
 Your `channel.backup` file will sync automatically whenever:
 
-- Your LND channel state changes (open, close, update)
+- LND creates or updates the backup when it starts or a channel opens or closes
 - Your local device is online and connected
 
 The sync happens in seconds. You don't need to keep your computer
@@ -113,6 +114,8 @@ the System section.
 - The sync port (22000) rejects all unapproved devices immediately
 - The `channel.backup` file is encrypted by LND and useless
   without your 24-word seed phrase
+- The backup contains static recovery information, not current balances or
+  commitment state; restoring it closes channels and depends on reachable peers
 - The Node publishes only a completed copy through its own
   `/var/lib/vpn/exports` boundary; no temporary file is placed in
   the synchronized folder

--- a/internal/helper/board.go
+++ b/internal/helper/board.go
@@ -33,7 +33,7 @@ import (
 //     the feature renders as unavailable with a logged reason,
 //     not a stale or default value. Staleness must surface as
 //     visible breakage.
-//   - nothing wallet-authoritative lives here. The seed, wallet.db,
+//   - nothing wallet-authoritative lives here. The seed, LND databases,
 //     and the auto-unlock password file are NOT board facts;
 //     the admin macaroon copy is a revocable credential the
 //     admin user needs to operate the node (it is the same

--- a/internal/helperd/verbs_test.go
+++ b/internal/helperd/verbs_test.go
@@ -281,6 +281,13 @@ func TestWalletAndVerificationReadsFailIndependently(t *testing.T) {
 	if !got.WalletExists {
 		t.Fatalf("live wallet state = %+v", got)
 	}
+	walletErr := errors.New("LND state RPC unavailable")
+	walletExists = func(string) (bool, error) {
+		return false, walletErr
+	}
+	if _, err := verbReadWalletState(&verbCtx{}, nil); !errors.Is(err, walletErr) {
+		t.Fatalf("unknown wallet fact was not preserved: %v", err)
+	}
 	if _, err := verbReadKeyVerificationState(
 		&verbCtx{}, nil); err == nil {
 		t.Fatal("unreadable verification marker reported a state")

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -200,10 +200,12 @@ protocol.wumbo-channels=true
 protocol.option-scid-alias=true
 
 [db]
-# Compact the bolt database on startup to reclaim disk
-# space from deleted records. Runs at most once per week.
-db.bolt.auto-compact=true
-db.bolt.auto-compact-min-age=168h
+# Fresh v0.7.0 nodes use LND's local SQLite backend and its native SQL
+# stores. These settings are permanent for the lifetime of the node.
+# Leave SQLite durability, locking, WAL, checkpoint, and vacuum behavior
+# at the pinned LND release's defaults.
+db.backend=sqlite
+db.use-native-sql=true
 
 [healthcheck]
 # Keep LND's chain-backend check at its upstream defaults.
@@ -222,10 +224,10 @@ healthcheck.torconnection.interval=1m
 healthcheck.torconnection.timeout=5s
 healthcheck.torconnection.backoff=1m
 healthcheck.torconnection.attempts=10
-# Graceful shutdown if disk space falls below 5%%. On a
-# 90GB SSD this triggers at ~4.5GB free — enough headroom
-# for bolt compaction while avoiding false shutdowns.
-healthcheck.diskspace.diskrequired=0.05
+# Graceful shutdown if filesystem free space falls to 10%%.
+# On a 90GB filesystem this preserves roughly 9GB and allows
+# about 81GB of operational usage before the safety stop.
+healthcheck.diskspace.diskrequired=0.10
 healthcheck.diskspace.attempts=2
 healthcheck.diskspace.interval=12h
 `, listenLine, paths.LNDGRPCEndpoint, restListenLine, externalLine,

--- a/internal/installer/lnd_test.go
+++ b/internal/installer/lnd_test.go
@@ -193,6 +193,8 @@ func TestBuildLNDConfigPinsTorAndHealthPolicy(t *testing.T) {
 	values := activeLNDConfigValues(content)
 	want := map[string]string{
 		"lnddir":                              "/var/lib/lnd",
+		"db.backend":                          "sqlite",
+		"db.use-native-sql":                   "true",
 		"tor.privatekeypath":                  "/var/lib/lnd/v3_onion_private_key",
 		"tor.encryptkey":                      "false",
 		"tor.skip-proxy-for-clearnet-targets": "false",
@@ -204,12 +206,22 @@ func TestBuildLNDConfigPinsTorAndHealthPolicy(t *testing.T) {
 		"healthcheck.torconnection.timeout":   "5s",
 		"healthcheck.torconnection.backoff":   "1m",
 		"healthcheck.torconnection.attempts":  "10",
+		"healthcheck.diskspace.diskrequired":  "0.10",
+		"healthcheck.diskspace.attempts":      "2",
+		"healthcheck.diskspace.interval":      "12h",
 	}
 	for key, wantValue := range want {
 		got := values[key]
 		if len(got) != 1 || got[0] != wantValue {
 			t.Errorf("config values for %q = %q, want exactly [%q]",
 				key, got, wantValue)
+		}
+	}
+	for _, forbidden := range []string{
+		"db.bolt.", "db.sqlite.", "skip-native-sql-migration",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("config contains unsupported database setting %q", forbidden)
 		}
 	}
 }

--- a/internal/installer/runtime_state.go
+++ b/internal/installer/runtime_state.go
@@ -1,34 +1,49 @@
 package installer
 
 import (
+	"errors"
 	"fmt"
-	"os"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
-	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
-// WalletExists observes LND's authoritative wallet database rather than a
-// duplicated TUI-written boolean. A non-regular or symlinked object is an
-// error, not evidence that a wallet exists.
+// WalletExists asks LND's always-running State service whether its wallet has
+// been initialized. SQLite creates chain.sqlite before a wallet exists, so no
+// database-file path can answer this question reliably.
 func WalletExists(network string) (bool, error) {
-	profile, err := config.NetworkConfigFromName(network)
+	_, err := config.NetworkConfigFromName(network)
 	if err != nil {
 		return false, err
 	}
-	return walletExistsAt(paths.LNDWalletDB(profile.LNDNetwork))
+
+	state, stateErr := readLNDWalletState()
+	return walletExistsFromState(state, stateErr)
 }
 
-func walletExistsAt(path string) (bool, error) {
-	info, err := os.Lstat(path)
-	if os.IsNotExist(err) {
+func walletExistsFromState(
+	state lnrpc.WalletState, stateErr error,
+) (bool, error) {
+	if stateErr != nil {
+		return false, fmt.Errorf("read LND wallet state: %w", stateErr)
+	}
+
+	switch state {
+	case lnrpc.WalletState_NON_EXISTING:
 		return false, nil
+
+	case lnrpc.WalletState_LOCKED,
+		lnrpc.WalletState_UNLOCKED,
+		lnrpc.WalletState_RPC_ACTIVE,
+		lnrpc.WalletState_SERVER_ACTIVE:
+
+		return true, nil
+
+	case lnrpc.WalletState_WAITING_TO_START:
+		return false, errors.New("LND is waiting to start; wallet state is unknown")
+
+	default:
+		return false, fmt.Errorf("unknown LND wallet state %d", state)
 	}
-	if err != nil {
-		return false, fmt.Errorf("inspect LND wallet state: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return false, fmt.Errorf("LND wallet state %s is not a regular file", path)
-	}
-	return true, nil
 }

--- a/internal/installer/runtime_state_test.go
+++ b/internal/installer/runtime_state_test.go
@@ -1,32 +1,56 @@
 package installer
 
 import (
-	"os"
-	"path/filepath"
+	"errors"
 	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
 
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
 
-func TestWalletExistsAtUsesRegularFileOnly(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "wallet.db")
-	if exists, err := walletExistsAt(path); err != nil || exists {
-		t.Fatalf("missing wallet: exists=%v err=%v", exists, err)
+func TestWalletExistsFromState(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  lnrpc.WalletState
+		exists bool
+		known  bool
+	}{
+		{"non-existing", lnrpc.WalletState_NON_EXISTING, false, true},
+		{"locked", lnrpc.WalletState_LOCKED, true, true},
+		{"unlocked", lnrpc.WalletState_UNLOCKED, true, true},
+		{"rpc active", lnrpc.WalletState_RPC_ACTIVE, true, true},
+		{"server active", lnrpc.WalletState_SERVER_ACTIVE, true, true},
+		{"waiting", lnrpc.WalletState_WAITING_TO_START, false, false},
+		{"unknown", lnrpc.WalletState(99), false, false},
 	}
-	if err := os.WriteFile(path, []byte("wallet"), 0o600); err != nil {
-		t.Fatal(err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exists, err := walletExistsFromState(test.state, nil)
+			if test.known && err != nil {
+				t.Fatalf("known state returned an error: %v", err)
+			}
+			if !test.known && err == nil {
+				t.Fatal("unknown state reported a wallet fact")
+			}
+			if exists != test.exists {
+				t.Fatalf("exists=%v, want %v", exists, test.exists)
+			}
+		})
 	}
-	if exists, err := walletExistsAt(path); err != nil || !exists {
-		t.Fatalf("regular wallet: exists=%v err=%v", exists, err)
+
+	probeErr := errors.New("state RPC unavailable")
+	if exists, err := walletExistsFromState(
+		lnrpc.WalletState_NON_EXISTING, probeErr,
+	); err == nil || exists || !errors.Is(err, probeErr) {
+		t.Fatalf("RPC error: exists=%v err=%v", exists, err)
 	}
-	if err := os.Remove(path); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink("elsewhere", path); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := walletExistsAt(path); err == nil {
-		t.Fatal("symlink accepted as wallet state")
+}
+
+func TestWalletExistsRejectsUnknownProfileBeforeObservation(t *testing.T) {
+	if _, err := WalletExists("signet"); err == nil {
+		t.Fatal("raw signet profile reached live wallet observation")
 	}
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -178,11 +178,6 @@ func LNDMacaroon(network string) string {
 	return fmt.Sprintf("/var/lib/lnd/data/chain/bitcoin/%s/admin.macaroon", network)
 }
 
-// LNDWalletDB returns LND's authoritative wallet database path for a network.
-func LNDWalletDB(network string) string {
-	return fmt.Sprintf("/var/lib/lnd/data/chain/bitcoin/%s/wallet.db", network)
-}
-
 // ChannelBackup returns the path to the channel backup for a given network.
 func ChannelBackup(network string) string {
 	return fmt.Sprintf("/var/lib/lnd/data/chain/bitcoin/%s/channel.backup", network)

--- a/internal/welcome/keybinds.go
+++ b/internal/welcome/keybinds.go
@@ -43,15 +43,16 @@ var (
 	kUpDownChannels   = bind("↑↓", "channels", "up", "down")
 
 	// Enter variants
-	kEnterOpen         = bind("enter", "open", "enter")
-	kEnterClose        = bind("enter", "close", "enter")
-	kEnterDetails      = bind("enter", "details", "enter")
-	kEnterNext         = bind("enter", "next", "enter")
-	kEnterConfirm      = bind("enter", "confirm", "enter")
-	kEnterCreate       = bind("enter", "create", "enter")
-	kEnterRemove       = bind("enter", "remove", "enter")
-	kEnterToggle       = bind("enter", "toggle", "enter")
-	kEnterCreateWallet = bind("enter", "create wallet", "enter")
+	kEnterOpen            = bind("enter", "open", "enter")
+	kEnterClose           = bind("enter", "close", "enter")
+	kEnterDetails         = bind("enter", "details", "enter")
+	kEnterNext            = bind("enter", "next", "enter")
+	kEnterConfirm         = bind("enter", "confirm", "enter")
+	kEnterCreate          = bind("enter", "create", "enter")
+	kEnterRemove          = bind("enter", "remove", "enter")
+	kEnterToggle          = bind("enter", "toggle", "enter")
+	kEnterCreateWallet    = bind("enter", "create wallet", "enter")
+	kEnterRetryWalletRead = bind("enter", "retry wallet state", "enter")
 )
 
 // ── Button navigation helper ────────────────────────────

--- a/internal/welcome/screen.go
+++ b/internal/welcome/screen.go
@@ -81,6 +81,14 @@ func (c *ScreenContext) walletKnown() bool {
 	return c.State != nil && c.State.WalletKnown
 }
 
+func walletUnavailableHelpBindings(c *ScreenContext) []key.Binding {
+	enter := kEnterCreateWallet
+	if !c.walletKnown() {
+		enter = kEnterRetryWalletRead
+	}
+	return []key.Binding{enter, kSidebar, kBack, kQuit}
+}
+
 // ── OnChainContext ───────────────────────────────────────
 // Shared on-chain state that the on-chain send screen
 // reads. Model owns the data and keeps it synced.

--- a/internal/welcome/screen_channels_home.go
+++ b/internal/welcome/screen_channels_home.go
@@ -517,12 +517,7 @@ func (s *ChannelsHomeScreen) View(
 
 func (s *ChannelsHomeScreen) HelpBindings() []key.Binding {
 	if !s.ctx.walletExists() {
-		return []key.Binding{
-			kEnterCreateWallet,
-			kSidebar,
-			kBack,
-			kQuit,
-		}
+		return walletUnavailableHelpBindings(s.ctx)
 	}
 	if s.zeroBalanceMsg {
 		return actionButtonBindings(

--- a/internal/welcome/screen_offchain_home.go
+++ b/internal/welcome/screen_offchain_home.go
@@ -492,12 +492,7 @@ func (s *WalletHomeScreen) View(
 
 func (s *WalletHomeScreen) HelpBindings() []key.Binding {
 	if !s.ctx.walletExists() {
-		return []key.Binding{
-			kEnterCreateWallet,
-			kSidebar,
-			kBack,
-			kQuit,
-		}
+		return walletUnavailableHelpBindings(s.ctx)
 	}
 	if s.focusZone == walletHomeZoneList {
 		return homeListBindings(

--- a/internal/welcome/screen_onchain_home.go
+++ b/internal/welcome/screen_onchain_home.go
@@ -981,12 +981,7 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 
 func (s *OnChainHomeScreen) HelpBindings() []key.Binding {
 	if !s.ctx.walletExists() {
-		return []key.Binding{
-			kEnterCreateWallet,
-			kSidebar,
-			kBack,
-			kQuit,
-		}
+		return walletUnavailableHelpBindings(s.ctx)
 	}
 	if s.labelEditing {
 		return s.labelPopupBindings()

--- a/internal/welcome/screen_wallet_state_test.go
+++ b/internal/welcome/screen_wallet_state_test.go
@@ -1,0 +1,49 @@
+package welcome
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+)
+
+func TestWalletHomeHelpPreservesUnknownState(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func(*ScreenContext) interface{ HelpBindings() []key.Binding }
+	}{
+		{
+			"on-chain",
+			func(ctx *ScreenContext) interface{ HelpBindings() []key.Binding } {
+				return NewOnChainHomeScreen(ctx, &OnChainContext{})
+			},
+		},
+		{
+			"off-chain",
+			func(ctx *ScreenContext) interface{ HelpBindings() []key.Binding } {
+				return NewWalletHomeScreen(ctx)
+			},
+		},
+		{
+			"channels",
+			func(ctx *ScreenContext) interface{ HelpBindings() []key.Binding } {
+				return NewChannelsHomeScreen(ctx)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unknown := test.new(&ScreenContext{State: &RuntimeState{}})
+			if got := unknown.HelpBindings()[0].Help().Desc; got != "retry wallet state" {
+				t.Fatalf("unknown wallet help = %q", got)
+			}
+
+			absent := test.new(&ScreenContext{
+				State: &RuntimeState{WalletKnown: true},
+			})
+			if got := absent.HelpBindings()[0].Help().Desc; got != "create wallet" {
+				t.Fatalf("absent wallet help = %q", got)
+			}
+		})
+	}
+}

--- a/scripts/validation/verify-lnd-sqlite.sh
+++ b/scripts/validation/verify-lnd-sqlite.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+set -u -o pipefail
+
+# Read-only Debian 13 amd64 validation for VPN's LND SQLite boundary.
+# Run as root on a disposable, freshly installed candidate. The default live
+# mode verifies configuration, exact database inventory, ownership, modes, and
+# LND's authoritative wallet state. The stopped mode additionally requires a
+# process-free LND service and runs SQLite integrity checks on temporary copies
+# without opening the source databases.
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "ERROR: run as root on the disposable Debian fixture" >&2
+    exit 2
+fi
+
+profile=${1:-}
+mode=${2:-live}
+case "${profile}" in
+    mainnet) lnd_network=mainnet ;;
+    testnet4) lnd_network=testnet4 ;;
+    public-signet) lnd_network=signet ;;
+    *)
+        echo "Usage: $0 <mainnet|testnet4|public-signet> [live|stopped]" >&2
+        exit 2
+        ;;
+esac
+case "${mode}" in
+    live|stopped) ;;
+    *)
+        echo "Usage: $0 <mainnet|testnet4|public-signet> [live|stopped]" >&2
+        exit 2
+        ;;
+esac
+
+passes=0
+failures=0
+
+pass() {
+    passes=$((passes + 1))
+    echo "PASS $1"
+}
+
+fail() {
+    failures=$((failures + 1))
+    echo "FAIL $1: $2"
+}
+
+assert_equal() {
+    local label=$1
+    local got=$2
+    local want=$3
+    if [[ ${got} == "${want}" ]]; then
+        pass "${label}"
+    else
+        fail "${label}" "got '${got}', want '${want}'"
+    fi
+}
+
+assert_exact_config_line() {
+    local label=$1
+    local line=$2
+    local count
+    count=$(grep -Fxc -- "${line}" /etc/lnd/lnd.conf 2>/dev/null || true)
+    assert_equal "${label}" "${count}" 1
+}
+
+assert_private_file() {
+    local label=$1
+    local file=$2
+    if [[ -L ${file} || ! -f ${file} ]]; then
+        fail "${label}" "${file} is missing, symlinked, or not regular"
+        return
+    fi
+    assert_equal "${label} owner" "$(stat -c '%U:%G' -- "${file}")" "lnd:lnd"
+    assert_equal "${label} mode" "$(stat -c '%a' -- "${file}")" 600
+    assert_equal "${label} link count" "$(stat -c '%h' -- "${file}")" 1
+}
+
+lnd_conf=/etc/lnd/lnd.conf
+assert_exact_config_line "CFG SQLite backend" "db.backend=sqlite"
+assert_exact_config_line "CFG native SQL" "db.use-native-sql=true"
+assert_exact_config_line "CFG disk threshold" \
+    "healthcheck.diskspace.diskrequired=0.10"
+assert_exact_config_line "CFG disk attempts" \
+    "healthcheck.diskspace.attempts=2"
+assert_exact_config_line "CFG disk interval" \
+    "healthcheck.diskspace.interval=12h"
+
+for forbidden in 'db.bolt.' 'db.sqlite.' 'skip-native-sql-migration'; do
+    if grep -Fq -- "${forbidden}" "${lnd_conf}" 2>/dev/null; then
+        fail "CFG excludes ${forbidden}" "unexpected setting exists"
+    else
+        pass "CFG excludes ${forbidden}"
+    fi
+done
+
+assert_equal "UNIT user" \
+    "$(systemctl show -p User --value lnd.service 2>/dev/null)" lnd
+assert_equal "UNIT group" \
+    "$(systemctl show -p Group --value lnd.service 2>/dev/null)" lnd
+assert_equal "UNIT private umask" \
+    "$(systemctl show -p UMask --value lnd.service 2>/dev/null)" 0077
+
+chain_dir=/var/lib/lnd/data/chain/bitcoin/${lnd_network}
+graph_dir=/var/lib/lnd/data/graph/${lnd_network}
+tower_dir=/var/lib/lnd/data/watchtower/bitcoin/${lnd_network}
+declare -a databases
+databases=(
+    "${chain_dir}/chain.sqlite"
+    "${graph_dir}/channel.sqlite"
+    "${graph_dir}/lnd.sqlite"
+    "${tower_dir}/watchtower.sqlite"
+)
+
+for database in "${databases[@]}"; do
+    assert_private_file "DB $(basename "${database}")" "${database}"
+    for suffix in -wal -shm; do
+        companion=${database}${suffix}
+        if [[ -e ${companion} || -L ${companion} ]]; then
+            assert_private_file "DB companion $(basename "${companion}")" \
+                "${companion}"
+        else
+            pass "DB companion $(basename "${companion}") absent"
+        fi
+    done
+done
+
+expected_inventory=$(printf '%s\n' "${databases[@]}" | sort)
+actual_inventory=$(find /var/lib/lnd/data -xdev \
+    \( -type f -o -type l \) -name '*.sqlite' \
+    -printf '%p\n' 2>/dev/null | sort)
+assert_equal "DB exact SQLite inventory" "${actual_inventory}" \
+    "${expected_inventory}"
+
+declare -a forbidden_databases
+forbidden_databases=(
+    "${chain_dir}/wallet.db"
+    "${chain_dir}/macaroons.db"
+    "${graph_dir}/channel.db"
+    "${graph_dir}/sphinxreplay.db"
+    "${graph_dir}/wtclient.db"
+    "${tower_dir}/watchtower.db"
+)
+for database in "${forbidden_databases[@]}"; do
+    if [[ ! -e ${database} && ! -L ${database} ]]; then
+        pass "DB no legacy $(basename "${database}")"
+    else
+        fail "DB no legacy $(basename "${database}")" \
+            "unexpected ${database} exists"
+    fi
+done
+
+if [[ ${mode} == live ]]; then
+    state_json=$(/usr/local/bin/lncli \
+        --rpcserver=127.0.0.1:10009 \
+        --tlscertpath=/var/lib/lnd/tls.cert \
+        state 2>/dev/null || true)
+    wallet_state=$(python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("state", ""))
+except Exception:
+    print("")
+' <<<"${state_json}")
+    case "${wallet_state}" in
+        NON_EXISTING)
+            pass "RPC wallet does not exist"
+            ;;
+        LOCKED|UNLOCKED|RPC_ACTIVE|SERVER_ACTIVE)
+            pass "RPC wallet exists (${wallet_state})"
+            ;;
+        *)
+            fail "RPC wallet fact is known" \
+                "State/GetState returned '${wallet_state:-unavailable}'"
+            ;;
+    esac
+else
+    active_state=$(systemctl show -p ActiveState --value lnd.service 2>/dev/null)
+    main_pid=$(systemctl show -p MainPID --value lnd.service 2>/dev/null)
+    control_pid=$(systemctl show -p ControlPID --value lnd.service 2>/dev/null)
+    case "${active_state}" in
+        inactive|failed) pass "STOP LND inactive" ;;
+        *) fail "STOP LND inactive" "ActiveState=${active_state}" ;;
+    esac
+    assert_equal "STOP no main process" "${main_pid}" 0
+    assert_equal "STOP no control process" "${control_pid}" 0
+
+    check_dir=$(mktemp -d /tmp/vpn-lnd-sqlite-check.XXXXXX 2>/dev/null || true)
+    if [[ -z ${check_dir} || ! -d ${check_dir} ]]; then
+        fail "DB prepare integrity checks" "could not create temporary directory"
+        check_dir=
+    else
+        pass "DB prepare integrity checks"
+    fi
+
+    declare -a check_databases
+    check_databases=()
+    if [[ -n ${check_dir} ]]; then
+        for database in "${databases[@]}"; do
+            check_database=${check_dir}/$(basename "${database}")
+            if cp --preserve=mode,timestamps -- "${database}" \
+                "${check_database}" 2>/dev/null; then
+                check_databases+=("${check_database}")
+            else
+                fail "DB copy $(basename "${database}")" \
+                    "could not create stopped-state validation copy"
+            fi
+            for suffix in -wal -shm; do
+                companion=${database}${suffix}
+                if [[ -f ${companion} && ! -L ${companion} ]]; then
+                    if ! cp --preserve=mode,timestamps -- "${companion}" \
+                        "${check_database}${suffix}" 2>/dev/null; then
+                        fail "DB copy $(basename "${companion}")" \
+                            "could not copy stopped-state companion"
+                    fi
+                fi
+            done
+        done
+    fi
+
+    integrity_status=1
+    integrity_output=
+    if [[ ${#check_databases[@]} -eq ${#databases[@]} ]]; then
+        integrity_output=$(python3 - "${check_databases[@]}" <<'PY'
+import sqlite3
+import sys
+import urllib.parse
+
+failed = False
+for path in sys.argv[1:]:
+    uri = "file:" + urllib.parse.quote(path) + "?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+        connection.execute("PRAGMA query_only=ON")
+        rows = [row[0] for row in connection.execute("PRAGMA integrity_check")]
+        foreign = list(connection.execute("PRAGMA foreign_key_check"))
+        connection.close()
+        if rows == ["ok"] and not foreign:
+            print("PASS " + path)
+        else:
+            print("FAIL " + path + " integrity=" + repr(rows) +
+                  " foreign_keys=" + repr(foreign))
+            failed = True
+    except Exception as exc:
+        print("FAIL " + path + " error=" + str(exc))
+        failed = True
+sys.exit(1 if failed else 0)
+PY
+        )
+        integrity_status=$?
+    fi
+    while IFS= read -r line; do
+        [[ -n ${line} ]] && echo "SQLITE ${line}"
+    done <<<"${integrity_output}"
+    if [[ ${integrity_status} -eq 0 ]]; then
+        pass "DB all integrity checks"
+    else
+        fail "DB all integrity checks" "one or more checks failed"
+    fi
+    if [[ -n ${check_dir} ]]; then
+        rm -rf -- "${check_dir}"
+    fi
+fi
+
+echo "SUMMARY pass=${passes} fail=${failures}"
+if (( failures > 0 )); then
+    exit 1
+fi

--- a/scripts/validation/verify-network-profile.sh
+++ b/scripts/validation/verify-network-profile.sh
@@ -185,6 +185,17 @@ assert_file_contains "LND block ZMQ" "${lnd_conf}" \
     "bitcoind.zmqpubrawblock=tcp://127.0.0.1:${zmq_block}"
 assert_file_contains "LND transaction ZMQ" "${lnd_conf}" \
     "bitcoind.zmqpubrawtx=tcp://127.0.0.1:${zmq_tx}"
+assert_file_contains "LND SQLite backend" "${lnd_conf}" \
+    "db.backend=sqlite"
+assert_file_contains "LND native SQL" "${lnd_conf}" \
+    "db.use-native-sql=true"
+assert_file_contains "LND disk safety threshold" "${lnd_conf}" \
+    "healthcheck.diskspace.diskrequired=0.10"
+assert_file_excludes "LND no bbolt tuning" "${lnd_conf}" "db.bolt."
+assert_file_excludes "LND no custom SQLite pragmas" "${lnd_conf}" \
+    "db.sqlite.pragmaoptions="
+assert_file_excludes "LND no skipped native migration" "${lnd_conf}" \
+    "skip-native-sql-migration"
 assert_file_excludes "LND no Bitcoin cookie" "${lnd_conf}" "bitcoind.rpccookie="
 assert_file_excludes "LND no custom signet challenge" "${lnd_conf}" \
     "bitcoin.signetchallenge="
@@ -270,22 +281,44 @@ assert_equal "RUN lnd active" \
 assert_equal "RUN Tor active" \
     "$(systemctl is-active tor.service 2>/dev/null || true)" active
 
-if [[ -f /var/lib/lnd/data/chain/bitcoin/${lnd_network}/wallet.db ]]; then
-    pass "STATE wallet uses ${lnd_network}"
-else
-    pass "STATE wallet not created yet"
-fi
+state_json=$(/usr/local/bin/lncli \
+    --rpcserver=127.0.0.1:10009 \
+    --tlscertpath=/var/lib/lnd/tls.cert \
+    state 2>/dev/null || true)
+wallet_state=$(python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("state", ""))
+except Exception:
+    print("")
+' <<<"${state_json}")
+case "${wallet_state}" in
+    NON_EXISTING)
+        pass "STATE LND reports no wallet"
+        ;;
+    LOCKED|UNLOCKED|RPC_ACTIVE|SERVER_ACTIVE)
+        pass "STATE LND reports existing wallet (${wallet_state})"
+        ;;
+    *)
+        fail "STATE LND wallet fact is known" \
+            "State/GetState returned '${wallet_state:-unavailable}'"
+        ;;
+esac
 for foreign in mainnet testnet4 signet; do
     if [[ ${foreign} == "${lnd_network}" ]]; then
         continue
     fi
-    foreign_wallet=/var/lib/lnd/data/chain/bitcoin/${foreign}/wallet.db
-    if [[ ! -e ${foreign_wallet} && ! -L ${foreign_wallet} ]]; then
-        pass "STATE no ${foreign} wallet reuse"
-    else
-        fail "STATE no ${foreign} wallet reuse" \
-            "unexpected ${foreign_wallet} exists"
-    fi
+    for foreign_state in \
+        /var/lib/lnd/data/chain/bitcoin/${foreign} \
+        /var/lib/lnd/data/graph/${foreign} \
+        /var/lib/lnd/data/watchtower/bitcoin/${foreign}; do
+        if [[ ! -e ${foreign_state} && ! -L ${foreign_state} ]]; then
+            pass "STATE no ${foreign} reuse at ${foreign_state}"
+        else
+            fail "STATE no ${foreign} reuse at ${foreign_state}" \
+                "unexpected path exists"
+        fi
+    done
 done
 
 assert_file_contains "CLI bitcoin wrapper RPC port" /home/vpn/.bashrc \


### PR DESCRIPTION
## Summary

Configure fresh LND installations to use SQLite with native SQL stores instead of bbolt.

This change:

- Enables LND's SQLite backend and native SQL stores.
- Uses LND's wallet-state RPC instead of checking for a `wallet.db` file.
- Preserves unknown wallet state as an error and offers a retry in the TUI.
- Adds validation for SQLite configuration, database inventory, permissions, and legacy database absence.
- Raises the LND disk safety threshold from 5% to 10% free space.
- Updates the network-profile validator and directly related recovery documentation.

## Scope

- Applies only to fresh installations.
- Does not migrate existing bbolt nodes.
- Leaves SQLite durability, WAL, locking, checkpoint, and vacuum behavior at LND's defaults.
- Continues to use the seed phrase and static channel backup as the supported routine recovery artifacts.

## Validation

The complete portable development gate passed with Go 1.26.1:

- `gofmt`
- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`

The change was also validated on two fresh Debian 13 amd64 public-signet nodes, including:

- SQLite-backed wallet creation and normal operation.
- Direct peer connectivity over Tor.
- Private channel opening and bidirectional payments.
- Automatic and manual wallet-unlock restart paths.
- Graceful shutdown and stopped-database integrity checks.
- Static channel backup verification.
- Cooperative channel close and final on-chain settlement.
- Post-close SQLite and service-state validation on both nodes.