### PR TITLE
build: update go to 1.26.8

### DIFF
--- a/docs/reproducing.md
+++ b/docs/reproducing.md
@@ -47,7 +47,7 @@ Go is available for all supported platforms from
 [go.dev/dl](https://go.dev/dl/).
 
 ```bash
-GO_VERSION="1.26.1"  # check go.mod for exact version
+GO_VERSION="1.26.8"  # check go.mod for exact version
 wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/virtualprivatenode/vpn
 
-go 1.26.1
+go 1.26.8
 
 require (
 	charm.land/bubbles/v2 v2.0.0


### PR DESCRIPTION
Update the required Go toolchain from 1.26.1 to 1.26.8 and align the installation example in the reproducible-build documentation.