### PR TITLE
fix: preserve reviewed on-chain send intent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
+	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179
+	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/lightningnetwork/lnd v0.21.2-beta
 	github.com/mdp/qrterminal/v3 v3.2.1
 	golang.org/x/crypto v0.46.0
@@ -27,9 +29,7 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.10 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/btcsuite/btcd/v2transport v1.0.1 // indirect

--- a/internal/app/coin_selection.go
+++ b/internal/app/coin_selection.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+// CoinSelection retains outpoint identity even when a refresh removes a coin.
+// Missing coins must be reviewed or cleared, never replaced by automatic selection.
+type CoinSelection struct {
+	outpoints map[string]bool
+}
+
+func coinOutpoint(coin lndrpc.UTXO) string {
+	return fmt.Sprintf("%s:%d", coin.Txid, coin.Vout)
+}
+
+func (s *CoinSelection) Toggle(coin lndrpc.UTXO) {
+	op := coinOutpoint(coin)
+	if s.outpoints[op] {
+		delete(s.outpoints, op)
+		return
+	}
+	if s.outpoints == nil {
+		s.outpoints = make(map[string]bool)
+	}
+	s.outpoints[op] = true
+}
+
+func (s CoinSelection) Contains(coin lndrpc.UTXO) bool {
+	return s.outpoints[coinOutpoint(coin)]
+}
+
+func (s CoinSelection) Outpoints() []string {
+	var outpoints []string
+	for op := range s.outpoints {
+		outpoints = append(outpoints, op)
+	}
+	sort.Strings(outpoints)
+	return outpoints
+}
+
+func (s CoinSelection) Len() int { return len(s.outpoints) }
+
+func (s *CoinSelection) Clear() { s.outpoints = nil }
+
+func (s CoinSelection) Total(available []lndrpc.UTXO) (int64, error) {
+	coins, err := resolveCoins(s.Outpoints(), available)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, coin := range coins {
+		total += coin.AmountSats
+	}
+	return total, nil
+}
+
+func resolveCoins(outpoints []string, available []lndrpc.UTXO) ([]lndrpc.UTXO, error) {
+	byOutpoint := make(map[string]lndrpc.UTXO, len(available))
+	for _, coin := range available {
+		byOutpoint[coinOutpoint(coin)] = coin
+	}
+	coins := make([]lndrpc.UTXO, 0, len(outpoints))
+	seen := make(map[string]bool, len(outpoints))
+	for _, op := range outpoints {
+		if seen[op] {
+			return nil, fmt.Errorf("Duplicate selected input: %s", op)
+		}
+		coin, ok := byOutpoint[op]
+		if !ok {
+			return nil, fmt.Errorf("Selected input is unavailable: %s. Clear the selection and review again", op)
+		}
+		seen[op] = true
+		coins = append(coins, coin)
+	}
+	return coins, nil
+}

--- a/internal/app/onchain_send.go
+++ b/internal/app/onchain_send.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"errors"
+	"math"
+	"slices"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type OnChainSendClient interface {
+	ListUnspent(int32, int32) ([]lndrpc.UTXO, error)
+	SendCoins(lndrpc.SendCoinsRequest) (*lndrpc.SendCoinsResult, error)
+}
+
+type OnChainSendInput struct {
+	Address     string
+	AmountSats  int64
+	SendAll     bool
+	SatPerVbyte int64
+	Label       string
+	Outpoints   []string
+}
+
+// PreparedOnChainSend owns the reviewed intent, including automatic selection
+// when Outpoints is empty. It is not a signed transaction or a single-use token.
+// LND's pinned EstimateFee API cannot quote manual-rate or send-all requests;
+// no total fee, net Max amount, or change amount is promised here.
+type PreparedOnChainSend struct {
+	request lndrpc.SendCoinsRequest
+	coins   []lndrpc.UTXO
+}
+
+func (p PreparedOnChainSend) Request() lndrpc.SendCoinsRequest {
+	r := p.request
+	r.Outpoints = slices.Clone(r.Outpoints)
+	return r
+}
+
+func (p PreparedOnChainSend) Coins() []lndrpc.UTXO { return slices.Clone(p.coins) }
+
+func PrepareOnChainSend(network string, input OnChainSendInput, available []lndrpc.UTXO) (PreparedOnChainSend, error) {
+	var params *chaincfg.Params
+	switch network {
+	case config.NetworkMainnet:
+		params = &chaincfg.MainNetParams
+	case config.NetworkTestnet4:
+		params = &chaincfg.TestNet4Params
+	case config.NetworkPublicSignet:
+		params = &chaincfg.SigNetParams
+	default:
+		return PreparedOnChainSend{}, errors.New("Unsupported node network profile")
+	}
+	address := strings.TrimSpace(input.Address)
+	decoded, err := btcutil.DecodeAddress(address, params)
+	if err != nil || !decoded.IsForNet(params) {
+		return PreparedOnChainSend{}, errors.New("Enter a valid address for this node's network")
+	}
+	if _, bareKey := decoded.(*btcutil.AddressPubKey); bareKey {
+		return PreparedOnChainSend{}, errors.New("Sending to a bare public key is unsupported")
+	}
+	// Keep the existing minimum amount policy. LND checks output-specific dust.
+	if !input.SendAll && (input.AmountSats < 546 || input.AmountSats > btcutil.MaxSatoshi) {
+		return PreparedOnChainSend{}, errors.New("Enter an amount between 546 sats and the Bitcoin supply limit")
+	}
+	if input.SatPerVbyte < 1 {
+		return PreparedOnChainSend{}, errors.New("Enter a fee rate of at least 1 sat/vB")
+	}
+	label := strings.TrimSpace(input.Label)
+	if len(label) > 500 {
+		return PreparedOnChainSend{}, errors.New("Transaction label exceeds 500 bytes")
+	}
+	coins, err := resolveCoins(input.Outpoints, available)
+	if err != nil {
+		return PreparedOnChainSend{}, err
+	}
+	amount := input.AmountSats
+	if input.SendAll {
+		amount = 0
+	}
+	return PreparedOnChainSend{
+		request: lndrpc.SendCoinsRequest{
+			Address: decoded.EncodeAddress(), AmountSats: amount,
+			SatPerVbyte: input.SatPerVbyte, SendAll: input.SendAll,
+			Label: label, Outpoints: slices.Clone(input.Outpoints),
+			MinConfs: 0, SpendUnconfirmed: true,
+		},
+		coins: coins,
+	}, nil
+}
+
+type OnChainSendState int
+
+const (
+	OnChainNotSubmitted OnChainSendState = iota
+	OnChainBroadcast
+	OnChainOutcomeUnknown
+)
+
+type OnChainSendResult struct {
+	State OnChainSendState
+	Txid  string
+	Err   error
+}
+
+// SendOnChain rechecks explicit inputs and makes at most one send RPC. LND
+// validates and selects under its own wallet lock; this precheck reserves nothing.
+// A lost RPC response cannot prove that no transaction was published.
+func SendOnChain(client OnChainSendClient, prepared PreparedOnChainSend) OnChainSendResult {
+	if prepared.request.Address == "" {
+		return OnChainSendResult{Err: errors.New("Review the transaction before sending")}
+	}
+	if client == nil {
+		return OnChainSendResult{Err: errors.New("LND not connected")}
+	}
+	req := prepared.Request()
+	if len(req.Outpoints) > 0 {
+		available, err := client.ListUnspent(req.MinConfs, math.MaxInt32)
+		if err == nil {
+			_, err = resolveCoins(req.Outpoints, available)
+		}
+		if err != nil {
+			return OnChainSendResult{Err: err}
+		}
+	}
+	result, err := client.SendCoins(req)
+	if err != nil {
+		return OnChainSendResult{State: OnChainOutcomeUnknown, Err: err}
+	}
+	if result == nil || result.Txid == "" {
+		return OnChainSendResult{State: OnChainOutcomeUnknown, Err: errors.New("LND returned no transaction ID")}
+	}
+	return OnChainSendResult{State: OnChainBroadcast, Txid: result.Txid}
+}

--- a/internal/app/onchain_send_test.go
+++ b/internal/app/onchain_send_test.go
@@ -1,0 +1,174 @@
+package app
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type onChainClient struct {
+	coins            []lndrpc.UTXO
+	listErr, sendErr error
+	sent             []lndrpc.SendCoinsRequest
+	result           *lndrpc.SendCoinsResult
+	minConfs         int32
+}
+
+func (c *onChainClient) ListUnspent(min, max int32) ([]lndrpc.UTXO, error) {
+	c.minConfs = min
+	return c.coins, c.listErr
+}
+
+func (c *onChainClient) SendCoins(req lndrpc.SendCoinsRequest) (*lndrpc.SendCoinsResult, error) {
+	c.sent = append(c.sent, req)
+	return c.result, c.sendErr
+}
+
+func sendInput(t *testing.T) OnChainSendInput {
+	t.Helper()
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return OnChainSendInput{Address: addr.EncodeAddress(), AmountSats: 1000, SatPerVbyte: 9, Label: "reviewed"}
+}
+
+func TestCoinSelectionPreservesIdentityAcrossRefresh(t *testing.T) {
+	a := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 1000}
+	b := lndrpc.UTXO{Txid: strings.Repeat("b", 64), AmountSats: 2000}
+	c := lndrpc.UTXO{Txid: strings.Repeat("c", 64), AmountSats: 3000}
+	var selection CoinSelection
+	selection.Toggle(b)
+	for _, coins := range [][]lndrpc.UTXO{{a, b}, {b, a}, {c, a, b}} {
+		total, err := selection.Total(coins)
+		if err != nil || total != 2000 || !selection.Contains(b) || selection.Contains(c) {
+			t.Fatalf("refresh changed selected coin: total=%d err=%v", total, err)
+		}
+	}
+	for _, coins := range [][]lndrpc.UTXO{{a, c}, nil} {
+		if _, err := selection.Total(coins); err == nil || selection.Len() != 1 {
+			t.Fatal("missing selection silently became automatic selection")
+		}
+	}
+	copy := selection.Outpoints()
+	copy[0] = coinOutpoint(c)
+	if !selection.Contains(b) {
+		t.Fatal("caller mutated selected identity")
+	}
+	selection.Clear()
+	if total, err := selection.Total(nil); err != nil || total != 0 || selection.Len() != 0 {
+		t.Fatal("explicit clear did not restore empty selection")
+	}
+}
+
+func TestOnChainPreparationRejectsInvalidIntent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(*OnChainSendInput)
+	}{
+		{"checksum", func(i *OnChainSendInput) { i.Address += "x" }},
+		{"amount", func(i *OnChainSendInput) { i.AmountSats = 545 }},
+		{"fee", func(i *OnChainSendInput) { i.SatPerVbyte = -1 }},
+		{"supply", func(i *OnChainSendInput) { i.AmountSats = btcutil.MaxSatoshi + 1 }},
+		{"label", func(i *OnChainSendInput) { i.Label = strings.Repeat("a", 501) }},
+		{"missing coin", func(i *OnChainSendInput) { i.Outpoints = []string{strings.Repeat("a", 64) + ":0"} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := sendInput(t)
+			tc.edit(&input)
+			prepared, err := PrepareOnChainSend(config.NetworkMainnet, input, nil)
+			if err == nil {
+				t.Fatal("invalid intent accepted")
+			}
+			client := &onChainClient{}
+			if result := SendOnChain(client, prepared); result.State != OnChainNotSubmitted || len(client.sent) != 0 {
+				t.Fatal("invalid preparation authorized submission")
+			}
+		})
+	}
+	for _, network := range []string{config.NetworkPublicSignet, config.NetworkTestnet4, "signet"} {
+		if _, err := PrepareOnChainSend(network, sendInput(t), nil); err == nil {
+			t.Fatal("foreign address or unknown profile accepted")
+		}
+	}
+	for _, network := range []string{config.NetworkPublicSignet, config.NetworkTestnet4} {
+		input := sendInput(t)
+		address, _ := btcutil.NewAddressTaproot(make([]byte, 32), &chaincfg.SigNetParams)
+		input.Address = address.EncodeAddress()
+		if _, err := PrepareOnChainSend(network, input, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := PrepareOnChainSend(config.NetworkMainnet, input, nil); err == nil {
+			t.Fatal("test-network address accepted for mainnet")
+		}
+	}
+}
+
+func TestOnChainSubmissionOwnsReviewedRequest(t *testing.T) {
+	coin := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 10000, Confirmations: 0}
+	for _, sendAll := range []bool{false, true} {
+		input := sendInput(t)
+		input.SendAll = sendAll
+		input.Outpoints = []string{coinOutpoint(coin)}
+		prepared, err := PrepareOnChainSend(config.NetworkMainnet, input, []lndrpc.UTXO{coin})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reviewed := prepared.Request()
+		input.Outpoints[0] = "replaced"
+		copy := prepared.Request()
+		copy.Outpoints[0] = "replaced again"
+		coins := prepared.Coins()
+		coins[0].AmountSats = 1
+		client := &onChainClient{coins: []lndrpc.UTXO{coin}, result: &lndrpc.SendCoinsResult{Txid: "tx"}}
+		result := SendOnChain(client, prepared)
+		if result.State != OnChainBroadcast || len(client.sent) != 1 || !reflect.DeepEqual(client.sent[0], reviewed) {
+			t.Fatalf("review and submission differ: %+v %+v", reviewed, client.sent)
+		}
+		if client.minConfs != 0 || !reviewed.SpendUnconfirmed || (sendAll && reviewed.AmountSats != 0) {
+			t.Fatal("unconfirmed or Max semantics changed")
+		}
+		if prepared.Coins()[0].AmountSats != 10000 {
+			t.Fatal("review metadata mutated")
+		}
+	}
+}
+
+func TestOnChainPreflightAndUnknownOutcomesNeverRetryOrWidenSelection(t *testing.T) {
+	coin := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 10000}
+	input := sendInput(t)
+	input.Outpoints = []string{coinOutpoint(coin)}
+	prepared, err := PrepareOnChainSend(config.NetworkMainnet, input, []lndrpc.UTXO{coin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, client := range []*onChainClient{{}, {listErr: errors.New("wallet unavailable")}} {
+		if result := SendOnChain(client, prepared); result.State != OnChainNotSubmitted || result.Err == nil || len(client.sent) != 0 {
+			t.Fatal("failed preflight sent a transaction")
+		}
+	}
+	for _, client := range []*onChainClient{
+		{coins: []lndrpc.UTXO{coin}, sendErr: errors.New("response lost")},
+		{coins: []lndrpc.UTXO{coin}},
+		{coins: []lndrpc.UTXO{coin}, result: &lndrpc.SendCoinsResult{}},
+	} {
+		if result := SendOnChain(client, prepared); result.State != OnChainOutcomeUnknown || result.Err == nil || len(client.sent) != 1 {
+			t.Fatal("ambiguous response became success, definite failure, or a retry")
+		}
+	}
+	input.Outpoints = nil
+	prepared, err = PrepareOnChainSend(config.NetworkMainnet, input, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &onChainClient{result: &lndrpc.SendCoinsResult{Txid: "auto"}}
+	if result := SendOnChain(client, prepared); result.State != OnChainBroadcast || len(client.sent[0].Outpoints) != 0 {
+		t.Fatal("intentional automatic selection no longer works")
+	}
+}

--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -42,8 +42,6 @@ type NetworkConfig struct {
 	P2PPort                 int
 	ZMQBlockPort            int
 	ZMQTxPort               int
-	Bech32HRP               string
-	Base58Prefixes          string
 	InvoicePrefix           string
 	AddressPlaceholder      string
 	InvoicePlaceholder      string
@@ -61,8 +59,6 @@ var networkConfigs = map[string]NetworkConfig{
 		P2PPort:            8333,
 		ZMQBlockPort:       28332,
 		ZMQTxPort:          28333,
-		Bech32HRP:          "bc",
-		Base58Prefixes:     "13",
 		InvoicePrefix:      "lnbc",
 		AddressPlaceholder: "bc1p...",
 		InvoicePlaceholder: "lnbc...",
@@ -82,8 +78,6 @@ var networkConfigs = map[string]NetworkConfig{
 		P2PPort:            48333,
 		ZMQBlockPort:       28334,
 		ZMQTxPort:          28335,
-		Bech32HRP:          "tb",
-		Base58Prefixes:     "2mn",
 		InvoicePrefix:      "lntb",
 		AddressPlaceholder: "tb1p...",
 		InvoicePlaceholder: "lntb...",
@@ -104,8 +98,6 @@ var networkConfigs = map[string]NetworkConfig{
 		P2PPort:                 38333,
 		ZMQBlockPort:            28336,
 		ZMQTxPort:               28337,
-		Bech32HRP:               "tb",
-		Base58Prefixes:          "2mn",
 		InvoicePrefix:           "lntbs",
 		AddressPlaceholder:      "tb1p...",
 		InvoicePlaceholder:      "lntbs...",
@@ -133,19 +125,6 @@ func NetworkConfigFromName(name string) (*NetworkConfig, error) {
 func ValidateNetwork(name string) error {
 	_, err := NetworkConfigFromName(name)
 	return err
-}
-
-// AcceptsOnChainAddress performs the TUI's deliberately shallow network
-// prefix check. LND remains the authoritative full decoder. Unknown profiles
-// cannot reach this method because lookup fails closed.
-func (n *NetworkConfig) AcceptsOnChainAddress(address string) bool {
-	if strings.HasPrefix(strings.ToLower(address), n.Bech32HRP+"1") {
-		return true
-	}
-	if address == "" || !strings.ContainsRune(n.Base58Prefixes, rune(address[0])) {
-		return false
-	}
-	return true
 }
 
 // AcceptsInvoicePrefix distinguishes testnet4's lntb HRP from public signet's

--- a/internal/config/network_test.go
+++ b/internal/config/network_test.go
@@ -32,7 +32,7 @@ func TestNetworkProfiles(t *testing.T) {
 				t.Fatalf("unexpected profile: %+v", net)
 			}
 			if net.ExpectedGenesis == "" || net.LNDBitcoinFlag == "" ||
-				net.Bech32HRP == "" || net.AddressPlaceholder == "" ||
+				net.AddressPlaceholder == "" ||
 				net.InvoicePlaceholder == "" {
 				t.Fatalf("incomplete profile: %+v", net)
 			}
@@ -70,34 +70,6 @@ func TestPublicSignetIdentityIsPinned(t *testing.T) {
 		net.BitcoinFlag != "signet=1" || net.BitcoinCLIFlag != "-signet" ||
 		net.LNDBitcoinFlag != "bitcoin.signet=true" {
 		t.Fatalf("public signet identity drifted: %+v", net)
-	}
-}
-
-func TestNetworkAddressPrefixes(t *testing.T) {
-	tests := []struct {
-		network string
-		accept  []string
-		reject  []string
-	}{
-		{NetworkMainnet, []string{"bc1qexample000", "1example000000", "3example000000"}, []string{"tb1qexample000", "mexample000000"}},
-		{NetworkTestnet4, []string{"tb1qexample000", "mexample000000", "nexample000000", "2example000000"}, []string{"bc1qexample000", "sb1qexample000"}},
-		{NetworkPublicSignet, []string{"tb1qexample000", "mexample000000", "nexample000000", "2example000000"}, []string{"bc1qexample000", "sb1qexample000"}},
-	}
-	for _, tt := range tests {
-		net, err := NetworkConfigFromName(tt.network)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, address := range tt.accept {
-			if !net.AcceptsOnChainAddress(address) {
-				t.Errorf("%s rejected %q", tt.network, address)
-			}
-		}
-		for _, address := range tt.reject {
-			if net.AcceptsOnChainAddress(address) {
-				t.Errorf("%s accepted %q", tt.network, address)
-			}
-		}
 	}
 }
 

--- a/internal/lndrpc/onchain.go
+++ b/internal/lndrpc/onchain.go
@@ -26,9 +26,15 @@ type SendCoinsResult struct {
 	Txid string
 }
 
-type FeeEstimate struct {
-	FeeSats     int64
-	SatPerVbyte uint64
+type SendCoinsRequest struct {
+	Address          string
+	AmountSats       int64
+	SatPerVbyte      int64
+	SendAll          bool
+	Label            string
+	Outpoints        []string
+	MinConfs         int32
+	SpendUnconfirmed bool
 }
 
 type OnChainTx struct {
@@ -127,81 +133,47 @@ func (c *Client) ListUnspent(
 
 // ── Send on-chain ────────────────────────────────────────
 
-func (c *Client) SendCoins(
-	address string, amountSats int64,
-	satPerVbyte int64, sendAll bool,
-	outpoints []string,
-) (*SendCoinsResult, error) {
+func (c *Client) SendCoins(input SendCoinsRequest) (*SendCoinsResult, error) {
+	req, err := buildSendCoinsRequest(input)
+	if err != nil {
+		return nil, err
+	}
 	rpc := c.rpc()
 	if rpc == nil {
 		return nil, errNotConnected
 	}
 	ctx, cancel := c.callCtx(60 * time.Second)
 	defer cancel()
-
-	req := &lnrpc.SendCoinsRequest{
-		Addr:             address,
-		Amount:           amountSats,
-		SatPerVbyte:      uint64(satPerVbyte),
-		SendAll:          sendAll,
-		MinConfs:         0,
-		SpendUnconfirmed: true,
-	}
-
-	// Coin control: restrict inputs to the selected UTXOs. A
-	// malformed outpoint aborts the whole operation — silently
-	// skipping one would widen coin selection past what the
-	// operator chose.
-	for _, op := range outpoints {
-		outPoint, err := parseOutpoint(op)
-		if err != nil {
-			return nil, err
-		}
-		req.Outpoints = append(req.Outpoints, outPoint)
-	}
-
 	resp, err := rpc.SendCoins(ctx, req)
 	if err != nil {
 		c.handleError(err)
 		return nil, err
 	}
-
-	return &SendCoinsResult{
-		Txid: resp.GetTxid(),
-	}, nil
+	return &SendCoinsResult{Txid: resp.GetTxid()}, nil
 }
 
-// ── Fee estimation ───────────────────────────────────────
-
-func (c *Client) EstimateFee(
-	address string, amountSats int64,
-	targetConf int32,
-) (*FeeEstimate, error) {
-	rpc := c.rpc()
-	if rpc == nil {
-		return nil, errNotConnected
+func buildSendCoinsRequest(input SendCoinsRequest) (*lnrpc.SendCoinsRequest, error) {
+	if input.SatPerVbyte < 1 || input.AmountSats < 0 || (input.SendAll && input.AmountSats != 0) {
+		return nil, fmt.Errorf("invalid send amount or fee rate")
 	}
-	ctx, cancel := c.callCtx(defaultTimeout)
-	defer cancel()
-
-	addrToAmount := map[string]int64{
-		address: amountSats,
-	}
-
-	resp, err := rpc.EstimateFee(ctx,
-		&lnrpc.EstimateFeeRequest{
-			AddrToAmount: addrToAmount,
-			TargetConf:   targetConf,
-		})
-	if err != nil {
-		c.handleError(err)
+	if _, err := lnrpc.ExtractMinConfs(input.MinConfs, input.SpendUnconfirmed); err != nil {
 		return nil, err
 	}
-
-	return &FeeEstimate{
-		FeeSats:     resp.GetFeeSat(),
-		SatPerVbyte: resp.GetSatPerVbyte(),
-	}, nil
+	req := &lnrpc.SendCoinsRequest{
+		Addr: input.Address, Amount: input.AmountSats,
+		SatPerVbyte: uint64(input.SatPerVbyte), SendAll: input.SendAll,
+		Label: input.Label, MinConfs: input.MinConfs,
+		SpendUnconfirmed: input.SpendUnconfirmed,
+	}
+	// Reject the entire request if any selected outpoint is malformed.
+	for _, op := range input.Outpoints {
+		outpoint, err := parseOutpoint(op)
+		if err != nil {
+			return nil, err
+		}
+		req.Outpoints = append(req.Outpoints, outpoint)
+	}
+	return req, nil
 }
 
 // ── Get on-chain transactions ────────────────────────────

--- a/internal/lndrpc/onchain_test.go
+++ b/internal/lndrpc/onchain_test.go
@@ -1,0 +1,46 @@
+package lndrpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+type sendCoinsRPC struct {
+	lnrpc.LightningClient
+	requests []*lnrpc.SendCoinsRequest
+}
+
+func (c *sendCoinsRPC) SendCoins(_ context.Context, req *lnrpc.SendCoinsRequest, _ ...grpc.CallOption) (*lnrpc.SendCoinsResponse, error) {
+	c.requests = append(c.requests, req)
+	return &lnrpc.SendCoinsResponse{Txid: "broadcast"}, nil
+}
+
+func TestSendCoinsWireBoundaryPreservesIntentAndRejectsMalformedSelection(t *testing.T) {
+	rpc := &sendCoinsRPC{}
+	client := &Client{lightning: rpc}
+	input := SendCoinsRequest{Address: "destination", AmountSats: 1000, SatPerVbyte: 9, Label: "reviewed", SpendUnconfirmed: true,
+		Outpoints: []string{strings.Repeat("a", 64) + ":7"}}
+	for _, sendAll := range []bool{false, true} {
+		input.SendAll = sendAll
+		if sendAll {
+			input.AmountSats = 0
+		}
+		if _, err := client.SendCoins(input); err != nil {
+			t.Fatal(err)
+		}
+		req := rpc.requests[len(rpc.requests)-1]
+		if req.Amount != input.AmountSats || req.SendAll != sendAll || req.Addr != input.Address || req.Label != input.Label ||
+			req.SatPerVbyte != 9 || req.MinConfs != 0 || !req.SpendUnconfirmed || len(req.Outpoints) != 1 ||
+			req.Outpoints[0].TxidStr != strings.Repeat("a", 64) || req.Outpoints[0].OutputIndex != 7 {
+			t.Fatalf("wire request changes reviewed intent: %+v", req)
+		}
+	}
+	input.Outpoints = append(input.Outpoints, "malformed")
+	if _, err := client.SendCoins(input); err == nil || len(rpc.requests) != 2 {
+		t.Fatal("malformed selection reached send RPC")
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -285,22 +285,10 @@ func listUnspentCmd(
 	}
 }
 
-func sendCoinsCmd(
-	client *lndrpc.Client, addr string,
-	amount int64, feeRate int64, sendAll bool,
-	outpoints []string,
-) tea.Cmd {
+func sendCoinsCmd(client app.OnChainSendClient, attempt *onChainSendAttempt) tea.Cmd {
+	prepared := attempt.prepared
 	return func() tea.Msg {
-		if client == nil {
-			return sendCoinsResultMsg{err: fmt.Errorf(
-				"LND not connected")}
-		}
-		result, err := client.SendCoins(
-			addr, amount, feeRate, sendAll, outpoints)
-		if err != nil {
-			return sendCoinsResultMsg{err: err}
-		}
-		return sendCoinsResultMsg{txid: result.Txid}
+		return sendCoinsResultMsg{attempt: attempt, result: app.SendOnChain(client, prepared)}
 	}
 }
 
@@ -324,24 +312,6 @@ func fetchFeeTiersCmd(
 ) tea.Cmd {
 	return func() tea.Msg {
 		return fetchFeeTiers(cfg)
-	}
-}
-
-func estimateTxFeeCmd(
-	client *lndrpc.Client, addr string,
-	amount int64, targetConf int32,
-) tea.Cmd {
-	return func() tea.Msg {
-		if client == nil {
-			return feeEstimateMsg{err: fmt.Errorf(
-				"LND not connected")}
-		}
-		est, err := client.EstimateFee(
-			addr, amount, targetConf)
-		if err != nil {
-			return feeEstimateMsg{err: err}
-		}
-		return feeEstimateMsg{feeSats: est.FeeSats}
 	}
 }
 

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -117,19 +117,6 @@ func estimateSimpleFee(
 	return vbytes * satPerVB
 }
 
-// isValidOnChainAddr does a basic prefix check.
-// LND will do full validation on send.
-func isValidOnChainAddr(addr string, network string) bool {
-	if len(addr) < 14 {
-		return false
-	}
-	profile, err := config.NetworkConfigFromName(network)
-	if err != nil {
-		return false
-	}
-	return profile.AcceptsOnChainAddress(addr)
-}
-
 // renderViewport creates a local viewport, sets content,
 // auto-scrolls to keep cursorLine visible, and returns the
 // rendered view with scroll indicators overlaid.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -185,19 +185,16 @@ type utxoListMsg struct {
 	err   error
 }
 
+type onChainSendAttempt struct{ prepared app.PreparedOnChainSend }
+
 type sendCoinsResultMsg struct {
-	txid string
-	err  error
+	attempt *onChainSendAttempt
+	result  app.OnChainSendResult
 }
 
 type feeTiersMsg struct {
 	tiers [4]feeTier
 	err   error
-}
-
-type feeEstimateMsg struct {
-	feeSats int64
-	err     error
 }
 
 type onChainTxMsg struct {
@@ -373,9 +370,7 @@ func NewModel(
 		LndClient: client,
 		Version:   version,
 	}
-	m.ocCtx = &OnChainContext{
-		UtxoSelected: make(map[int]bool),
-	}
+	m.ocCtx = &OnChainContext{}
 	m.sectionScreens[secChannels] =
 		NewChannelsHomeScreen(m.screenCtx)
 	m.sectionScreens[secWallet] =

--- a/internal/tui/network_profile_test.go
+++ b/internal/tui/network_profile_test.go
@@ -7,49 +7,6 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/config"
 )
 
-func TestOnChainPrefixValidationUsesInstalledProfile(t *testing.T) {
-	tests := []struct {
-		network string
-		accept  string
-		reject  string
-	}{
-		{config.NetworkMainnet, "bc1qexample000", "tb1qexample000"},
-		{config.NetworkTestnet4, "tb1qexample000", "bc1qexample000"},
-		{config.NetworkPublicSignet, "tb1qexample000", "sb1qexample000"},
-	}
-	for _, tt := range tests {
-		if !isValidOnChainAddr(tt.accept, tt.network) {
-			t.Errorf("%s rejected %q", tt.network, tt.accept)
-		}
-		if isValidOnChainAddr(tt.reject, tt.network) {
-			t.Errorf("%s accepted %q", tt.network, tt.reject)
-		}
-	}
-	if isValidOnChainAddr("bc1qexample000", "signet") {
-		t.Fatal("unknown raw signet profile accepted an address")
-	}
-}
-
-func TestNetworkSpecificInputPlaceholders(t *testing.T) {
-	tests := []struct {
-		network string
-		address string
-		invoice string
-	}{
-		{config.NetworkMainnet, "bc1p...", "lnbc..."},
-		{config.NetworkTestnet4, "tb1p...", "lntb..."},
-		{config.NetworkPublicSignet, "tb1p...", "lntbs..."},
-	}
-	for _, tt := range tests {
-		if got := newOnChainAddrInput(tt.network).Placeholder; got != tt.address {
-			t.Errorf("%s address placeholder %q, want %q", tt.network, got, tt.address)
-		}
-		if got := newSendPayReqInput(tt.network).Placeholder; got != tt.invoice {
-			t.Errorf("%s invoice placeholder %q, want %q", tt.network, got, tt.invoice)
-		}
-	}
-}
-
 func TestLightningInvoicePrefilterUsesInstalledProfile(t *testing.T) {
 	for _, network := range config.SupportedNetworks() {
 		cfg := config.Default()

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -4,6 +4,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
@@ -89,19 +90,13 @@ func walletUnavailableHelpBindings(c *ScreenContext) []key.Binding {
 	return []key.Binding{enter, kSidebar, kBack, kQuit}
 }
 
-// ── OnChainContext ───────────────────────────────────────
-// Shared on-chain state that the on-chain send screen
-// reads. Model owns the data and keeps it synced.
-// Only OnChainSendScreen receives this — other screens
-// don't need it.
-
+// OnChainContext holds wallet data and the selection shared by home and send.
+// Prepared sends own copies of their reviewed inputs.
 type OnChainContext struct {
-	Utxos             []lndrpc.UTXO
-	UtxoSelected      map[int]bool
-	UtxoSelectedTotal int64
-	UtxoOutpoints     []string
-	OnChainTxs        []lndrpc.OnChainTx
-	SendFeeTiers      [4]feeTier
+	Utxos        []lndrpc.UTXO
+	Selection    app.CoinSelection
+	OnChainTxs   []lndrpc.OnChainTx
+	SendFeeTiers [4]feeTier
 }
 
 // ── Screen-to-Model messages ────────────────────────────
@@ -158,10 +153,6 @@ type showFullURLMsg struct {
 // data.
 type refreshStatusMsg struct{}
 
-// clearUtxoSelectionMsg tells Model to clear coin control
-// selection after a successful on-chain send.
-type clearUtxoSelectionMsg struct{}
-
 // ── Message emitters ────────────────────────────────────
 // Screens use these as tea.Cmd values. Each is a
 // func() tea.Msg that returns instantly — the message
@@ -185,8 +176,4 @@ func emitFocusParent() tea.Msg {
 
 func emitRefreshStatus() tea.Msg {
 	return refreshStatusMsg{}
-}
-
-func emitClearUtxoSelection() tea.Msg {
-	return clearUtxoSelectionMsg{}
 }

--- a/internal/tui/screen_onchain_home.go
+++ b/internal/tui/screen_onchain_home.go
@@ -314,16 +314,14 @@ func (s *OnChainHomeScreen) openSend() (
 ) {
 	screen := NewOnChainSendScreen(
 		s.ctx, s.ocCtx)
-	// Pre-fill fee before Max so the computation
-	// uses the real fee rate, not the default of 1.
+	// Pre-fill the manual rate from the cached suggestion.
 	if s.ocCtx.SendFeeTiers[0].SatPerVB > 0 {
 		screen.feeInput.SetSats(
 			int64(s.ocCtx.SendFeeTiers[0].SatPerVB))
 	}
-	// Engage Max for UTXO selection (send_all +
-	// amount = selectedTotal - estFee).
-	if len(s.ocCtx.UtxoSelected) > 0 {
-		screen.EngageMaxForSelection()
+	// Selected coins default to Max; LND determines the net amount.
+	if s.ocCtx.Selection.Len() > 0 {
+		screen.applyMax()
 	}
 	replace := s.utxoChanged
 	s.utxoChanged = false
@@ -566,9 +564,13 @@ func (s *OnChainHomeScreen) View(
 	headerLines = append(headerLines, "")
 
 	sendLabel := "Send"
-	if len(s.ocCtx.UtxoSelected) > 0 {
-		sendLabel = fmt.Sprintf("Send Selected (%s)",
-			formatSats(s.ocCtx.UtxoSelectedTotal))
+	if s.ocCtx.Selection.Len() > 0 {
+		total, err := s.ocCtx.Selection.Total(s.ocCtx.Utxos)
+		if err != nil {
+			sendLabel = "Send Selected (unavailable)"
+		} else {
+			sendLabel = fmt.Sprintf("Send Selected (%s)", formatSats(total))
+		}
 	}
 	headerLines = append(headerLines,
 		renderButtons(
@@ -623,7 +625,7 @@ func (s *OnChainHomeScreen) View(
 			isSelected := isFocused &&
 				s.focusZone == ocHomeZoneUtxos &&
 				s.utxoCursor == i
-			isChecked := s.ocCtx.UtxoSelected[i]
+			isChecked := s.ocCtx.Selection.Contains(u)
 
 			// Date from tx lookup
 			dateStr := s.utxoDate(u.Txid)
@@ -1039,28 +1041,7 @@ func (s *OnChainHomeScreen) toggleSelection(idx int) {
 	if idx < 0 || idx >= len(s.ocCtx.Utxos) {
 		return
 	}
-	if s.ocCtx.UtxoSelected[idx] {
-		delete(s.ocCtx.UtxoSelected, idx)
-	} else {
-		s.ocCtx.UtxoSelected[idx] = true
-	}
-	s.recalcSelectedTotal()
-}
-
-func (s *OnChainHomeScreen) recalcSelectedTotal() {
-	s.ocCtx.UtxoSelectedTotal = 0
-	s.ocCtx.UtxoOutpoints = nil
-	for idx := range s.ocCtx.UtxoSelected {
-		if idx < len(s.ocCtx.Utxos) {
-			s.ocCtx.UtxoSelectedTotal +=
-				s.ocCtx.Utxos[idx].AmountSats
-			s.ocCtx.UtxoOutpoints = append(
-				s.ocCtx.UtxoOutpoints,
-				fmt.Sprintf("%s:%d",
-					s.ocCtx.Utxos[idx].Txid,
-					s.ocCtx.Utxos[idx].Vout))
-		}
-	}
+	s.ocCtx.Selection.Toggle(s.ocCtx.Utxos[idx])
 }
 
 // ── Helpers ─────────────────────────────────────────────

--- a/internal/tui/screen_onchain_send.go
+++ b/internal/tui/screen_onchain_send.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -11,6 +12,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -48,19 +50,11 @@ type OnChainSendScreen struct {
 	// Buttons (step 4)
 	sendBtnIdx int // 0=Clear, 1=Create Transaction
 
-	// Validated values (set on confirm transition)
-	addrVal  string
-	amtVal   int64
-	feeRate  int64
-	labelVal string
-
-	// Confirm (step 5)
-	confirmBtnIdx int   // 0=Go Back, 1=Confirm & Broadcast
-	confirmFee    int64 // precise fee from estimateTxFeeCmd
-
-	// Result (step 7)
-	txid  string
-	error string
+	client        app.OnChainSendClient
+	attempt       *onChainSendAttempt
+	confirmBtnIdx int
+	result        app.OnChainSendResult
+	error         string
 }
 
 func NewOnChainSendScreen(
@@ -76,6 +70,9 @@ func NewOnChainSendScreen(
 		labelInput: newOCSendLabelInput(),
 		feeInput:   NewFeeInput(),
 		sendBtnIdx: 1, // default to Create Transaction
+	}
+	if ctx.LndClient != nil {
+		s.client = ctx.LndClient
 	}
 	return s
 }
@@ -113,8 +110,6 @@ func (s *OnChainSendScreen) HandleMsg(
 		return s.handleSendCoinsResult(msg)
 	case feeTiersMsg:
 		return s.handleFeeTiers(msg)
-	case feeEstimateMsg:
-		return s.handleFeeEstimate(msg)
 	}
 	return s, nil
 }
@@ -147,7 +142,7 @@ func (s *OnChainSendScreen) HelpBindings() []key.Binding {
 		return actionButtonBindings(
 			s.confirmBtnIdx, s.ctx.HasTabs)
 	case ocStepBroadcast:
-		return inFlightBindings()
+		return []key.Binding{kSidebar, kUpShiftTabBar}
 	case ocStepResult:
 		return resultBindings(s.ctx.HasTabs)
 	}
@@ -301,8 +296,7 @@ func (s *OnChainSendScreen) handleInputBackspace(
 			cmd := s.amtInput.Update(tea.Msg(msg))
 			return s, cmd
 		}
-		// Max button focused — non-input zone,
-		// navigate to parent.
+		// Backspace on the Max button returns to the parent.
 		return s, emitFocusParent
 	case ocStepLabel:
 		var cmd tea.Cmd
@@ -311,10 +305,8 @@ func (s *OnChainSendScreen) handleInputBackspace(
 		return s, cmd
 	case ocStepFee:
 		cmd := s.feeInput.Update(tea.Msg(msg))
-		s.syncMaxIfEngaged()
 		return s, cmd
 	case ocStepButtons:
-		// Non-input zone — navigate to parent.
 		return s, emitFocusParent
 	}
 	return s, nil
@@ -349,7 +341,6 @@ func (s *OnChainSendScreen) handleInputDown() (
 func (s *OnChainSendScreen) handleInputTab() (
 	Screen, tea.Cmd,
 ) {
-	// No lists to skip — same as down
 	return s.handleInputDown()
 }
 
@@ -418,7 +409,6 @@ func (s *OnChainSendScreen) handleInputDefault(
 		return s, cmd
 	case ocStepFee:
 		cmd := s.feeInput.Update(tea.Msg(msg))
-		s.syncMaxIfEngaged()
 		return s, cmd
 	}
 	return s, nil
@@ -460,15 +450,18 @@ func (s *OnChainSendScreen) handleConfirmKey(
 			s.backToInput()
 			return s, nil
 		case 1: // Confirm & Broadcast
+			if s.attempt == nil {
+				return s, nil
+			}
+			req := s.attempt.prepared.Request()
+			if !slices.Equal(req.Outpoints, s.ocCtx.Selection.Outpoints()) {
+				s.backToInput()
+				s.error = "Coin selection changed. Review the transaction again"
+				return s, nil
+			}
 			s.error = ""
 			s.step = ocStepBroadcast
-			return s, sendCoinsCmd(
-				s.ctx.LndClient,
-				s.addrVal,
-				s.amtVal,
-				s.feeRate,
-				s.sendAll,
-				s.ocCtx.UtxoOutpoints)
+			return s, sendCoinsCmd(s.client, s.attempt)
 		}
 	}
 	return s, nil
@@ -476,11 +469,22 @@ func (s *OnChainSendScreen) handleConfirmKey(
 
 // ── Broadcast step (step 6) ────────────────────────────
 
-func (s *OnChainSendScreen) handleBroadcastKey(
-	keyStr string,
-) (Screen, tea.Cmd) {
+func (s *OnChainSendScreen) handleBroadcastKey(keyStr string) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "left":
+		return s, emitFocusSidebar
+	case "up", "shift+tab":
+		return s, emitFocusTabBar
+	}
 	return s, nil
 }
+
+func onChainSendBusy(screen Screen) bool {
+	s, ok := screen.(*OnChainSendScreen)
+	return ok && s.step == ocStepBroadcast
+}
+
+type closeOnChainSendMsg struct{ screen *OnChainSendScreen }
 
 // ── Result step (step 7) ───────────────────────────────
 
@@ -491,12 +495,7 @@ func (s *OnChainSendScreen) handleResultKey(
 	case "ctrl+c":
 		return s, tea.Quit
 	case "enter":
-		return s, tea.Batch(
-			emitCloseTab,
-			listUnspentCmd(s.ctx.LndClient),
-			fetchOnChainTxCmd(s.ctx.LndClient),
-			fetchStatus(s.ctx.Cfg, s.ctx.State,
-				s.ctx.LndClient))
+		return s, func() tea.Msg { return closeOnChainSendMsg{screen: s} }
 	case "left":
 		return s, emitFocusSidebar
 	case "up", "shift+tab":
@@ -533,7 +532,6 @@ func (s *OnChainSendScreen) handlePaste(
 		return s, cmd
 	case ocStepFee:
 		cmd := s.feeInput.Update(msg)
-		s.syncMaxIfEngaged()
 		return s, cmd
 	}
 	return s, nil
@@ -541,52 +539,24 @@ func (s *OnChainSendScreen) handlePaste(
 
 // ── Async message handlers ─────────────────────────────
 
-func (s *OnChainSendScreen) handleSendCoinsResult(
-	msg sendCoinsResultMsg,
-) (Screen, tea.Cmd) {
-	if msg.err != nil {
-		s.error = msg.err.Error()
-	} else {
-		s.txid = msg.txid
-		s.error = ""
-	}
-	s.step = ocStepResult
-	// On success: clear UTXO selection + apply label
-	if msg.err == nil {
-		cmds := []tea.Cmd{emitClearUtxoSelection}
-		if s.labelVal != "" {
-			cmds = append(cmds,
-				labelTxCmd(s.ctx.LndClient,
-					msg.txid, s.labelVal))
-		}
-		return s, tea.Batch(cmds...)
-	}
-	return s, nil
-}
-
-func (s *OnChainSendScreen) handleFeeTiers(
-	msg feeTiersMsg,
-) (Screen, tea.Cmd) {
-	if msg.err != nil {
+func (s *OnChainSendScreen) handleSendCoinsResult(msg sendCoinsResultMsg) (Screen, tea.Cmd) {
+	if s.step != ocStepBroadcast || s.attempt == nil || msg.attempt != s.attempt {
 		return s, nil
 	}
-	// Pre-fill fee input if still empty
-	if s.feeInput.Empty() &&
-		msg.tiers[0].SatPerVB > 0 {
-		s.feeInput.SetSats(
-			int64(msg.tiers[0].SatPerVB))
+	s.result = msg.result
+	s.step = ocStepResult
+	if msg.result.State == app.OnChainBroadcast && slices.Equal(
+		s.ocCtx.Selection.Outpoints(), s.attempt.prepared.Request().Outpoints) {
+		s.ocCtx.Selection.Clear()
 	}
-	s.syncMaxIfEngaged()
-	return s, nil
+	// Refresh wallet facts even if the RPC outcome is unknown. Never retry here.
+	return s, tea.Batch(listUnspentCmd(s.ctx.LndClient), fetchOnChainTxCmd(s.ctx.LndClient),
+		fetchStatus(s.ctx.Cfg, s.ctx.State, s.ctx.LndClient))
 }
 
-func (s *OnChainSendScreen) handleFeeEstimate(
-	msg feeEstimateMsg,
-) (Screen, tea.Cmd) {
-	if msg.err == nil {
-		s.confirmFee = msg.feeSats
-	} else {
-		s.error = msg.err.Error()
+func (s *OnChainSendScreen) handleFeeTiers(msg feeTiersMsg) (Screen, tea.Cmd) {
+	if msg.err == nil && s.step <= ocStepButtons && s.feeInput.Empty() && msg.tiers[0].SatPerVB > 0 {
+		s.feeInput.SetSats(int64(msg.tiers[0].SatPerVB))
 	}
 	return s, nil
 }
@@ -613,189 +583,41 @@ func (s *OnChainSendScreen) focusStep() {
 	}
 }
 
-// ── Max-family helpers (Sparrow model) ────────────────
-//
-// Max is a one-way engage: pressing the Max button sets
-// sendAll and fills the amount. Typing or backspace
-// disengages silently. Fee edits auto-sync the amount
-// while engaged. The Max button is a no-op when already
-// engaged.
-
-// computeMaxAmount returns the max sendable amount in
-// sats given the current fee rate and UTXO selection
-// (or full wallet balance if no selection).
-func (s *OnChainSendScreen) computeMaxAmount() int64 {
-	feeRate := s.getFeeRate()
-	if len(s.ocCtx.UtxoSelected) > 0 {
-		numInputs := max(
-			len(s.ocCtx.UtxoOutpoints), 1)
-		estFee := estimateSimpleFee(
-			numInputs, 1, feeRate)
-		maxAmt := s.ocCtx.UtxoSelectedTotal - estFee
-		if maxAmt < 0 {
-			return 0
-		}
-		return maxAmt
-	}
-	if s.ctx.Status != nil &&
-		s.ctx.Status.lndBalance != "" {
-		bal := parseBalance(
-			s.ctx.Status.lndBalance)
-		numInputs := max(
-			len(s.ocCtx.Utxos), 1)
-		estFee := estimateSimpleFee(
-			numInputs, 1, feeRate)
-		maxAmt := bal - estFee
-		if maxAmt < 0 {
-			return 0
-		}
-		return maxAmt
-	}
-	return 0
-}
-
-// applyMax engages send-all mode. No-op when already
-// engaged. Called from enter on the Max button.
+// Max is an intent, not a locally computed net amount. LND accounts for
+// fees and any required reserve change when constructing the transaction.
 func (s *OnChainSendScreen) applyMax() {
-	if s.sendAll {
-		return
-	}
 	s.sendAll = true
-	s.amtInput.SetSats(s.computeMaxAmount())
+	s.amtInput.Clear()
 }
 
-// disengageMax exits send-all mode. No-op when not
-// engaged. Called from typed-digit and backspace
-// handlers — the keystroke itself goes through to
-// AmountInput after this returns.
-func (s *OnChainSendScreen) disengageMax() {
-	if !s.sendAll {
-		return
-	}
-	s.sendAll = false
-}
+func (s *OnChainSendScreen) disengageMax() { s.sendAll = false }
 
-// syncMaxIfEngaged recomputes the max amount when
-// sendAll is active. No-op otherwise. Called after any
-// fee-rate mutation so the amount field stays in sync.
-func (s *OnChainSendScreen) syncMaxIfEngaged() {
-	if !s.sendAll {
-		return
-	}
-	s.amtInput.SetSats(s.computeMaxAmount())
-}
-
-// EngageMaxForSelection is the entry point called from
-// OnChainHomeScreen.openSend when UTXOs are pre-selected.
-// Sets sendAll and fills the amount from the selection
-// total minus estimated fee.
-func (s *OnChainSendScreen) EngageMaxForSelection() {
-	s.sendAll = true
-	s.amtInput.SetSats(s.computeMaxAmount())
-}
-
-// getFeeRate returns the current fee rate from the fee
-// input, defaulting to 1 sat/vB.
-func (s *OnChainSendScreen) getFeeRate() int64 {
-	n := s.feeInput.Sats()
-	if n < 1 {
-		return 1
-	}
-	return n
-}
-
-// validateAndConfirm validates all fields and transitions
-// to the confirm step.
-func (s *OnChainSendScreen) validateAndConfirm() (
-	Screen, tea.Cmd,
-) {
-	// Validate address
-	addr := strings.TrimSpace(
-		s.addrInput.Value())
-	if addr == "" {
-		s.error = "Enter an address"
-		s.step = ocStepAddr
-		s.focusStep()
+func (s *OnChainSendScreen) validateAndConfirm() (Screen, tea.Cmd) {
+	prepared, err := app.PrepareOnChainSend(s.ctx.Cfg.Network, app.OnChainSendInput{
+		Address: s.addrInput.Value(), AmountSats: s.amtInput.Sats(), SendAll: s.sendAll,
+		SatPerVbyte: s.feeInput.Sats(), Label: s.labelInput.Value(),
+		Outpoints: s.ocCtx.Selection.Outpoints(),
+	}, s.ocCtx.Utxos)
+	if err != nil {
+		s.error = err.Error()
 		return s, nil
 	}
-	if !isValidOnChainAddr(addr, s.ctx.Cfg.Network) {
-		s.error = "Invalid address"
-		s.step = ocStepAddr
-		s.focusStep()
-		return s, nil
-	}
-
-	// Validate amount
-	var amountSats int64
-	if s.sendAll {
-		amountSats = 0
-		displayVal := s.amtInput.Sats()
-		if displayVal > 0 {
-			s.amtVal = displayVal
-		}
-	} else {
-		if s.amtInput.Empty() {
-			s.error = "Enter an amount"
-			s.step = ocStepAmount
-			s.focusStep()
-			return s, nil
-		}
-		n := s.amtInput.Sats()
-		if n < 546 {
-			s.error =
-				"Minimum 546 sats (dust limit)"
-			s.step = ocStepAmount
-			s.focusStep()
-			return s, nil
-		}
-		amountSats = n
-	}
-
-	// Validate fee rate
-	feeRateVal := s.feeInput.Sats()
-	if s.feeInput.Empty() {
-		s.error = "Enter a fee rate"
-		s.step = ocStepFee
-		s.focusStep()
-		return s, nil
-	}
-	if feeRateVal < 1 {
-		s.error = "Minimum 1 sat/vB"
-		s.step = ocStepFee
-		s.focusStep()
-		return s, nil
-	}
-
-	s.addrVal = addr
-	s.amtVal = amountSats
-	s.feeRate = feeRateVal
-	s.labelVal = strings.TrimSpace(
-		s.labelInput.Value())
+	s.attempt = &onChainSendAttempt{prepared: prepared}
 	s.error = ""
-	s.confirmFee = 0
 	s.confirmBtnIdx = 0
 	s.step = ocStepConfirm
-
-	if !s.sendAll && addr != "" {
-		target := int32(1)
-		return s, estimateTxFeeCmd(
-			s.ctx.LndClient, addr,
-			amountSats, target)
-	}
 	return s, nil
 }
 
-// backToInput returns to the input form, preserving
-// entered text. Only clears validated state and error.
 func (s *OnChainSendScreen) backToInput() {
+	s.attempt = nil
 	s.step = ocStepButtons
 	s.error = ""
-	s.confirmFee = 0
 	s.confirmBtnIdx = 0
 }
 
 // resetInputs creates fresh inputs and resets all
-// input-phase state.
+// input-phase state, including unavailable selected coins.
 func (s *OnChainSendScreen) resetInputs() {
 	s.addrInput = newOnChainAddrInput(s.ctx.Cfg.Network)
 	s.amtInput = NewAmountInput()
@@ -805,12 +627,9 @@ func (s *OnChainSendScreen) resetInputs() {
 	s.maxFocused = false
 	s.step = ocStepAddr
 	s.sendBtnIdx = 1
-	s.confirmFee = 0
 	s.confirmBtnIdx = 0
-	s.addrVal = ""
-	s.amtVal = 0
-	s.feeRate = 0
-	s.labelVal = ""
+	s.attempt = nil
+	s.ocCtx.Selection.Clear()
 	s.error = ""
 	// Re-fill fee from cached tiers
 	if s.ocCtx.SendFeeTiers[0].SatPerVB > 0 {
@@ -875,14 +694,18 @@ func (s *OnChainSendScreen) viewInput(
 		maxStyle = theme.BtnFocused
 	}
 	maxLabel := "Max"
-	if n := len(s.ocCtx.UtxoSelected); n == 1 {
+	if n := s.ocCtx.Selection.Len(); n == 1 {
 		maxLabel = "Max (1 UTXO selected)"
 	} else if n > 1 {
 		maxLabel = fmt.Sprintf(
 			"Max (%d UTXOs selected)", n)
 	}
 	renderedMax := maxStyle.Render(maxLabel)
-	leftPart := amtMarker + " " + s.amtInput.View()
+	amountView := s.amtInput.View()
+	if s.sendAll {
+		amountView = theme.Value.Render("Max (net amount set by LND)")
+	}
+	leftPart := amtMarker + " " + amountView
 	gap := w - lipgloss.Width(leftPart) -
 		lipgloss.Width(renderedMax) - 2
 	if gap < 2 {
@@ -927,59 +750,19 @@ func (s *OnChainSendScreen) viewInput(
 	}
 	lines = append(lines, "")
 
-	// ── Transaction preview diagram ─────────────
-	sendAmt := s.amtInput.Sats()
-	feeRate := s.getFeeRate()
-	showPreview := sendAmt > 0
-
+	// Preview expresses intent only; a manual fee rate has no supported total quote.
 	var diagLines []string
-	if showPreview {
-		diagOutpoints := s.ocCtx.UtxoOutpoints
-		if len(diagOutpoints) == 0 && s.sendAll &&
-			len(s.ocCtx.Utxos) > 0 {
-			for _, u := range s.ocCtx.Utxos {
-				diagOutpoints = append(diagOutpoints,
-					fmt.Sprintf("%s:%d",
-						u.Txid, u.Vout))
-			}
-		}
-
-		numInputs := max(len(diagOutpoints), 1)
-		numOutputs := 2
+	if s.sendAll || s.amtInput.Sats() > 0 {
+		amount := formatSats(s.amtInput.Sats())
 		if s.sendAll {
-			numOutputs = 1
+			amount = "unknown"
 		}
-		estFee := estimateSimpleFee(
-			numInputs, numOutputs, feeRate)
-
-		dispAmt := formatSats(sendAmt)
-
-		var changeStr string
-		if !s.sendAll {
-			if len(s.ocCtx.UtxoSelected) > 0 {
-				ch := s.ocCtx.UtxoSelectedTotal -
-					sendAmt - estFee
-				if ch > 0 {
-					changeStr = "~" +
-						formatSats(ch)
-				} else {
-					changeStr = "~?"
-				}
-			} else {
-				changeStr = "~?"
-			}
+		diagLines = renderTxDiagram(buildDiagramInputs(s.ocCtx.Selection.Outpoints(), s.ocCtx.Utxos, s.ocCtx.OnChainTxs),
+			strings.TrimSpace(s.addrInput.Value()), amount, "unknown", "unknown", s.sendAll, w)
+		diagLines = append(diagLines, " "+theme.Dim.Render("Total fee unavailable for this manual rate; LND determines change."))
+		if s.sendAll {
+			diagLines = append(diagLines, " "+theme.Dim.Render("Max deducts fees and may leave reserve change."))
 		}
-
-		feeStr := "~" + formatSats(estFee)
-		destAddr := strings.TrimSpace(
-			s.addrInput.Value())
-		diagInputs := buildDiagramInputs(
-			diagOutpoints,
-			s.ocCtx.Utxos,
-			s.ocCtx.OnChainTxs)
-		diagLines = renderTxDiagram(
-			diagInputs, destAddr, dispAmt,
-			changeStr, feeStr, s.sendAll, w)
 	}
 
 	// Error
@@ -1035,197 +818,45 @@ func (s *OnChainSendScreen) viewInput(
 	return strings.Join(lines, "\n")
 }
 
-func (s *OnChainSendScreen) viewConfirm(
-	w, h int,
-) string {
-	isFocused := s.ctx.ContentFocused
-
-	var lines []string
-	lines = append(lines, "")
-	lines = append(lines, centerPad(
-		theme.Warning.Render("Confirm On-Chain Send"),
-		w))
-	lines = append(lines, "")
-
-	addr := s.addrVal
-	lineW := w - 14
-	if len(addr) <= lineW {
-		lines = append(lines,
-			" "+theme.Label.Render("To:       ")+
-				theme.Mono.Render(addr))
+func (s *OnChainSendScreen) viewConfirm(w, h int) string {
+	p := newPane(w)
+	p.title(theme.Warning, "Confirm On-Chain Send")
+	req := s.attempt.prepared.Request()
+	p.labelLine("To:")
+	p.monoWrap(req.Address)
+	if req.SendAll {
+		p.line("Amount: Max (net amount determined by LND)")
 	} else {
-		lines = append(lines,
-			" "+theme.Label.Render("To:       ")+
-				theme.Mono.Render(addr[:lineW]))
-		lines = append(lines,
-			"           "+
-				theme.Mono.Render(addr[lineW:]))
+		p.line("Amount: " + formatSats(req.AmountSats) + " sats")
 	}
-	switch {
-	case s.sendAll && s.amtVal > 0:
-		lines = append(lines,
-			" "+theme.Label.Render("Amount:   ")+
-				theme.Value.Render(
-					formatSats(s.amtVal)+
-						" sats (max)"))
-	case s.sendAll:
-		lines = append(lines,
-			" "+theme.Label.Render("Amount:   ")+
-				theme.Value.Render("Send All"))
-	default:
-		lines = append(lines,
-			" "+theme.Label.Render("Amount:   ")+
-				theme.Value.Render(
-					formatSats(s.amtVal)+
-						" sats"))
-	}
-	if len(s.ocCtx.UtxoOutpoints) > 0 {
-		lines = append(lines,
-			" "+theme.Label.Render("Inputs:   ")+
-				theme.Value.Render(
-					fmt.Sprintf("%d selected UTXOs",
-						len(s.ocCtx.UtxoSelected))))
-	}
-	if s.labelVal != "" {
-		lines = append(lines,
-			" "+theme.Label.Render("Label:    ")+
-				theme.Value.Render(s.labelVal))
-	}
-	lines = append(lines,
-		" "+theme.Label.Render("Fee Rate: ")+
-			theme.Value.Render(
-				fmt.Sprintf("%d sat/vB",
-					s.feeRate)))
-	if s.confirmFee > 0 {
-		lines = append(lines,
-			" "+theme.Label.Render("Est. Fee: ")+
-				theme.Value.Render(
-					formatSats(s.confirmFee)+
-						" sats"))
-		if !s.sendAll && s.amtVal > 0 {
-			total := s.amtVal + s.confirmFee
-			lines = append(lines,
-				" "+theme.Label.Render("Total:    ")+
-					theme.Value.Render(
-						formatSats(total)+" sats"))
-		}
-	}
-	lines = append(lines, "")
-
-	// ── Diagram with real fee numbers ───────────
-	var destAmt string
-	if s.amtVal > 0 {
-		destAmt = formatSats(s.amtVal)
-	} else if s.sendAll {
-		if len(s.ocCtx.UtxoSelected) > 0 {
-			destAmt = formatSats(
-				s.ocCtx.UtxoSelectedTotal)
-		} else {
-			destAmt = formatSats(
-				parseBalance(
-					s.ctx.Status.lndBalance))
-		}
+	if len(req.Outpoints) > 0 {
+		p.line(fmt.Sprintf("Inputs: %d selected UTXOs", len(req.Outpoints)))
 	} else {
-		destAmt = "0"
+		p.line("Inputs: LND selects eligible wallet coins")
 	}
-
-	var changeStr string
-	if !s.sendAll && s.confirmFee > 0 &&
-		len(s.ocCtx.UtxoSelected) > 0 {
-		ch := s.ocCtx.UtxoSelectedTotal -
-			s.amtVal - s.confirmFee
-		if ch > 0 {
-			changeStr = formatSats(ch)
-		}
+	p.line("Unconfirmed inputs: allowed, subject to LND checks")
+	if req.Label != "" {
+		p.valueWrap("Label: " + req.Label)
 	}
-
-	var feeStr string
-	if s.confirmFee > 0 {
-		feeStr = formatSats(s.confirmFee)
-	} else {
-		feeRate := s.getFeeRate()
-		numInputs := max(
-			len(s.ocCtx.UtxoOutpoints), 1)
-		numOutputs := 2
-		if s.sendAll {
-			numOutputs = 1
-		}
-		feeStr = "~" + formatSats(
-			estimateSimpleFee(
-				numInputs, numOutputs, feeRate))
+	p.line(fmt.Sprintf("Fee rate: %d sat/vB", req.SatPerVbyte))
+	p.line("Total fee: unavailable for this manual rate")
+	if req.SendAll {
+		p.line("Max deducts fees and may leave reserve change.")
 	}
-
-	diagOutpoints := s.ocCtx.UtxoOutpoints
-	if len(diagOutpoints) == 0 && s.sendAll &&
-		len(s.ocCtx.Utxos) > 0 {
-		for _, u := range s.ocCtx.Utxos {
-			diagOutpoints = append(diagOutpoints,
-				fmt.Sprintf("%s:%d",
-					u.Txid, u.Vout))
-		}
+	amount := formatSats(req.AmountSats)
+	if req.SendAll {
+		amount = "unknown"
 	}
-
-	diagInputs := buildDiagramInputs(
-		diagOutpoints,
-		s.ocCtx.Utxos,
-		s.ocCtx.OnChainTxs)
-	diagLines := renderTxDiagram(
-		diagInputs, s.addrVal, destAmt,
-		changeStr, feeStr, s.sendAll, w)
-	lines = append(lines, diagLines...)
-
-	// Warning
-	lines = append(lines, "")
-	switch {
-	case s.sendAll && len(s.ocCtx.UtxoOutpoints) > 0:
-		lines = append(lines,
-			" "+theme.Warning.Render(
-				"Send all selected UTXOs?"))
-	case s.sendAll:
-		lines = append(lines,
-			" "+theme.Warning.Render(
-				"Send entire balance?"))
-	default:
-		lines = append(lines,
-			" "+theme.Warning.Render(
-				"Send "+formatSats(s.amtVal)+
-					" sats?"))
+	p.blank()
+	for _, line := range renderTxDiagram(
+		buildDiagramInputs(req.Outpoints, s.attempt.prepared.Coins(), nil),
+		req.Address, amount, "unknown", "unknown", req.SendAll, w) {
+		p.line(line)
 	}
-
-	// Error
 	if s.error != "" {
-		lines = append(lines, "")
-		lineW := w - 4
-		if lineW < 16 {
-			lineW = 16
-		}
-		errText := s.error
-		for len(errText) > 0 {
-			end := lineW
-			if end > len(errText) {
-				end = len(errText)
-			}
-			lines = append(lines,
-				" "+theme.Warning.Render(
-					errText[:end]))
-			errText = errText[end:]
-		}
+		p.warnWrap(s.error)
 	}
-
-	// ── Bottom buttons, pinned ──────────────────
-	btnFocused := isFocused
-	btnLine := renderButtons(
-		[]string{"Go Back", "Confirm & Broadcast"},
-		s.confirmBtnIdx, btnFocused, w)
-
-	contentH := len(lines)
-	padH := max(h-contentH-1, 1)
-	for i := 0; i < padH; i++ {
-		lines = append(lines, "")
-	}
-	lines = append(lines, btnLine)
-
-	return strings.Join(lines, "\n")
+	return p.renderWithBottomButtons([]string{"Go Back", "Confirm & Broadcast"}, s.confirmBtnIdx, s.ctx.ContentFocused, h)
 }
 
 func (s *OnChainSendScreen) viewBroadcast(
@@ -1241,27 +872,23 @@ func (s *OnChainSendScreen) viewBroadcast(
 		[]string{"Broadcasting..."}, 0, false, h)
 }
 
-func (s *OnChainSendScreen) viewResult(
-	w, h int,
-) string {
+func (s *OnChainSendScreen) viewResult(w, h int) string {
 	p := newPane(w)
-
-	if s.error != "" {
-		p.title(theme.Warning,
-			"On-Chain Send Failed")
-		p.warnWrap(s.error)
-	} else {
-		p.title(theme.Success,
-			"Transaction Broadcast")
-		if s.txid != "" {
-			p.labelLine("TX ID:")
-			p.monoWrap(s.txid)
-		}
+	switch s.result.State {
+	case app.OnChainBroadcast:
+		p.title(theme.Success, "Transaction Broadcast")
+		p.labelLine("TX ID:")
+		p.monoWrap(s.result.Txid)
+	case app.OnChainOutcomeUnknown:
+		p.title(theme.Warning, "Broadcast Outcome Unknown")
+		p.warnWrap("Check transaction history before attempting another send.")
+	default:
+		p.title(theme.Warning, "Transaction Not Submitted")
 	}
-
-	return p.renderWithBottomButtons(
-		[]string{"Done"}, 0,
-		s.ctx.ContentFocused, h)
+	if s.result.Err != nil {
+		p.warnWrap(s.result.Err.Error())
+	}
+	return p.renderWithBottomButtons([]string{"Done"}, 0, s.ctx.ContentFocused, h)
 }
 
 // ── Helpbar bindings ───────────────────────────────────
@@ -1301,27 +928,10 @@ func (s *OnChainSendScreen) inputButtonBindings() []key.Binding {
 	return binds
 }
 
-// ── Diagram helpers ────────────────────────────────────
-
-// ── Transaction diagram ────────────────────────────────
-//
-// Renders a Sparrow-style transaction diagram with inputs
-// on the left, "Transaction" centered, and outputs on
-// the right. Uses lipgloss/tree for outputs. Inputs are
-// shown with their label (from tx history) or truncated
-// address + amount.
-//
-//   test (recv)  ─────╮              ╭── bc1q..f39m   1,479,949
-//   003f8bce4d.. ─────┤              │
-//   8c7c97e111.. ─────┤ Transaction  │
-//   452a4c2b09.. ─────┤              ╰── fee               ~449
-//   2a191e9700.. ─────╯
-
-// txDiagramInput holds display info for a transaction
-// input in the diagram.
+// The diagram shows selected input labels and explicit unknown output values.
+// LND determines the transaction shape when submitting the reviewed request.
 type txDiagramInput struct {
 	label string // display label (tx label, address, or txid)
-	amt   string // formatted amount
 }
 
 func renderTxDiagram(
@@ -1336,7 +946,7 @@ func renderTxDiagram(
 	// ── Fallback if no inputs ────────────────────
 	if len(inputs) == 0 {
 		inputs = []txDiagramInput{
-			{label: "? inputs", amt: ""},
+			{label: "? inputs"},
 		}
 	}
 
@@ -1373,9 +983,12 @@ func renderTxDiagram(
 
 	outTree.Child(fmt.Sprintf("%-12s %*s",
 		destLabel, outValueW, destAmt))
-	if !sendAll && changeAmt != "" {
-		outTree.Child(fmt.Sprintf("%-12s %*s",
-			"change", outValueW, changeAmt))
+	if changeAmt != "" {
+		changeLabel := "change"
+		if sendAll {
+			changeLabel = "reserve?"
+		}
+		outTree.Child(fmt.Sprintf("%-12s %*s", changeLabel, outValueW, changeAmt))
 	}
 	outTree.Child(fmt.Sprintf("%-12s %*s",
 		"fee", outValueW, feeAmt))
@@ -1383,8 +996,7 @@ func renderTxDiagram(
 	outputsRendered := outTree.String()
 
 	// ── Build inputs column ──────────────────────
-	// Each input: "label ────╮" (no amounts — those
-	// are visible in the UTXO table above)
+	// Input amounts remain in the UTXO table.
 	inLabelW := 8
 	for _, inp := range inputs {
 		inLabelW = max(inLabelW,
@@ -1460,7 +1072,7 @@ func renderTxDiagram(
 
 // buildDiagramInputs creates txDiagramInput entries from
 // outpoints, cross-referencing UTXOs and tx history for
-// labels and amounts.
+// labels.
 func buildDiagramInputs(
 	outpoints []string,
 	utxos []lndrpc.UTXO,
@@ -1480,7 +1092,6 @@ func buildDiagramInputs(
 		for _, u := range utxos {
 			uOP := fmt.Sprintf("%s:%d", u.Txid, u.Vout)
 			if uOP == op {
-				inp.amt = formatSats(u.AmountSats)
 				if len(u.Address) > 14 {
 					inp.label = u.Address[:8] + ".." +
 						u.Address[len(u.Address)-4:]

--- a/internal/tui/screen_onchain_send_test.go
+++ b/internal/tui/screen_onchain_send_test.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type screenOnChainClient struct {
+	coins []lndrpc.UTXO
+	sent  []lndrpc.SendCoinsRequest
+	err   error
+}
+
+func (c *screenOnChainClient) ListUnspent(int32, int32) ([]lndrpc.UTXO, error) { return c.coins, nil }
+func (c *screenOnChainClient) SendCoins(req lndrpc.SendCoinsRequest) (*lndrpc.SendCoinsResult, error) {
+	c.sent = append(c.sent, req)
+	return &lndrpc.SendCoinsResult{Txid: "broadcast"}, c.err
+}
+
+func onChainScreen(t *testing.T) (*OnChainSendScreen, *screenOnChainClient) {
+	t.Helper()
+	coin := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 10000}
+	client := &screenOnChainClient{coins: []lndrpc.UTXO{coin}}
+	ocCtx := &OnChainContext{Utxos: client.coins}
+	ocCtx.Selection.Toggle(coin)
+	s := NewOnChainSendScreen(&ScreenContext{Cfg: config.Default(), State: &RuntimeState{}}, ocCtx)
+	s.client = client
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.addrInput.SetValue(addr.EncodeAddress())
+	s.amtInput.SetSats(1000)
+	s.feeInput.SetSats(9)
+	s.labelInput.SetValue("reviewed")
+	s.step = ocStepButtons
+	return s, client
+}
+
+func confirmOnChain(t *testing.T, s *OnChainSendScreen) tea.Cmd {
+	t.Helper()
+	s.validateAndConfirm()
+	if s.step != ocStepConfirm {
+		t.Fatalf("preparation failed: %s", s.error)
+	}
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil {
+		t.Fatalf("submission not scheduled: %s", s.error)
+	}
+	return cmd
+}
+
+func TestOnChainReviewAndSubmitStayTogether(t *testing.T) {
+	theme.Init(true)
+	s, client := onChainScreen(t)
+	s.validateAndConfirm()
+	reviewed := s.View(82, 34)
+	s.addrInput.SetValue("changed")
+	s.amtInput.SetSats(9999)
+	s.feeInput.Clear()
+	s.labelInput.SetValue("changed")
+	s.sendAll = true
+	s.HandleMsg(feeTiersMsg{tiers: [4]feeTier{{SatPerVB: 100}}})
+	if s.View(82, 34) != reviewed {
+		t.Fatal("form or late fee suggestion changed confirmation")
+	}
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil {
+		t.Fatal("no submission")
+	}
+	if _, duplicate := s.HandleKey("enter", tea.KeyPressMsg{}); duplicate != nil {
+		t.Fatal("duplicate submission scheduled")
+	}
+	msg := cmd()
+	s.HandleMsg(msg)
+	if len(client.sent) != 1 || client.sent[0].Address == "changed" || client.sent[0].AmountSats != 1000 ||
+		client.sent[0].SatPerVbyte != 9 || client.sent[0].SendAll || client.sent[0].Label != "reviewed" {
+		t.Fatalf("submitted edited form: %+v", client.sent)
+	}
+	if _, duplicate := s.HandleMsg(msg); duplicate != nil {
+		t.Fatal("duplicate result repeated completion work")
+	}
+}
+
+func TestOnChainSelectionRefreshAndRenewedConfirmation(t *testing.T) {
+	s, client := onChainScreen(t)
+	original := client.coins[0]
+	other := lndrpc.UTXO{Txid: strings.Repeat("b", 64), AmountSats: 20000}
+	s.validateAndConfirm()
+	m := Model{ocCtx: s.ocCtx}
+	m.Update(utxoListMsg{utxos: []lndrpc.UTXO{other, original}})
+	if !s.ocCtx.Selection.Contains(original) || s.ocCtx.Selection.Contains(other) {
+		t.Fatal("refresh substituted selected coin")
+	}
+	s.ocCtx.Selection.Toggle(other)
+	s.confirmBtnIdx = 1
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd != nil || s.step != ocStepButtons {
+		t.Fatal("selection edit bypassed review")
+	}
+	s.validateAndConfirm()
+	m.Update(utxoListMsg{utxos: nil})
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	client.coins = nil
+	s.HandleMsg(cmd())
+	if s.result.State != app.OnChainNotSubmitted || len(client.sent) != 0 || s.ocCtx.Selection.Len() != 2 {
+		t.Fatal("missing selected coins became an automatic send")
+	}
+	s.step = ocStepButtons
+	s.sendBtnIdx = 0
+	s.HandleKey("enter", tea.KeyPressMsg{})
+	if s.ocCtx.Selection.Len() != 0 {
+		t.Fatal("Clear cannot recover unavailable selection")
+	}
+}
+
+func TestOnChainResultsRespectAttemptAndTabOwnership(t *testing.T) {
+	s, client := onChainScreen(t)
+	oldCommand := confirmOnChain(t, s)
+	oldMsg := oldCommand()
+	s.HandleMsg(oldMsg)
+	current, _ := onChainScreen(t)
+	currentCommand := confirmOnChain(t, current)
+	if _, cmd := current.HandleMsg(oldMsg); cmd != nil || current.step != ocStepBroadcast {
+		t.Fatal("old result reached replacement screen")
+	}
+	m := Model{nav: NewNavSidebar(), ocCtx: current.ocCtx, screenCtx: current.ctx,
+		tabs: []openTab{{Kind: tabOnChain, Section: secOnChain, Screen: current}}}
+	m.nav.ActiveItem = secOnChain
+	m.activeTab = 1
+	closed, _ := m.closeTab(1)
+	if len(closed.(Model).tabs) != 1 {
+		t.Fatal("closed a pending broadcast")
+	}
+	replaced, _ := m.Update(openTabMsg{Kind: tabOnChain, Screen: s, Replace: true})
+	m = replaced.(Model)
+	if m.tabs[0].Screen != current {
+		t.Fatal("replaced a pending broadcast")
+	}
+	m.nav.ActiveItem = secSystem
+	added := lndrpc.UTXO{Txid: strings.Repeat("b", 64), AmountSats: 20000}
+	current.ocCtx.Selection.Toggle(added)
+	msg := currentCommand()
+	updated, cmd := m.Update(msg)
+	m = updated.(Model)
+	if current.step != ocStepResult || current.result.State != app.OnChainBroadcast || cmd == nil {
+		t.Fatal("hidden on-chain tab lost its result")
+	}
+	if _, duplicate := m.Update(msg); duplicate != nil {
+		t.Fatal("duplicate result triggered wallet refresh again")
+	}
+	if !current.ocCtx.Selection.Contains(added) {
+		t.Fatal("completion cleared a newer selection")
+	}
+	if len(client.sent) != 1 {
+		t.Fatal("old send retried")
+	}
+	m.nav.ActiveItem = secOnChain
+	closed, _ = m.closeTab(1)
+	if len(closed.(Model).tabs) != 0 {
+		t.Fatal("completed send cannot be closed")
+	}
+}
+
+func TestOnChainDoneCannotCloseAnotherTab(t *testing.T) {
+	s, _ := onChainScreen(t)
+	s.HandleMsg(confirmOnChain(t, s)())
+	_, done := s.HandleKey("enter", tea.KeyPressMsg{})
+	other, _ := onChainScreen(t)
+	m := Model{nav: NewNavSidebar(), screenCtx: s.ctx, activeTab: 1,
+		tabs: []openTab{
+			{Kind: tabOnChain, Section: secOnChain, Screen: s},
+			{Kind: tabReceive, Section: secWallet, Screen: other},
+		}}
+	m.nav.ActiveItem = secWallet
+	updated, _ := m.Update(done())
+	m = updated.(Model)
+	if len(m.tabs) != 1 || m.tabs[0].Screen != other {
+		t.Fatal("delayed Done closed the newly active tab")
+	}
+	m.tabs = append(m.tabs, openTab{Kind: tabOnChain, Section: secOnChain, Screen: other})
+	updated, _ = m.Update(done())
+	if len(updated.(Model).tabs) != 2 {
+		t.Fatal("duplicate Done closed a replacement tab")
+	}
+}
+
+func TestOnChainMaxAndUnknownOutcomePresentation(t *testing.T) {
+	theme.Init(true)
+	s, client := onChainScreen(t)
+	s.applyMax()
+	s.validateAndConfirm()
+	view := s.View(67, 30)
+	if len(strings.Split(view, "\n")) > 30 || lipgloss.Width(view) > 67 {
+		t.Fatal("review exceeds the current content pane")
+	}
+	for _, text := range []string{"net amount determined by LND", "Total fee: unavailable", "reserve change", "Unconfirmed inputs: allowed"} {
+		if !strings.Contains(view, text) {
+			t.Fatalf("missing Max contract: %s", text)
+		}
+	}
+	if strings.Contains(view, "10,000") {
+		t.Fatal("gross selection presented as net Max amount")
+	}
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	client.err = errors.New("connection lost")
+	s.HandleMsg(cmd())
+	view = s.View(82, 34)
+	if !strings.Contains(view, "Broadcast Outcome Unknown") || strings.Contains(view, "Send Failed") || strings.Contains(view, "Transaction Broadcast") {
+		t.Fatal("transport error presented as a definite outcome")
+	}
+	if len(client.sent) != 1 || !client.sent[0].SendAll || client.sent[0].AmountSats != 0 {
+		t.Fatal("Max submitted a guessed amount")
+	}
+	if s.ocCtx.Selection.Len() != 1 {
+		t.Fatal("uncertain send cleared selection")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"fmt"
-
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/virtualprivatenode/vpn/internal/helper"
@@ -152,6 +150,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// ── L16 screen-to-Model messages ────────────────
 	case closeTabMsg:
 		return m.closeTab(m.activeTab)
+	case closeOnChainSendMsg:
+		if msg.screen == nil || msg.screen.step != ocStepResult {
+			return m, nil
+		}
+		// Done belongs to its screen even if navigation changes before delivery.
+		for i, tab := range m.tabs {
+			if tab.Screen != msg.screen || onChainSendBusy(tab.Screen) {
+				continue
+			}
+			if tab.Section == m.nav.ActiveSection() {
+				for index, visible := range m.effectiveTabs() {
+					if visible.Screen == msg.screen {
+						return m.closeTab(index)
+					}
+				}
+			} else {
+				m.tabs = append(m.tabs[:i], m.tabs[i+1:]...)
+				m.sectionFocus[tab.Section] = 0
+				return m, nil
+			}
+		}
+		return m, nil
 	case focusSidebarMsg:
 		m.focusSidebar()
 		return m, nil
@@ -214,9 +234,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case refreshStatusMsg:
 		return m, fetchStatus(m.cfg, m.state, m.lndClient)
-	case clearUtxoSelectionMsg:
-		m.clearUtxoSelection()
-		return m, nil
 	case openTabMsg:
 		// Dedup by kind + index if Index is set
 		if msg.Index != 0 {
@@ -245,6 +262,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					t.Section == sec {
 					m.activeTab = i
 					m.rememberTabPosition()
+					if msg.Replace && onChainSendBusy(t.Screen) {
+						return m, nil
+					}
 					if msg.Replace &&
 						msg.Screen != nil {
 						m.setTabScreen(i, msg.Screen)
@@ -375,13 +395,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case utxoListMsg:
 		if msg.err == nil {
 			m.ocCtx.Utxos = msg.utxos
-			// Prune selections beyond new UTXO range
-			for idx := range m.ocCtx.UtxoSelected {
-				if idx >= len(m.ocCtx.Utxos) {
-					delete(m.ocCtx.UtxoSelected, idx)
-				}
-			}
-			m.recalcSelectedTotal()
 		}
 		return m, nil
 	case onChainTxMsg:
@@ -435,25 +448,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.ocCtx.SendFeeTiers = msg.tiers
-		// Fan out to every screen that may want fee
-		// tiers. Each routeToScreen call returns an
-		// updated Model and a possibly-nil cmd; thread
-		// the model through and batch the cmds so none
-		// get dropped.
-		//
-		// The m = rm threading looks redundant because
-		// routeToScreen's screen-writeback goes through
-		// the m.tabs slice (shared backing array) and
-		// its screenCtx mutations go through a pointer,
-		// so today the discarded returns would still
-		// land in shared memory. The threading is
-		// defensive: the day someone adds a non-pointer
-		// Model mutation to routeToScreen, this loop
-		// stays correct without needing a second look.
-		// Contrast with routeToSectionScreen, which
-		// writes to the m.sectionScreens array and was
-		// converted to a pointer receiver for the same
-		// reason.
+		// Keep each screen update and batch the resulting commands.
 		var cmds []tea.Cmd
 		for _, kind := range []tabKind{
 			tabChannel, tabOnChain, tabOpenChannel,
@@ -468,8 +463,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, tea.Batch(cmds...)
-	case feeEstimateMsg:
-		return m.dispatchToTab(tabOnChain, msg)
 	case installStepDoneMsg:
 		// Route to whichever install flow tab is open.
 		// Only one install runs at a time, so first
@@ -624,42 +617,6 @@ func (m Model) handleKey(
 	}
 
 	return m, nil
-}
-
-// ── Coin control helpers ─────────────────────────────────
-
-func (m *Model) toggleUtxoSelection(idx int) {
-	if idx < 0 || idx >= len(m.ocCtx.Utxos) {
-		return
-	}
-	if m.ocCtx.UtxoSelected[idx] {
-		delete(m.ocCtx.UtxoSelected, idx)
-	} else {
-		m.ocCtx.UtxoSelected[idx] = true
-	}
-	m.recalcSelectedTotal()
-}
-
-func (m *Model) recalcSelectedTotal() {
-	m.ocCtx.UtxoSelectedTotal = 0
-	m.ocCtx.UtxoOutpoints = nil
-	for idx := range m.ocCtx.UtxoSelected {
-		if idx < len(m.ocCtx.Utxos) {
-			m.ocCtx.UtxoSelectedTotal +=
-				m.ocCtx.Utxos[idx].AmountSats
-			m.ocCtx.UtxoOutpoints = append(
-				m.ocCtx.UtxoOutpoints,
-				fmt.Sprintf("%s:%d",
-					m.ocCtx.Utxos[idx].Txid,
-					m.ocCtx.Utxos[idx].Vout))
-		}
-	}
-}
-
-func (m *Model) clearUtxoSelection() {
-	m.ocCtx.UtxoSelected = make(map[int]bool)
-	m.ocCtx.UtxoSelectedTotal = 0
-	m.ocCtx.UtxoOutpoints = nil
 }
 
 func buildChannelHistoryEntries(
@@ -935,28 +892,17 @@ func (m Model) closeTab(
 	}
 
 	closingTab := tabs[tabIdx]
+	// Keep a submitted send reachable until its bounded RPC returns.
+	if onChainSendBusy(closingTab.Screen) {
+		return m, nil
+	}
 
 	// Screens own all subview state; just clear the
 	// Model-level subview flag on any tab close.
 	m.subview = svNone
 
-	// Build a set of tabs to remove. Always includes
-	// the closing tab itself; if the closing tab is a
-	// parent, also includes all tabs in the same
-	// section whose Parent matches the closing tab's
-	// kind. Cascade is silent — no confirmation.
-	//
-	// Async results that arrive after a child is
-	// cascade-closed will land in routeToScreen,
-	// find no matching tab, and be dropped silently.
-	// This is safe for the existing flows because
-	// state-changing async messages
-	// (syncthingPairedMsg, syncthingRemovedMsg)
-	// update m.cfg directly in their handlers, not
-	// only in the screen handler — so the side
-	// effect persists even if the tab is gone.
-	// Future flows that change state only via screen
-	// handlers would break this assumption.
+	// Closing a parent also removes its child tabs in the same section.
+	// Future asynchronous results will no longer reach the removed screens.
 	shouldRemove := func(t openTab) bool {
 		if t.Section != closingTab.Section {
 			return false
@@ -1098,12 +1044,12 @@ func (m *Model) setTabScreen(
 	}
 }
 
-// Send and receive workflows continue in hidden sections. Other workflows
-// retain their visible-section routing until their lifecycle is reviewed.
+// Payment, invoice, and on-chain send results reach their open tabs across sections.
+// Other workflows retain visible-section routing until their lifecycle is reviewed.
 func (m Model) routeToScreen(kind tabKind, msg tea.Msg) (Model, tea.Cmd, bool) {
 	section := m.nav.ActiveSection()
 	for i, tab := range m.tabs {
-		if tab.Section != section && kind != tabSend && kind != tabReceive {
+		if tab.Section != section && kind != tabSend && kind != tabReceive && kind != tabOnChain {
 			continue
 		}
 		if tab.Kind == kind && tab.Screen != nil {


### PR DESCRIPTION
On-chain sends could lose selected-coin identity during refresh and show fee estimates that did not match execution.

Move send preparation and submission into the application layer. Preserve selected outpoints and the reviewed request, validate destination addresses, and explicitly allow unconfirmed inputs subject to LND checks. Show unknown totals when an accurate estimate is unavailable, submit labels with the transaction, and guard asynchronous results against stale attempts.

## Validation

Tested candidate: `2758087f677eab9b2ab0b22b24cf6ec10ff7d671`.

- Go 1.26.8: tests, race tests, vet, build, tidy-diff, formatting and diff checks passed.
- Matching Linux amd64 binaries built and deployed on Signet nodes.
- Selected fixed-amount, unconfirmed-input, selected Max and automatic-selection sends passed.
- All five transactions confirmed; wallet balances reconciled with fees.
- Existing private Taproot channel remained active without pending channels or HTLCs.
- Deterministic tests cover stale results, tab ownership and failure outcomes.