### PR TITLE
refactor: extract lightning invoice workflow

### DIFF
--- a/internal/app/lightning_invoice.go
+++ b/internal/app/lightning_invoice.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type LightningInvoiceClient interface {
+	AddInvoice(int64, string, bool) (*lndrpc.Invoice, error)
+	LookupInvoice([]byte) (*lndrpc.Invoice, error)
+}
+
+type InvoiceRequest struct {
+	AmountSats int64
+	Memo       string
+	Blinded    bool
+}
+
+// LightningInvoice binds the displayed invoice to the hash used to check it.
+type LightningInvoice struct {
+	paymentRequest string
+	paymentHash    [32]byte
+	amountSats     int64
+}
+
+func (i LightningInvoice) PaymentRequest() string { return i.paymentRequest }
+func (i LightningInvoice) AmountSats() int64      { return i.amountSats }
+
+type InvoiceState int
+
+const (
+	InvoicePending InvoiceState = iota
+	InvoicePaid
+	InvoiceExpired
+)
+
+func CreateLightningInvoice(client LightningInvoiceClient, request InvoiceRequest) (LightningInvoice, error) {
+	if request.AmountSats < 1 {
+		return LightningInvoice{}, errors.New("Minimum 1 sat")
+	}
+	if client == nil {
+		return LightningInvoice{}, errors.New("LND not connected")
+	}
+	invoice, err := client.AddInvoice(request.AmountSats, request.Memo, request.Blinded)
+	if err != nil {
+		return LightningInvoice{}, err
+	}
+	if invoice == nil || invoice.PaymentRequest == "" {
+		return LightningInvoice{}, errors.New("LND returned no invoice; check Payment History before retrying")
+	}
+	hash, err := hex.DecodeString(invoice.PaymentHash)
+	if err != nil || len(hash) != 32 {
+		return LightningInvoice{}, errors.New("LND returned an invalid invoice hash; check Payment History before retrying")
+	}
+	return LightningInvoice{
+		paymentRequest: invoice.PaymentRequest,
+		paymentHash:    [32]byte(hash),
+		amountSats:     invoice.AmountSats,
+	}, nil
+}
+
+// CheckLightningInvoice performs one lookup. A lookup error does not establish
+// whether payment succeeded; the caller decides when to check again.
+func CheckLightningInvoice(client LightningInvoiceClient, invoice LightningInvoice) (InvoiceState, error) {
+	if invoice.paymentRequest == "" {
+		return InvoicePending, errors.New("Create an invoice before checking payment")
+	}
+	if client == nil {
+		return InvoicePending, errors.New("LND not connected")
+	}
+	status, err := client.LookupInvoice(invoice.paymentHash[:])
+	if err != nil {
+		return InvoicePending, err
+	}
+	if status == nil {
+		return InvoicePending, errors.New("LND returned no invoice status")
+	}
+	if status.Settled {
+		return InvoicePaid, nil
+	}
+	if status.IsExpired {
+		return InvoiceExpired, nil
+	}
+	return InvoicePending, nil
+}

--- a/internal/app/lightning_invoice_test.go
+++ b/internal/app/lightning_invoice_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type invoiceClient struct {
+	invoice *lndrpc.Invoice
+	err     error
+	creates int
+	lookups int
+}
+
+func (c *invoiceClient) AddInvoice(int64, string, bool) (*lndrpc.Invoice, error) {
+	c.creates++
+	return c.invoice, c.err
+}
+
+func (c *invoiceClient) LookupInvoice([]byte) (*lndrpc.Invoice, error) {
+	c.lookups++
+	return c.invoice, c.err
+}
+
+func TestInvoiceCreationRefusesInvalidRequestsAndResponses(t *testing.T) {
+	client := &invoiceClient{}
+	for _, amount := range []int64{0, -1} {
+		if _, err := CreateLightningInvoice(client, InvoiceRequest{AmountSats: amount}); err == nil || client.creates != 0 {
+			t.Fatal("invalid amount reached LND")
+		}
+	}
+	for _, invoice := range []*lndrpc.Invoice{
+		nil,
+		{PaymentHash: strings.Repeat("01", 32)},
+		{PaymentRequest: "lntbs1example", PaymentHash: "not-a-hash"},
+		{PaymentRequest: "lntbs1example", PaymentHash: "01"},
+	} {
+		client.invoice = invoice
+		created, err := CreateLightningInvoice(client, InvoiceRequest{AmountSats: 42})
+		if err == nil {
+			t.Fatalf("accepted unusable invoice: %+v", invoice)
+		}
+		if _, err := CheckLightningInvoice(client, created); err == nil || client.lookups != 0 {
+			t.Fatal("failed creation started monitoring")
+		}
+	}
+}
+
+func TestInvoiceLookupPreservesPendingAndUnknownOutcomes(t *testing.T) {
+	client := &invoiceClient{invoice: &lndrpc.Invoice{
+		PaymentRequest: "lntbs1example", PaymentHash: strings.Repeat("01", 32),
+	}}
+	invoice, err := CreateLightningInvoice(client, InvoiceRequest{AmountSats: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name    string
+		invoice *lndrpc.Invoice
+		err     error
+		want    InvoiceState
+	}{
+		{"open", &lndrpc.Invoice{}, nil, InvoicePending},
+		{"paid", &lndrpc.Invoice{Settled: true}, nil, InvoicePaid},
+		{"expired", &lndrpc.Invoice{IsExpired: true}, nil, InvoiceExpired},
+		{"lookup error", nil, errors.New("connection lost"), InvoicePending},
+		{"missing status", nil, nil, InvoicePending},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client.invoice, client.err = tc.invoice, tc.err
+			state, err := CheckLightningInvoice(client, invoice)
+			wantError := tc.err != nil || tc.invoice == nil
+			if state != tc.want || (err != nil) != wantError {
+				t.Fatalf("state=%v error=%v", state, err)
+			}
+		})
+	}
+}

--- a/internal/lndrpc/invoices_test.go
+++ b/internal/lndrpc/invoices_test.go
@@ -1,115 +1,8 @@
 package lndrpc
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestInvoiceFields(t *testing.T) {
-	inv := &Invoice{
-		AmountSats: 1000,
-		Memo:       "test payment",
-		Settled:    false,
-	}
-	if inv.AmountSats != 1000 {
-		t.Errorf("AmountSats: got %d", inv.AmountSats)
-	}
-	if inv.Memo != "test payment" {
-		t.Errorf("Memo: got %q", inv.Memo)
-	}
-	if inv.Settled {
-		t.Error("should not be settled")
-	}
-}
-
-func TestDecodedPayReqFields(t *testing.T) {
-	d := &DecodedPayReq{
-		Destination: "03abc...",
-		AmountSats:  50000,
-		Description: "Coffee",
-		IsExpired:   false,
-	}
-	if d.AmountSats != 50000 {
-		t.Errorf("AmountSats: got %d", d.AmountSats)
-	}
-	if d.Description != "Coffee" {
-		t.Errorf("Description: got %q", d.Description)
-	}
-	if d.IsExpired {
-		t.Error("should not be expired")
-	}
-}
-
-func TestPaymentEntryFields(t *testing.T) {
-	e := PaymentEntry{
-		PaymentHash: "abc123",
-		AmountSats:  10000,
-		FeeSats:     15,
-		Status:      "SUCCEEDED",
-		IsIncoming:  false,
-		Preimage:    "preimage123",
-		Memo:        "sent to friend",
-		Hops: []RouteHop{
-			{PubKey: "03aaa", Alias: "ACINQ", FeeSats: 10},
-			{PubKey: "03bbb", Alias: "Dest", FeeSats: 5},
-		},
-	}
-	if len(e.Hops) != 2 {
-		t.Errorf("Hops: got %d, want 2", len(e.Hops))
-	}
-	if e.Hops[0].Alias != "ACINQ" {
-		t.Errorf("Hop[0].Alias: got %q", e.Hops[0].Alias)
-	}
-	if e.FeeSats != 15 {
-		t.Errorf("FeeSats: got %d", e.FeeSats)
-	}
-}
-
-func TestRouteHopFields(t *testing.T) {
-	hop := RouteHop{
-		PubKey:   "03abc123",
-		Alias:    "TestNode",
-		ChanID:   839201214501,
-		FeeSats:  10,
-		AmtToFwd: 50000,
-	}
-	if hop.Alias != "TestNode" {
-		t.Errorf("Alias: got %q", hop.Alias)
-	}
-	if hop.AmtToFwd != 50000 {
-		t.Errorf("AmtToFwd: got %d", hop.AmtToFwd)
-	}
-}
-
-func TestSendPaymentResultFields(t *testing.T) {
-	r := &SendPaymentResult{
-		Preimage: "abc123",
-		FeeSats:  25,
-		Status:   "SUCCEEDED",
-		Hops: []RouteHop{
-			{Alias: "Hop1"},
-			{Alias: "Hop2"},
-			{Alias: "Dest"},
-		},
-	}
-	if r.Status != "SUCCEEDED" {
-		t.Errorf("Status: got %q", r.Status)
-	}
-	if len(r.Hops) != 3 {
-		t.Errorf("Hops: got %d, want 3", len(r.Hops))
-	}
-}
-
-func TestSendPaymentResultFailed(t *testing.T) {
-	r := &SendPaymentResult{
-		Status: "FAILED",
-		Error:  "FAILURE_REASON_NO_ROUTE",
-	}
-	if r.Error == "" {
-		t.Error("failed result should have error")
-	}
-}
-
-func TestNilClientInvoiceMethods(t *testing.T) {
+func TestDisconnectedClientInvoiceMethods(t *testing.T) {
 	c := &Client{}
 	if _, err := c.AddInvoice(1000, "test", false); err == nil {
 		t.Error("should error")
@@ -128,19 +21,5 @@ func TestNilClientInvoiceMethods(t *testing.T) {
 	}
 	if _, err := c.SendPayment("lnbc..."); err == nil {
 		t.Error("should error")
-	}
-}
-
-func TestPaymentEntryIncoming(t *testing.T) {
-	e := PaymentEntry{IsIncoming: true, Status: "SETTLED"}
-	if !e.IsIncoming {
-		t.Error("should be incoming")
-	}
-}
-
-func TestPaymentEntryOutgoing(t *testing.T) {
-	e := PaymentEntry{IsIncoming: false, Status: "SUCCEEDED"}
-	if e.IsIncoming {
-		t.Error("should be outgoing")
 	}
 }

--- a/internal/lndrpc/payments.go
+++ b/internal/lndrpc/payments.go
@@ -209,32 +209,3 @@ func (c *Client) recoverPaymentOutcome(
 			"before retrying: sending again could pay twice.",
 	}, nil
 }
-
-// WaitForInvoiceSettlement polls an invoice until settled or expired.
-// Uses re-subscribe pattern (Approach 1) — polls every 2 seconds.
-func (c *Client) WaitForInvoiceSettlement(
-	paymentHash []byte, expiry time.Duration,
-) (*Invoice, error) {
-	deadline := time.Now().Add(expiry)
-
-	for time.Now().Before(deadline) {
-		inv, err := c.LookupInvoice(paymentHash)
-		if err != nil {
-			time.Sleep(2 * time.Second)
-			continue
-		}
-		if inv.Settled {
-			return inv, nil
-		}
-		if inv.IsExpired {
-			return inv, nil
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	inv, err := c.LookupInvoice(paymentHash)
-	if err != nil {
-		return nil, fmt.Errorf("invoice lookup: %w", err)
-	}
-	return inv, nil
-}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -1,30 +1,8 @@
-// Package tui — cmds.go
-//
-// tea.Cmd factories. Each function here returns a tea.Cmd
-// (or a tea.Cmd-producing closure) that, when run by the
-// Bubble Tea runtime, performs side effects and returns a
-// message. These are intentionally separate from Model:
-// they have no receiver, depend only on their typed
-// arguments, and are thin wrappers over internal/app, daemon clients,
-// internal/installer, and system shell-outs.
-//
-// Organization (by comment banner below):
-//   - Polling & version
-//   - Syncthing actions
-//   - LND queries & fund-moving
-//   - On-chain queries & fund-moving
-//   - Fee estimation
-//   - Transaction labeling
-//   - Shell-out overlays
-//   - System actions
-//
-// Behaviour note: fetchPaymentHistoryCmd reports either RPC's failure so
-// the wallet home screen retains its last complete history after a partial fetch.
+// Command factories connect screen messages to application and system operations.
 
 package tui
 
 import (
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -199,49 +177,24 @@ func fetchClosedChannelsCmd(
 	}
 }
 
-func createInvoiceCmd(
-	client *lndrpc.Client, amount int64, memo string,
-	blind bool,
-) tea.Cmd {
+func createInvoiceCmd(client app.LightningInvoiceClient, attempt *invoiceAttempt) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return invoiceCreatedMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		inv, err := client.AddInvoice(amount, memo, blind)
-		if err != nil {
-			return invoiceCreatedMsg{err: err}
-		}
-		return invoiceCreatedMsg{
-			payReq:      inv.PaymentRequest,
-			paymentHash: inv.PaymentHash,
-			amountSats:  inv.AmountSats,
-		}
+		invoice, err := app.CreateLightningInvoice(client, attempt.request)
+		return invoiceCreatedMsg{attempt: attempt, invoice: invoice, err: err}
 	}
 }
 
-func waitForInvoiceCmd(
-	client *lndrpc.Client, paymentHash string,
-) tea.Cmd {
+func checkInvoiceCmd(client app.LightningInvoiceClient, attempt *invoiceAttempt, invoice app.LightningInvoice) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return invoiceSettledMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		hashBytes, err := hex.DecodeString(paymentHash)
-		if err != nil {
-			return invoiceSettledMsg{err: err}
-		}
-		inv, err := client.WaitForInvoiceSettlement(
-			hashBytes, 3600*time.Second)
-		if err != nil {
-			return invoiceSettledMsg{err: err}
-		}
-		return invoiceSettledMsg{
-			settled: inv.Settled,
-			expired: inv.IsExpired,
-		}
+		state, err := app.CheckLightningInvoice(client, invoice)
+		return invoiceStatusMsg{attempt: attempt, state: state, err: err}
 	}
+}
+
+func scheduleInvoiceCheck(attempt *invoiceAttempt) tea.Cmd {
+	return tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+		return invoiceCheckMsg{attempt: attempt}
+	})
 }
 
 func preparePaymentCmd(client app.LightningPaymentClient, attempt *paymentAttempt) tea.Cmd {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,14 +153,16 @@ type newAddressMsg struct {
 	err     error
 }
 type invoiceCreatedMsg struct {
-	payReq      string
-	paymentHash string
-	amountSats  int64
-	err         error
+	attempt *invoiceAttempt
+	invoice app.LightningInvoice
+	err     error
 }
-type invoiceSettledMsg struct {
-	settled bool
-	expired bool
+type invoiceCheckMsg struct {
+	attempt *invoiceAttempt
+}
+type invoiceStatusMsg struct {
+	attempt *invoiceAttempt
+	state   app.InvoiceState
 	err     error
 }
 type payReqDecodedMsg struct {

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -20,7 +20,7 @@ type Screen interface {
 	HandleKey(key string, msg tea.KeyPressMsg) (Screen, tea.Cmd)
 
 	// HandleMsg processes async results (e.g.
-	// invoiceSettledMsg), paste messages, and any
+	// invoiceStatusMsg), paste messages, and any
 	// future non-key message types.
 	HandleMsg(msg tea.Msg) (Screen, tea.Cmd)
 

--- a/internal/tui/screen_offchain_receive.go
+++ b/internal/tui/screen_offchain_receive.go
@@ -8,22 +8,19 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
-
-// ── Receive screen steps ────────────────────────────────
 
 type recvStep int
 
 const (
-	recvStepInput   recvStep = iota // amount + memo entry
-	recvStepWaiting                 // invoice created, waiting for payment
-	recvStepPaid                    // payment received
-	recvStepExpired                 // invoice expired
-	recvStepError                   // connection lost / error
+	recvStepInput    recvStep = iota // amount + memo entry
+	recvStepCreating                 // invoice creation in progress
+	recvStepWaiting                  // invoice created, waiting for payment
+	recvStepPaid                     // payment received
+	recvStepExpired                  // invoice expired
 )
-
-// ── Input focus zones ───────────────────────────────────
 
 const (
 	recvZoneAmount  = 0
@@ -32,11 +29,19 @@ const (
 	recvZoneButtons = 3
 )
 
-// ── ReceiveScreen ───────────────────────────────────────
+// Each creation attempt owns its results, even after a tab is closed and reopened.
+type invoiceAttempt struct {
+	request app.InvoiceRequest
+}
 
 type ReceiveScreen struct {
-	ctx  *ScreenContext
-	step recvStep
+	ctx         *ScreenContext
+	step        recvStep
+	invoices    app.LightningInvoiceClient
+	attempt     *invoiceAttempt
+	invoice     app.LightningInvoice
+	checking    bool
+	lookupError string
 
 	// Input state
 	amountInput AmountInput
@@ -46,27 +51,21 @@ type ReceiveScreen struct {
 	btnIdx      int  // 0=Clear, 1=Create Invoice
 	inputError  string
 
-	// Invoice state (set after creation)
-	payReq      string
-	paymentHash string
-	amountSats  int64
-
-	// Waiting state
 	buttonIdx int // 0=Show QR, 1=Copyable Invoice
-
-	// Result state
-	settled bool
-	expired bool
-	error   string
 }
 
 func NewReceiveScreen(
 	ctx *ScreenContext,
 ) *ReceiveScreen {
+	var invoices app.LightningInvoiceClient
+	if ctx.LndClient != nil {
+		invoices = ctx.LndClient
+	}
 	amt := NewAmountInput()
 	amt.Focus() // amount is the initial focus zone
 	return &ReceiveScreen{
 		ctx:         ctx,
+		invoices:    invoices,
 		step:        recvStepInput,
 		amountInput: amt,
 		memoInput:   newRecvMemoInput(),
@@ -75,8 +74,6 @@ func NewReceiveScreen(
 		btnIdx:      1, // default to Create Invoice
 	}
 }
-
-// ── Screen interface ────────────────────────────────────
 
 func (s *ReceiveScreen) Init() tea.Cmd {
 	return nil
@@ -88,14 +85,20 @@ func (s *ReceiveScreen) HandleKey(
 	switch s.step {
 	case recvStepInput:
 		return s.handleInputKey(keyStr, msg)
+	case recvStepCreating:
+		switch keyStr {
+		case "ctrl+c":
+			return s, tea.Quit
+		case "left":
+			return s, emitFocusSidebar
+		case "backspace":
+			return s, emitFocusParent
+		}
+		return s, nil
 	case recvStepWaiting:
 		return s.handleWaitingKey(keyStr)
-	case recvStepPaid:
-		return s.handlePaidKey(keyStr)
-	case recvStepExpired:
-		return s.handleExpiredKey(keyStr)
-	case recvStepError:
-		return s.handleErrorKey(keyStr)
+	case recvStepPaid, recvStepExpired:
+		return s.handleResultKey(keyStr)
 	}
 	return s, nil
 }
@@ -108,8 +111,13 @@ func (s *ReceiveScreen) HandleMsg(
 		return s.handlePaste(msg)
 	case invoiceCreatedMsg:
 		return s.handleInvoiceCreated(msg)
-	case invoiceSettledMsg:
-		return s.handleInvoiceSettled(msg)
+	case invoiceCheckMsg:
+		if s.step == recvStepWaiting && s.attempt != nil && msg.attempt == s.attempt && !s.checking {
+			s.checking = true
+			return s, checkInvoiceCmd(s.invoices, s.attempt, s.invoice)
+		}
+	case invoiceStatusMsg:
+		return s.handleInvoiceStatus(msg)
 	}
 	return s, nil
 }
@@ -118,14 +126,17 @@ func (s *ReceiveScreen) View(w, h int) string {
 	switch s.step {
 	case recvStepInput:
 		return s.viewInput(w, h)
+	case recvStepCreating:
+		p := newPane(w)
+		p.title(theme.Header, "Creating Invoice")
+		p.dim("Waiting for LND...")
+		return p.render()
 	case recvStepWaiting:
 		return s.viewWaiting(w, h)
 	case recvStepPaid:
 		return s.viewPaid(w, h)
 	case recvStepExpired:
 		return s.viewExpired(w, h)
-	case recvStepError:
-		return s.viewError(w, h)
 	}
 	return ""
 }
@@ -134,10 +145,12 @@ func (s *ReceiveScreen) HelpBindings() []key.Binding {
 	switch s.step {
 	case recvStepInput:
 		return s.inputBindings()
+	case recvStepCreating:
+		return []key.Binding{kSidebar, kBack, kQuit}
 	case recvStepWaiting:
 		return actionButtonBindings(
 			s.buttonIdx, s.ctx.HasTabs)
-	case recvStepPaid, recvStepExpired, recvStepError:
+	case recvStepPaid, recvStepExpired:
 		return resultBindings(s.ctx.HasTabs)
 	}
 	return nil
@@ -175,8 +188,6 @@ func (s *ReceiveScreen) inputBindings() []key.Binding {
 	return binds
 }
 
-// ── Focus helpers ──────────────────────────────────────
-
 func (s *ReceiveScreen) focusInputZone() {
 	s.amountInput.Blur()
 	s.memoInput.Blur()
@@ -189,8 +200,6 @@ func (s *ReceiveScreen) focusInputZone() {
 		// no text input to focus
 	}
 }
-
-// ── Input step ──────────────────────────────────────────
 
 func (s *ReceiveScreen) handleInputKey(
 	keyStr string, msg tea.KeyPressMsg,
@@ -216,8 +225,6 @@ func (s *ReceiveScreen) advanceToButtons() {
 	s.focusZone = recvZoneButtons
 	s.btnIdx = 1 // default to Create Invoice
 }
-
-// ── Per-zone key handlers ─────────────────────────────
 
 func (s *ReceiveScreen) handleAmountKey(
 	keyStr string, msg tea.KeyPressMsg,
@@ -363,28 +370,23 @@ func (s *ReceiveScreen) handleButtonKey(
 	return s, nil
 }
 
-// submitInvoice validates and creates the invoice.
-func (s *ReceiveScreen) submitInvoice() (
-	Screen, tea.Cmd,
-) {
+func (s *ReceiveScreen) submitInvoice() (Screen, tea.Cmd) {
+	if s.step != recvStepInput {
+		return s, nil
+	}
 	if s.amountInput.Empty() {
 		s.inputError = "Enter an amount"
 		return s, nil
 	}
-	amt := s.amountInput.Sats()
-	if amt < 1 {
-		s.inputError = "Minimum 1 sat"
-		return s, nil
-	}
-	s.amountSats = amt
+	s.attempt = &invoiceAttempt{request: app.InvoiceRequest{
+		AmountSats: s.amountInput.Sats(),
+		Memo:       s.memoInput.Value(),
+		Blinded:    s.blindPaths,
+	}}
+	s.step = recvStepCreating
 	s.inputError = ""
-	return s, createInvoiceCmd(
-		s.ctx.LndClient, amt,
-		s.memoInput.Value(),
-		s.blindPaths)
+	return s, createInvoiceCmd(s.invoices, s.attempt)
 }
-
-// ── Waiting step ────────────────────────────────────────
 
 func (s *ReceiveScreen) handleWaitingKey(
 	keyStr string,
@@ -414,58 +416,32 @@ func (s *ReceiveScreen) handleWaitingKey(
 		}
 		return s, nil
 	case "enter":
-		if s.buttonIdx == 0 && s.payReq != "" {
+		if s.buttonIdx == 0 && s.invoice.PaymentRequest() != "" {
 			return s, func() tea.Msg {
 				return showQRMsg{
-					URL: s.payReq,
+					URL: s.invoice.PaymentRequest(),
 					Label: fmt.Sprintf(
 						"Invoice — %s sats",
-						formatSats(s.amountSats)),
+						formatSats(s.invoice.AmountSats())),
 				}
 			}
 		}
-		if s.buttonIdx == 1 && s.payReq != "" {
-			return s, showInvoiceCmd(s.payReq)
+		if s.buttonIdx == 1 && s.invoice.PaymentRequest() != "" {
+			return s, showInvoiceCmd(s.invoice.PaymentRequest())
 		}
 	}
 	return s, nil
 }
 
-// ── Paid step ───────────────────────────────────────────
-
-func (s *ReceiveScreen) handlePaidKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
+func (s *ReceiveScreen) handleResultKey(keyStr string) (Screen, tea.Cmd) {
 	switch keyStr {
 	case "ctrl+c":
 		return s, tea.Quit
 	case "enter":
-		return s, tea.Batch(
-			emitCloseTab,
-			emitRefreshStatus,
-			fetchPaymentHistoryCmd(
-				s.ctx.LndClient))
-	case "left":
-		return s, emitFocusSidebar
-	case "up", "shift+tab":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
+		if s.step == recvStepPaid {
+			return s, tea.Batch(emitCloseTab, emitRefreshStatus,
+				fetchPaymentHistoryCmd(s.ctx.LndClient))
 		}
-	case "backspace":
-		return s, emitFocusParent
-	}
-	return s, nil
-}
-
-// ── Expired step ────────────────────────────────────────
-
-func (s *ReceiveScreen) handleExpiredKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "enter":
 		return s, emitCloseTab
 	case "left":
 		return s, emitFocusSidebar
@@ -478,30 +454,6 @@ func (s *ReceiveScreen) handleExpiredKey(
 	}
 	return s, nil
 }
-
-// ── Error step ──────────────────────────────────────────
-
-func (s *ReceiveScreen) handleErrorKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
-	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
-	case "enter":
-		return s, emitCloseTab
-	case "left":
-		return s, emitFocusSidebar
-	case "up", "shift+tab":
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
-	case "backspace":
-		return s, emitFocusParent
-	}
-	return s, nil
-}
-
-// ── Paste handling ──────────────────────────────────────
 
 func (s *ReceiveScreen) handlePaste(
 	msg tea.PasteMsg,
@@ -519,50 +471,47 @@ func (s *ReceiveScreen) handlePaste(
 	return s, cmd
 }
 
-// ── Async message handlers ──────────────────────────────
-
-func (s *ReceiveScreen) handleInvoiceCreated(
-	msg invoiceCreatedMsg,
-) (Screen, tea.Cmd) {
+func (s *ReceiveScreen) handleInvoiceCreated(msg invoiceCreatedMsg) (Screen, tea.Cmd) {
+	if s.step != recvStepCreating || s.attempt == nil || msg.attempt != s.attempt {
+		return s, nil
+	}
 	if msg.err != nil {
-		errStr := msg.err.Error()
-		if s.blindPaths && (strings.Contains(errStr,
-			"blinded") || strings.Contains(errStr,
-			"routes to self")) {
-			s.inputError = errStr +
-				" — try turning off blinded paths"
-		} else {
-			s.inputError = errStr
+		s.inputError = msg.err.Error()
+		if s.attempt.request.Blinded && (strings.Contains(s.inputError, "blinded") || strings.Contains(s.inputError, "routes to self")) {
+			s.inputError += " - try turning off blinded paths"
 		}
+		s.attempt = nil
+		s.step = recvStepInput
 		return s, nil
 	}
-	s.payReq = msg.payReq
-	s.paymentHash = msg.paymentHash
-	s.amountSats = msg.amountSats
+	s.invoice = msg.invoice
 	s.step = recvStepWaiting
-	return s, waitForInvoiceCmd(
-		s.ctx.LndClient, msg.paymentHash)
+	s.checking = true
+	return s, checkInvoiceCmd(s.invoices, s.attempt, s.invoice)
 }
 
-func (s *ReceiveScreen) handleInvoiceSettled(
-	msg invoiceSettledMsg,
-) (Screen, tea.Cmd) {
-	if msg.err != nil {
-		s.error = msg.err.Error()
-		s.step = recvStepError
+func (s *ReceiveScreen) handleInvoiceStatus(msg invoiceStatusMsg) (Screen, tea.Cmd) {
+	if s.step != recvStepWaiting || s.attempt == nil || msg.attempt != s.attempt || !s.checking {
 		return s, nil
 	}
-	if msg.settled {
-		s.settled = true
-		s.step = recvStepPaid
-	} else if msg.expired {
-		s.expired = true
-		s.step = recvStepExpired
+	s.checking = false
+	s.lookupError = ""
+	if msg.err != nil {
+		s.lookupError = msg.err.Error()
+	} else {
+		switch msg.state {
+		case app.InvoicePaid:
+			s.step = recvStepPaid
+			return s, nil
+		case app.InvoiceExpired:
+			s.step = recvStepExpired
+			return s, nil
+		}
 	}
-	return s, nil
+	// Only this screen schedules the next lookup. Closing its tab drops the
+	// pending result or timer, so no further lookups are started.
+	return s, scheduleInvoiceCheck(s.attempt)
 }
-
-// ── Views ───────────────────────────────────────────────
 
 func (s *ReceiveScreen) viewInput(w, h int) string {
 	p := newPane(w)
@@ -593,7 +542,6 @@ func (s *ReceiveScreen) viewInput(w, h int) string {
 	p.dim("Visible to the sender.")
 	p.blank()
 
-	// ── Blinded paths toggle ──
 	blindFocused := isFocused &&
 		s.focusZone == recvZoneBlind
 	blindLabel := theme.Header
@@ -611,7 +559,6 @@ func (s *ReceiveScreen) viewInput(w, h int) string {
 
 	p.appendError(s.inputError)
 
-	// ── Buttons pinned to bottom ──
 	btnFocused := isFocused &&
 		s.focusZone == recvZoneButtons
 	return p.renderWithBottomButtons(
@@ -626,12 +573,12 @@ func (s *ReceiveScreen) viewWaiting(
 	p.title(theme.Header, "Waiting for Payment")
 
 	p.field("Amount: ",
-		formatSats(s.amountSats)+" sats")
+		formatSats(s.invoice.AmountSats())+" sats")
 	p.blank()
 
-	if s.payReq != "" {
+	if s.invoice.PaymentRequest() != "" {
 		p.labelLine("Invoice:")
-		display := s.payReq
+		display := s.invoice.PaymentRequest()
 		maxChars := (w - 2) * 4 // ~4 wrapped lines
 		if len(display) > maxChars {
 			display = display[:maxChars] + "..."
@@ -639,10 +586,14 @@ func (s *ReceiveScreen) viewWaiting(
 		p.monoWrap(display)
 		p.blank()
 
-		p.dim("Waiting for payment...")
+		if s.lookupError != "" {
+			p.warnWrap("Unable to check payment: " + s.lookupError)
+			p.dim("Retrying while this tab remains open.")
+		} else {
+			p.dim("Waiting for payment...")
+		}
 	}
 
-	// ── Buttons pinned to bottom ──
 	btnFocused := s.ctx.ContentFocused
 	return p.renderWithBottomButtons(
 		[]string{"Show QR", "Copyable Invoice"},
@@ -655,7 +606,7 @@ func (s *ReceiveScreen) viewPaid(
 	p := newPane(w)
 	p.title(theme.Success, "Payment Received")
 	p.field("Amount: ",
-		formatSats(s.amountSats)+" sats")
+		formatSats(s.invoice.AmountSats())+" sats")
 	return p.renderWithBottomButtons(
 		[]string{"Done"}, 0,
 		s.ctx.ContentFocused, h)
@@ -667,22 +618,6 @@ func (s *ReceiveScreen) viewExpired(
 	p := newPane(w)
 	p.title(theme.Warning, "Invoice Expired")
 	p.dim("Create a new invoice to try again.")
-	return p.renderWithBottomButtons(
-		[]string{"Done"}, 0,
-		s.ctx.ContentFocused, h)
-}
-
-func (s *ReceiveScreen) viewError(
-	w, h int,
-) string {
-	p := newPane(w)
-	p.title(theme.Warning, "Receive Failed")
-	p.warnWrap(s.error)
-	p.blank()
-	p.dim("The connection to LND was lost while")
-	p.dim("waiting for payment. Your invoice may")
-	p.dim("still be valid — check your payment")
-	p.dim("history after reconnecting.")
 	return p.renderWithBottomButtons(
 		[]string{"Done"}, 0,
 		s.ctx.ContentFocused, h)

--- a/internal/tui/screen_offchain_receive_test.go
+++ b/internal/tui/screen_offchain_receive_test.go
@@ -1,0 +1,179 @@
+package tui
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type screenInvoiceClient struct {
+	requests []app.InvoiceRequest
+	hashes   []string
+	status   *lndrpc.Invoice
+	err      error
+}
+
+func (c *screenInvoiceClient) AddInvoice(amount int64, memo string, blind bool) (*lndrpc.Invoice, error) {
+	c.requests = append(c.requests, app.InvoiceRequest{AmountSats: amount, Memo: memo, Blinded: blind})
+	return &lndrpc.Invoice{
+		PaymentRequest: fmt.Sprintf("lntbs1invoice%d", len(c.requests)),
+		PaymentHash:    fmt.Sprintf("%064x", len(c.requests)), AmountSats: amount,
+	}, c.err
+}
+
+func (c *screenInvoiceClient) LookupInvoice(hash []byte) (*lndrpc.Invoice, error) {
+	c.hashes = append(c.hashes, hex.EncodeToString(hash))
+	return c.status, c.err
+}
+
+func receiveScreen(client *screenInvoiceClient) *ReceiveScreen {
+	s := NewReceiveScreen(&ScreenContext{Cfg: config.Default()})
+	s.invoices = client
+	s.amountInput.SetSats(42)
+	s.memoInput.SetValue("coffee")
+	s.focusZone = recvZoneButtons
+	return s
+}
+
+func TestReceiveCreatesOnceAndMonitorsTheCreatedInvoice(t *testing.T) {
+	client := &screenInvoiceClient{}
+	s := receiveScreen(client)
+	_, create := s.HandleKey("enter", tea.KeyPressMsg{})
+	if create == nil {
+		t.Fatal("creation was not scheduled")
+	}
+	if _, duplicate := s.HandleKey("enter", tea.KeyPressMsg{}); duplicate != nil {
+		t.Fatal("repeated Enter scheduled another invoice")
+	}
+	s.HandleMsg(tea.PasteMsg{Content: "999"})
+	_, check := s.HandleMsg(create())
+	if check == nil || len(client.requests) != 1 || client.requests[0] != (app.InvoiceRequest{AmountSats: 42, Memo: "coffee", Blinded: true}) {
+		t.Fatalf("invoice submission changed: %+v", client.requests)
+	}
+	check()
+	if len(client.hashes) != 1 || client.hashes[0] != fmt.Sprintf("%064x", 1) {
+		t.Fatalf("monitored the wrong invoice: %v", client.hashes)
+	}
+}
+
+func TestReceiveRejectsResultsFromReplacedScreen(t *testing.T) {
+	client := &screenInvoiceClient{status: &lndrpc.Invoice{Settled: true}}
+	old := receiveScreen(client)
+	_, createOld := old.submitInvoice()
+	oldCreated := createOld()
+	_, checkOld := old.HandleMsg(oldCreated)
+	current := receiveScreen(client)
+	_, createCurrent := current.submitInvoice()
+	if _, cmd := current.HandleMsg(oldCreated); cmd != nil || current.step != recvStepCreating {
+		t.Fatal("old creation reached the replacement screen")
+	}
+	_, checkCurrent := current.HandleMsg(createCurrent())
+	if _, cmd := current.HandleMsg(checkOld()); cmd != nil || current.step != recvStepWaiting {
+		t.Fatal("old settlement completed the replacement invoice")
+	}
+	if _, cmd := current.HandleMsg(invoiceCheckMsg{attempt: old.attempt}); cmd != nil {
+		t.Fatal("old timer scheduled another lookup")
+	}
+	current.HandleMsg(checkCurrent())
+	if current.step != recvStepPaid {
+		t.Fatal("current settlement was not accepted")
+	}
+}
+
+func TestReceiveContinuesAfterPendingOrUnavailableStatus(t *testing.T) {
+	theme.Init(true)
+	client := &screenInvoiceClient{err: errors.New("no blinded routes to self")}
+	s := receiveScreen(client)
+	_, create := s.submitInvoice()
+	s.HandleMsg(create())
+	if s.step != recvStepInput || !strings.Contains(s.inputError, "turning off blinded paths") {
+		t.Fatal("creation failure did not allow correcting the request")
+	}
+	client.err = nil
+	_, create = s.submitInvoice()
+	_, check := s.HandleMsg(create())
+	for _, lookupError := range []error{errors.New("connection lost"), nil} {
+		client.err = lookupError
+		client.status = &lndrpc.Invoice{}
+		_, next := s.HandleMsg(check())
+		if s.step != recvStepWaiting || next == nil {
+			t.Fatal("pending or unavailable status stopped monitoring")
+		}
+		view := s.View(82, 34)
+		if strings.Contains(view, "Invoice Expired") || strings.Contains(view, "Payment Received") || strings.Contains(view, "Receive Failed") {
+			t.Fatal("lookup invented a terminal outcome")
+		}
+		if strings.Contains(view, "connection lost") != (lookupError != nil) {
+			t.Fatal("lookup warning did not reflect the latest check")
+		}
+		_, check = s.HandleMsg(next())
+		if check == nil {
+			t.Fatal("next lookup was not scheduled")
+		}
+		if _, duplicate := s.HandleMsg(invoiceCheckMsg{attempt: s.attempt}); duplicate != nil {
+			t.Fatal("overlapping lookup scheduled")
+		}
+	}
+	client.status = &lndrpc.Invoice{Settled: true}
+	if _, next := s.HandleMsg(check()); next != nil || s.step != recvStepPaid {
+		t.Fatal("settlement did not stop monitoring")
+	}
+}
+
+func TestReceiveExpiryStopsMonitoring(t *testing.T) {
+	client := &screenInvoiceClient{status: &lndrpc.Invoice{IsExpired: true}}
+	s := receiveScreen(client)
+	_, create := s.submitInvoice()
+	_, check := s.HandleMsg(create())
+	if _, next := s.HandleMsg(check()); next != nil || s.step != recvStepExpired {
+		t.Fatal("expiry did not stop monitoring")
+	}
+	if _, next := s.HandleMsg(invoiceCheckMsg{attempt: s.attempt}); next != nil {
+		t.Fatal("expired invoice restarted monitoring")
+	}
+}
+
+func TestReceiveMonitoringSurvivesSectionChangeAndStopsOnClose(t *testing.T) {
+	client := &screenInvoiceClient{status: &lndrpc.Invoice{}}
+	s := receiveScreen(client)
+	m := Model{nav: NewNavSidebar(), screenCtx: s.ctx,
+		tabs: []openTab{{Kind: tabReceive, Section: secWallet, Screen: s}}}
+	_, create := s.submitInvoice()
+	// The default sidebar section is Channels, while this invoice belongs to Wallet.
+	updated, check := m.Update(create())
+	m = updated.(Model)
+	if check == nil || s.step != recvStepWaiting {
+		t.Fatal("hidden receive tab lost its creation result")
+	}
+	updated, next := m.Update(check())
+	m = updated.(Model)
+	if next == nil {
+		t.Fatal("hidden receive tab stopped polling")
+	}
+	updated, inFlight := m.Update(invoiceCheckMsg{attempt: s.attempt})
+	m = updated.(Model)
+	if inFlight == nil {
+		t.Fatal("hidden tab lost its next check")
+	}
+	m.nav.SetActive(secWallet)
+	closed, _ := m.closeTab(1)
+	m = closed.(Model)
+	if _, cmd := m.Update(invoiceCheckMsg{attempt: s.attempt}); cmd != nil {
+		t.Fatal("closed tab started another lookup")
+	}
+	if _, cmd := m.Update(inFlight()); cmd != nil {
+		t.Fatal("lookup finishing after close restarted monitoring")
+	}
+	if len(client.hashes) != 2 {
+		t.Fatal("unexpected lookup after close")
+	}
+}

--- a/internal/tui/screen_offchain_send_test.go
+++ b/internal/tui/screen_offchain_send_test.go
@@ -150,3 +150,21 @@ func TestPaymentOutcomeHeadings(t *testing.T) {
 		})
 	}
 }
+
+func TestPaymentResultsReachHiddenWalletSection(t *testing.T) {
+	client := &screenPaymentClient{result: &lndrpc.SendPaymentResult{Status: "SUCCEEDED"}}
+	s := paymentScreen(client)
+	m := Model{nav: NewNavSidebar(), screenCtx: s.ctx,
+		tabs: []openTab{{Kind: tabSend, Section: secWallet, Screen: s}}}
+	decode := submitInvoice(t, s, "lnbc1approved")
+	updated, _ := m.Update(decode())
+	m = updated.(Model)
+	if s.step != sendStepConfirm {
+		t.Fatal("hidden payment tab lost its decoded invoice")
+	}
+	_, send := s.HandleKey("enter", tea.KeyPressMsg{})
+	m.Update(send())
+	if s.step != sendStepResult || s.result.Status != "SUCCEEDED" {
+		t.Fatal("hidden payment tab lost its payment result")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -359,7 +359,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.dispatchToTab(tabOCReceive, msg)
 	case invoiceCreatedMsg:
 		return m.dispatchToTab(tabReceive, msg)
-	case invoiceSettledMsg:
+	case invoiceCheckMsg, invoiceStatusMsg:
 		return m.dispatchToTab(tabReceive, msg)
 	case payReqDecodedMsg:
 		return m.dispatchToTab(tabSend, msg)
@@ -1098,32 +1098,19 @@ func (m *Model) setTabScreen(
 	}
 }
 
-// routeToScreen delivers a message to the screen on the
-// tab matching the given kind. Routes by tab kind, not
-// by which tab is active — an invoiceCreatedMsg must
-// reach the receive screen even if the user switched to
-// a different tab while the async operation was in
-// flight. Returns (model, cmd, true) if routed, or
-// (model, nil, false) if no matching screen exists.
-//
-// screenCtx.HasTabs and screenCtx.ContentFocused are
-// both refreshed before dispatch so HandleMsg sees the
-// same view of focus state that HandleKey would. Without
-// this, a screen that branches on ContentFocused inside
-// HandleMsg (e.g. to decide whether to consume a paste)
-// would see whatever the last key event left the flag
-// as — silently wrong when the async message arrives
-// during sidebar or tab-bar focus.
-func (m Model) routeToScreen(
-	kind tabKind, msg tea.Msg,
-) (Model, tea.Cmd, bool) {
-	tabs := m.effectiveTabs()
-	for i, tab := range tabs {
+// Send and receive workflows continue in hidden sections. Other workflows
+// retain their visible-section routing until their lifecycle is reviewed.
+func (m Model) routeToScreen(kind tabKind, msg tea.Msg) (Model, tea.Cmd, bool) {
+	section := m.nav.ActiveSection()
+	for i, tab := range m.tabs {
+		if tab.Section != section && kind != tabSend && kind != tabReceive {
+			continue
+		}
 		if tab.Kind == kind && tab.Screen != nil {
-			m.screenCtx.HasTabs = m.hasDetailTabs()
-			m.screenCtx.ContentFocused = m.contentFocused
+			m.screenCtx.HasTabs = true
+			m.screenCtx.ContentFocused = m.contentFocused && tab.Section == section
 			newScreen, cmd := tab.Screen.HandleMsg(msg)
-			m.setTabScreen(i, newScreen)
+			m.tabs[i].Screen = newScreen
 			return m, cmd, true
 		}
 	}


### PR DESCRIPTION
## Summary

Move Lightning invoice creation and status checks into `internal/app`, separating the workflow from TUI presentation.

Replace the long-running polling worker with individual lookups scheduled by the Receive screen. Monitoring stops when the invoice settles, expires, or the tab closes. Lookup errors remain visible and retry without implying that the invoice failed or expired.

Reject stale results and duplicate creation requests. Route send and receive results to their open tabs even when another sidebar section is visible.

Replace field-assignment tests with focused workflow and lifecycle coverage.

## Validation

Live testing covered this PR together with the Lightning payment workflow introduced in #113, completing post-merge live validation of #113 and pre-merge live validation of this PR.

- Formatting, module tidy, tests, race tests, vet, build, and whitespace checks passed.
- Live testing on two Debian 13 amd64 Signet nodes covered bidirectional payments, invoice replacement, expired-invoice rejection, background receive monitoring, and recovery after LND restart.
- Sender and receiver records matched by payment hash and amount.
- Successful payments used unblinded invoices. Blinded invoice creation returned an LND route-construction error, which the TUI displayed correctly.