### PR TITLE
refactor: extract lightning payment workflow

### DIFF
--- a/internal/app/lightning_payment.go
+++ b/internal/app/lightning_payment.go
@@ -1,0 +1,94 @@
+// Package app owns node workflows independently of terminal presentation.
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+// LightningPaymentClient is the daemon access needed to prepare and pay an
+// invoice. LND retains responsibility for routing and recovering stream outcomes.
+type LightningPaymentClient interface {
+	DecodePayReq(string) (*lndrpc.DecodedPayReq, error)
+	SendPayment(string) (*lndrpc.SendPaymentResult, error)
+}
+
+// PaymentRequest contains an invoice that passed the installed network prefilter.
+// LND must still decode and validate the invoice; a prefix is not proof of validity.
+type PaymentRequest struct {
+	invoice string
+}
+
+func (r PaymentRequest) Invoice() string { return r.invoice }
+
+// ParseLightningPayment normalizes pasted input and applies the node's network
+// policy before any daemon call. It does not authorize sending a payment.
+func ParseLightningPayment(network, raw string) (PaymentRequest, error) {
+	if strings.TrimSpace(raw) == "" {
+		return PaymentRequest{}, errors.New("Paste a payment request")
+	}
+	invoice := strings.NewReplacer("[", "", "]", "", "\"", "", "'", "").Replace(raw)
+	invoice = strings.TrimSpace(invoice)
+	invoice = strings.TrimPrefix(invoice, "lightning:")
+	invoice = strings.TrimPrefix(invoice, "LIGHTNING:")
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
+		return PaymentRequest{}, errors.New("Unsupported node network profile")
+	}
+	if !profile.AcceptsInvoicePrefix(invoice) {
+		return PaymentRequest{}, fmt.Errorf("Invoice is not for %s", profile.DisplayName)
+	}
+	return PaymentRequest{invoice: invoice}, nil
+}
+
+// PreparedPayment keeps the decoded details and their exact invoice together.
+// Its fields are private so editing a form or a details copy cannot change what
+// will be submitted after confirmation.
+type PreparedPayment struct {
+	request PaymentRequest
+	details lndrpc.DecodedPayReq
+}
+
+func (p PreparedPayment) Details() lndrpc.DecodedPayReq { return p.details }
+
+func PrepareLightningPayment(client LightningPaymentClient, request PaymentRequest) (PreparedPayment, error) {
+	if request.invoice == "" {
+		return PreparedPayment{}, errors.New("Paste a payment request")
+	}
+	if client == nil {
+		return PreparedPayment{}, errors.New("LND not connected")
+	}
+	decoded, err := client.DecodePayReq(request.invoice)
+	if err != nil {
+		return PreparedPayment{}, err
+	}
+	if decoded == nil {
+		return PreparedPayment{}, errors.New("LND returned no invoice details")
+	}
+	if decoded.IsExpired {
+		return PreparedPayment{}, errors.New("This invoice has expired")
+	}
+	return PreparedPayment{request: request, details: *decoded}, nil
+}
+
+// SendLightningPayment submits a prepared invoice with at most one daemon call.
+// It does not retry or reinterpret the outcome. Callers own confirmation and
+// duplicate-action prevention; PreparedPayment is not a single-use token.
+// LND revalidates the invoice at execution and retains its existing fee policy.
+func SendLightningPayment(client LightningPaymentClient, payment PreparedPayment) (*lndrpc.SendPaymentResult, error) {
+	if payment.request.invoice == "" {
+		return nil, errors.New("Prepare the invoice before sending")
+	}
+	if client == nil {
+		return nil, errors.New("LND not connected")
+	}
+	result, err := client.SendPayment(payment.request.invoice)
+	if err == nil && result == nil {
+		return nil, errors.New("LND returned no payment outcome; check Payment History before retrying")
+	}
+	return result, err
+}

--- a/internal/app/lightning_payment_test.go
+++ b/internal/app/lightning_payment_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type paymentClient struct {
+	decoded         *lndrpc.DecodedPayReq
+	decodeErr       error
+	decodedRequests []string
+	sentRequests    []string
+}
+
+func (c *paymentClient) DecodePayReq(request string) (*lndrpc.DecodedPayReq, error) {
+	c.decodedRequests = append(c.decodedRequests, request)
+	return c.decoded, c.decodeErr
+}
+
+func (c *paymentClient) SendPayment(request string) (*lndrpc.SendPaymentResult, error) {
+	c.sentRequests = append(c.sentRequests, request)
+	return nil, nil
+}
+
+// Installed-network selection is exercised through the TUI's existing
+// profile test; the complete prefix matrix belongs to config's network tests.
+func TestPaymentRequestNormalizationAndInvalidInput(t *testing.T) {
+	for _, raw := range []string{"lnbc1example", "  [\"lightning:lnbc1example\"]  ", "'LIGHTNING:lnbc1example'"} {
+		request, err := ParseLightningPayment(config.NetworkMainnet, raw)
+		if err != nil || request.Invoice() != "lnbc1example" {
+			t.Fatalf("input %q: request=%q err=%v", raw, request.Invoice(), err)
+		}
+	}
+	for _, tc := range []struct{ network, raw string }{
+		{config.NetworkMainnet, " \n "},
+		{"unsupported", "lnbc1example"},
+		{config.NetworkMainnet, "not-an-invoice"},
+	} {
+		if _, err := ParseLightningPayment(tc.network, tc.raw); err == nil {
+			t.Fatalf("accepted invalid request: %+v", tc)
+		}
+	}
+}
+
+func TestPaymentPreparationRefusesInvalidInvoicesWithoutSending(t *testing.T) {
+	request, err := ParseLightningPayment(config.NetworkMainnet, "lnbc1example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name    string
+		decoded *lndrpc.DecodedPayReq
+		err     error
+	}{
+		{"decode rejection", nil, errors.New("invalid invoice signature")},
+		{"expired", &lndrpc.DecodedPayReq{IsExpired: true}, nil},
+		{"missing details", nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &paymentClient{decoded: tc.decoded, decodeErr: tc.err}
+			payment, err := PrepareLightningPayment(client, request)
+			if err == nil {
+				t.Fatal("preparation unexpectedly succeeded")
+			}
+			if _, err := SendLightningPayment(client, payment); err == nil {
+				t.Fatal("failed preparation could be sent")
+			}
+			if len(client.sentRequests) != 0 {
+				t.Fatal("sent an unprepared invoice")
+			}
+		})
+	}
+	if _, err := PrepareLightningPayment(nil, request); err == nil {
+		t.Fatal("accepted missing client")
+	}
+	client := &paymentClient{}
+	if _, err := PrepareLightningPayment(client, PaymentRequest{}); err == nil || len(client.decodedRequests) != 0 {
+		t.Fatal("empty request reached decoder")
+	}
+}
+
+func TestPreparedPaymentOwnsDecodedDetails(t *testing.T) {
+	request, err := ParseLightningPayment(config.NetworkMainnet, "lnbc1example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &paymentClient{decoded: &lndrpc.DecodedPayReq{AmountSats: 42}}
+	payment, err := PrepareLightningPayment(client, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.decoded.AmountSats = 99
+	details := payment.Details()
+	details.AmountSats = 100
+	if payment.Details().AmountSats != 42 {
+		t.Fatal("prepared details changed through an external reference")
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -5,7 +5,7 @@
 // Bubble Tea runtime, performs side effects and returns a
 // message. These are intentionally separate from Model:
 // they have no receiver, depend only on their typed
-// arguments, and are thin wrappers over internal/lndrpc,
+// arguments, and are thin wrappers over internal/app, daemon clients,
 // internal/installer, and system shell-outs.
 //
 // Organization (by comment banner below):
@@ -18,10 +18,8 @@
 //   - Shell-out overlays
 //   - System actions
 //
-// Behaviour note: fetchPaymentHistoryCmd uses separate
-// err variables per RPC and rolls them up into a single
-// message-level err. See design-decisions.md
-// ("Multi-RPC fetch cmds must aggregate their errors").
+// Behaviour note: fetchPaymentHistoryCmd reports either RPC's failure so
+// the wallet home screen retains its last complete history after a partial fetch.
 
 package tui
 
@@ -36,6 +34,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
@@ -245,35 +244,17 @@ func waitForInvoiceCmd(
 	}
 }
 
-func decodePayReqCmd(
-	client *lndrpc.Client, payReq string,
-) tea.Cmd {
+func preparePaymentCmd(client app.LightningPaymentClient, attempt *paymentAttempt) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return payReqDecodedMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		decoded, err := client.DecodePayReq(payReq)
-		if err != nil {
-			return payReqDecodedMsg{err: err}
-		}
-		return payReqDecodedMsg{decoded: decoded}
+		payment, err := app.PrepareLightningPayment(client, attempt.request)
+		return payReqDecodedMsg{attempt: attempt, payment: payment, err: err}
 	}
 }
 
-func sendPaymentCmd(
-	client *lndrpc.Client, payReq string,
-) tea.Cmd {
+func sendPaymentCmd(client app.LightningPaymentClient, attempt *paymentAttempt, payment app.PreparedPayment) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return sendPaymentResultMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		result, err := client.SendPayment(payReq)
-		if err != nil {
-			return sendPaymentResultMsg{err: err}
-		}
-		return sendPaymentResultMsg{result: result}
+		result, err := app.SendLightningPayment(client, payment)
+		return sendPaymentResultMsg{attempt: attempt, result: result, err: err}
 	}
 }
 
@@ -282,8 +263,6 @@ func sendPaymentCmd(
 // is tracked independently and rolled up into rpcErr so
 // the handler's `if msg.err == nil` partial-data guard
 // doesn't overwrite last-good entries on a flaky fetch.
-// See design-decisions.md ("Multi-RPC fetch cmds must
-// aggregate their errors").
 func fetchPaymentHistoryCmd(
 	client *lndrpc.Client,
 ) tea.Cmd {

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -529,19 +529,6 @@ func confIndicator(confs int32) string {
 	}
 }
 
-// ── Parse helpers ──────────────────────────────────────
-
-func cleanPayReq(s string) string {
-	s = strings.ReplaceAll(s, "[", "")
-	s = strings.ReplaceAll(s, "]", "")
-	s = strings.ReplaceAll(s, "\"", "")
-	s = strings.ReplaceAll(s, "'", "")
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "lightning:")
-	s = strings.TrimPrefix(s, "LIGHTNING:")
-	return s
-}
-
 // ── Wallet creation prompt ──────────────────────────────
 // Shared across all three section home screens when no
 // wallet exists. Renders a centered call-to-action with

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/helper"
 	"github.com/virtualprivatenode/vpn/internal/installer"
@@ -163,12 +164,14 @@ type invoiceSettledMsg struct {
 	err     error
 }
 type payReqDecodedMsg struct {
-	decoded *lndrpc.DecodedPayReq
+	attempt *paymentAttempt
+	payment app.PreparedPayment
 	err     error
 }
 type sendPaymentResultMsg struct {
-	result *lndrpc.SendPaymentResult
-	err    error
+	attempt *paymentAttempt
+	result  *lndrpc.SendPaymentResult
+	err     error
 }
 type paymentHistoryMsg struct {
 	entries []lndrpc.PaymentEntry

--- a/internal/tui/screen_offchain_send.go
+++ b/internal/tui/screen_offchain_send.go
@@ -1,12 +1,11 @@
 package tui
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -31,9 +30,18 @@ const (
 
 // ── SendScreen ───────────────────────────────────────────
 
+// Each submission has its own identity, including across closed/reopened tabs.
+// The request makes this a non-zero-sized object with a distinct address.
+type paymentAttempt struct {
+	request app.PaymentRequest
+}
+
 type SendScreen struct {
-	ctx  *ScreenContext
-	step sendStep
+	ctx      *ScreenContext
+	step     sendStep
+	payments app.LightningPaymentClient
+	attempt  *paymentAttempt
+	prepared app.PreparedPayment
 
 	// Input state
 	sendInput   textinput.Model
@@ -41,25 +49,22 @@ type SendScreen struct {
 	focusZone   int // 0=input field, 1=buttons
 	inputError  string
 
-	// Decoded (set after payReqDecodedMsg)
-	decodedAmt  int64
-	decodedDesc string
-	decodedDest string
-
 	// Confirm state
 	confirmBtnIdx int // 0=Go Back, 1=Confirm
 
 	// Result state
-	error     string
-	preimage  string
-	routeHops []lndrpc.RouteHop
-	feeSats   int64
+	result lndrpc.SendPaymentResult
 }
 
 func NewSendScreen(
 	ctx *ScreenContext,
 ) *SendScreen {
+	var payments app.LightningPaymentClient
+	if ctx.LndClient != nil {
+		payments = ctx.LndClient
+	}
 	return &SendScreen{
+		payments:    payments,
 		ctx:         ctx,
 		step:        sendStepInput,
 		sendInput:   newSendPayReqInput(ctx.Cfg.Network),
@@ -256,32 +261,18 @@ func (s *SendScreen) handleInputKey(
 	return s, nil
 }
 
-// submitSendPayment validates the pay req and fires
-// decodePayReqCmd.
-func (s *SendScreen) submitSendPayment() (
-	Screen, tea.Cmd,
-) {
-	payReq := strings.TrimSpace(
-		s.sendInput.Value())
-	if payReq == "" {
-		s.inputError = "Paste a payment request"
-		return s, nil
-	}
-	payReq = cleanPayReq(payReq)
-	s.sendInput.SetValue(payReq)
-	profile, err := s.ctx.Cfg.NetworkConfig()
+// submitSendPayment validates input before scheduling daemon work.
+func (s *SendScreen) submitSendPayment() (Screen, tea.Cmd) {
+	s.attempt = nil
+	request, err := app.ParseLightningPayment(s.ctx.Cfg.Network, s.sendInput.Value())
 	if err != nil {
-		s.inputError = "Unsupported node network profile"
+		s.inputError = err.Error()
 		return s, nil
 	}
-	if !profile.AcceptsInvoicePrefix(payReq) {
-		s.inputError =
-			"Invoice is not for " + profile.DisplayName
-		return s, nil
-	}
+	s.sendInput.SetValue(request.Invoice())
 	s.inputError = ""
-	return s, decodePayReqCmd(
-		s.ctx.LndClient, payReq)
+	s.attempt = &paymentAttempt{request: request}
+	return s, preparePaymentCmd(s.payments, s.attempt)
 }
 
 // ── Confirm step ────────────────────────────────────────
@@ -322,9 +313,7 @@ func (s *SendScreen) handleConfirmKey(
 		case 1: // Confirm
 			s.step = sendStepInFlight
 			return s, sendPaymentCmd(
-				s.ctx.LndClient,
-				strings.TrimSpace(
-					s.sendInput.Value()))
+				s.payments, s.attempt, s.prepared)
 		}
 	}
 	return s, nil
@@ -333,11 +322,10 @@ func (s *SendScreen) handleConfirmKey(
 // backToInput returns to the input step, clearing
 // decoded state and error.
 func (s *SendScreen) backToInput() {
+	s.attempt = nil
+	s.prepared = app.PreparedPayment{}
 	s.step = sendStepInput
 	s.inputError = ""
-	s.decodedAmt = 0
-	s.decodedDesc = ""
-	s.decodedDest = ""
 	s.confirmBtnIdx = 0
 	s.focusZone = sendZoneInput
 	s.sendInput.Focus()
@@ -399,17 +387,17 @@ func (s *SendScreen) handlePaste(
 func (s *SendScreen) handlePayReqDecoded(
 	msg payReqDecodedMsg,
 ) (Screen, tea.Cmd) {
+	// The attempt must still own this screen, and its invoice must still be
+	// the one in the form. This also covers edits made while decoding.
+	if s.step != sendStepInput || s.attempt == nil || msg.attempt != s.attempt ||
+		s.sendInput.Value() != s.attempt.request.Invoice() {
+		return s, nil
+	}
 	if msg.err != nil {
 		s.inputError = msg.err.Error()
 		return s, nil
 	}
-	if msg.decoded.IsExpired {
-		s.inputError = "This invoice has expired"
-		return s, nil
-	}
-	s.decodedAmt = msg.decoded.AmountSats
-	s.decodedDesc = msg.decoded.Description
-	s.decodedDest = msg.decoded.Destination
+	s.prepared = msg.payment
 	s.confirmBtnIdx = 1 // default to Confirm
 	s.step = sendStepConfirm
 	return s, nil
@@ -418,15 +406,17 @@ func (s *SendScreen) handlePayReqDecoded(
 func (s *SendScreen) handleSendResult(
 	msg sendPaymentResultMsg,
 ) (Screen, tea.Cmd) {
+	if s.step != sendStepInFlight || s.attempt == nil || msg.attempt != s.attempt {
+		return s, nil
+	}
+	s.result = lndrpc.SendPaymentResult{Status: "UNKNOWN"}
 	if msg.err != nil {
-		s.error = msg.err.Error()
-	} else if msg.result.Status == "SUCCEEDED" {
-		s.preimage = msg.result.Preimage
-		s.feeSats = msg.result.FeeSats
-		s.routeHops = msg.result.Hops
-		s.error = ""
-	} else {
-		s.error = msg.result.Error
+		s.result.Error = msg.err.Error()
+	} else if msg.result != nil {
+		s.result = *msg.result
+	}
+	if s.result.Status != "SUCCEEDED" && s.result.Error == "" {
+		s.result.Error = "Check Payment History before retrying."
 	}
 	s.step = sendStepResult
 	return s, nil
@@ -480,17 +470,18 @@ func (s *SendScreen) viewConfirm(
 ) string {
 	p := newPane(w)
 	p.title(theme.Warning, "Confirm Payment")
+	details := s.prepared.Details()
 
 	p.field("Amount:      ",
-		formatSats(s.decodedAmt)+" sats")
-	if s.decodedDesc != "" {
-		p.field("Description: ", s.decodedDesc)
+		formatSats(details.AmountSats)+" sats")
+	if details.Description != "" {
+		p.field("Description: ", details.Description)
 	}
 	p.labelLine("Destination:")
-	p.mono(s.decodedDest)
+	p.mono(details.Destination)
 	p.blank()
 	p.warn("Send " +
-		formatSats(s.decodedAmt) + " sats?")
+		formatSats(details.AmountSats) + " sats?")
 
 	// ── Buttons pinned to bottom ──
 	btnFocused := s.ctx.ContentFocused
@@ -505,7 +496,7 @@ func (s *SendScreen) viewInFlight(
 	p := newPane(w)
 	p.title(theme.Header, "Sending Payment...")
 	p.line(" " + theme.Value.Render(
-		"Routing "+formatSats(s.decodedAmt)+
+		"Routing "+formatSats(s.prepared.Details().AmountSats)+
 			" sats"))
 	p.blank()
 	p.dim("May take up to 60 seconds over Tor.")
@@ -518,25 +509,32 @@ func (s *SendScreen) viewResult(
 ) string {
 	p := newPane(w)
 
-	if s.error != "" {
-		p.title(theme.Warning, "Payment Failed")
-		p.warnWrap(s.error)
+	if s.result.Status != "SUCCEEDED" {
+		title := "Payment Status Unknown"
+		switch s.result.Status {
+		case "FAILED":
+			title = "Payment Failed"
+		case "IN_FLIGHT":
+			title = "Payment Still In Flight"
+		}
+		p.title(theme.Warning, title)
+		p.warnWrap(s.result.Error)
 	} else {
 		p.title(theme.Success, "Payment Sent")
 		p.field("Amount: ",
-			formatSats(s.decodedAmt)+" sats")
+			formatSats(s.prepared.Details().AmountSats)+" sats")
 		p.field("Fee:    ",
-			formatSats(s.feeSats)+" sats")
-		if s.preimage != "" {
+			formatSats(s.result.FeeSats)+" sats")
+		if s.result.Preimage != "" {
 			p.blank()
 			p.labelLine("Preimage:")
-			p.mono(s.preimage)
+			p.mono(s.result.Preimage)
 		}
-		if len(s.routeHops) > 0 {
+		if len(s.result.Hops) > 0 {
 			p.blank()
 			p.labelLine("Route:")
 			p.line(renderRouteDiagram(
-				s.routeHops, w))
+				s.result.Hops, w))
 		}
 	}
 

--- a/internal/tui/screen_offchain_send_test.go
+++ b/internal/tui/screen_offchain_send_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type screenPaymentClient struct {
+	sent   []string
+	result *lndrpc.SendPaymentResult
+	err    error
+}
+
+func (c *screenPaymentClient) DecodePayReq(request string) (*lndrpc.DecodedPayReq, error) {
+	return &lndrpc.DecodedPayReq{AmountSats: 42, Description: request}, nil
+}
+
+func (c *screenPaymentClient) SendPayment(request string) (*lndrpc.SendPaymentResult, error) {
+	c.sent = append(c.sent, request)
+	return c.result, c.err
+}
+
+func paymentScreen(client *screenPaymentClient) *SendScreen {
+	s := NewSendScreen(&ScreenContext{Cfg: config.Default()})
+	s.payments = client
+	return s
+}
+
+func submitInvoice(t *testing.T, s *SendScreen, invoice string) tea.Cmd {
+	t.Helper()
+	s.sendInput.SetValue(invoice)
+	_, decode := s.submitSendPayment()
+	if decode == nil {
+		t.Fatalf("invoice rejected before decode: %s", s.inputError)
+	}
+	return decode
+}
+
+func TestPaymentConfirmationSubmitsPreparedInvoiceOnce(t *testing.T) {
+	client := &screenPaymentClient{result: &lndrpc.SendPaymentResult{Status: "SUCCEEDED"}}
+	s := paymentScreen(client)
+	decode := submitInvoice(t, s, "lightning:lnbc1approved")
+	s.HandleMsg(decode())
+	if s.step != sendStepConfirm || len(client.sent) != 0 {
+		t.Fatal("invoice was not prepared for confirmation")
+	}
+	// Even an unrelated later form mutation must not replace the reviewed invoice.
+	s.sendInput.SetValue("lnbc1different")
+	_, send := s.HandleKey("enter", tea.KeyPressMsg{})
+	if send == nil {
+		t.Fatal("confirmation did not schedule payment")
+	}
+	if _, duplicate := s.HandleKey("enter", tea.KeyPressMsg{}); duplicate != nil {
+		t.Fatal("repeated confirmation scheduled another payment")
+	}
+	s.HandleMsg(send())
+	if len(client.sent) != 1 || client.sent[0] != "lnbc1approved" || s.result.Status != "SUCCEEDED" {
+		t.Fatalf("sent=%v status=%s", client.sent, s.result.Status)
+	}
+}
+
+func TestPaymentScreenIgnoresSupersededDecode(t *testing.T) {
+	client := &screenPaymentClient{}
+	s := paymentScreen(client)
+	old := submitInvoice(t, s, "lnbc1old")
+	current := submitInvoice(t, s, "lnbc1new")
+	s.HandleMsg(old())
+	if s.step != sendStepInput || s.inputError != "" {
+		t.Fatal("old response changed the current input step")
+	}
+	s.HandleMsg(current())
+	if s.step != sendStepConfirm || s.prepared.Details().Description != "lnbc1new" {
+		t.Fatal("current response did not reach confirmation")
+	}
+	s.HandleMsg(old())
+	if s.prepared.Details().Description != "lnbc1new" {
+		t.Fatal("old response replaced confirmed details")
+	}
+}
+
+func TestPaymentInputEditRejectsPendingDecode(t *testing.T) {
+	s := paymentScreen(&screenPaymentClient{})
+	decode := submitInvoice(t, s, "lnbc1old")
+	s.sendInput.SetValue("lnbc1edited")
+	s.HandleMsg(decode())
+	if s.step != sendStepInput {
+		t.Fatal("edited input accepted its previous decode")
+	}
+}
+
+func TestPaymentResponseCannotCrossScreenInstances(t *testing.T) {
+	client := &screenPaymentClient{result: &lndrpc.SendPaymentResult{Status: "SUCCEEDED"}}
+	old := paymentScreen(client)
+	decodeOld := submitInvoice(t, old, "lnbc1same")
+	old.HandleMsg(decodeOld())
+	_, sendOld := old.handleConfirmKey("enter")
+	current := paymentScreen(client)
+	decodeCurrent := submitInvoice(t, current, "lnbc1same")
+	current.HandleMsg(decodeOld())
+	if current.step != sendStepInput {
+		t.Fatal("a closed screen's decode reached its replacement")
+	}
+	current.HandleMsg(decodeCurrent())
+	current.HandleKey("enter", tea.KeyPressMsg{})
+	current.HandleMsg(sendOld())
+	if current.step != sendStepInFlight {
+		t.Fatal("a closed screen's result reached its replacement")
+	}
+}
+
+func TestPaymentOutcomeHeadings(t *testing.T) {
+	theme.Init(true)
+	for _, tc := range []struct {
+		name, status, heading string
+		err                   error
+	}{
+		{"success", "SUCCEEDED", "Payment Sent", nil},
+		{"failure", "FAILED", "Payment Failed", nil},
+		{"unresolved", "IN_FLIGHT", "Payment Still In Flight", nil},
+		{"unknown status", "FUTURE_STATUS", "Payment Status Unknown", nil},
+		{"transport error", "", "Payment Status Unknown", errors.New("connection lost")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &screenPaymentClient{result: &lndrpc.SendPaymentResult{Status: tc.status}, err: tc.err}
+			s := paymentScreen(client)
+			decode := submitInvoice(t, s, "lnbc1example")
+			s.HandleMsg(decode())
+			_, send := s.handleConfirmKey("enter")
+			s.HandleMsg(send())
+			view := s.View(82, 34)
+			if !strings.Contains(view, tc.heading) {
+				t.Fatalf("missing %q in %s", tc.heading, view)
+			}
+			if tc.status != "FAILED" && strings.Contains(view, "Payment Failed") {
+				t.Fatal("invented failure")
+			}
+			if tc.status != "SUCCEEDED" && strings.Contains(view, "Payment Sent") {
+				t.Fatal("invented success")
+			}
+			if len(client.sent) != 1 {
+				t.Fatal("retried a payment")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move Lightning invoice preparation and submission into internal/app so payment rules can be exercised independently of the TUI.

Keep confirmation tied to the prepared invoice, ignore responses from obsolete attempts, and distinguish unresolved payments from failures. Remove duplicated screen state and add focused behavioral tests.

Local checks passed. Disposable Signet validation remains pending.