### PR TITLE
fix: preserve channel-open intent through submission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.2
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/lightningnetwork/lnd v0.21.2-beta
 	github.com/mdp/qrterminal/v3 v3.2.1
@@ -29,7 +30,6 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.10 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/btcsuite/btcd/v2transport v1.0.1 // indirect

--- a/internal/app/channel_open.go
+++ b/internal/app/channel_open.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type ChannelOpenClient interface {
+	ConnectPeer(string, string) error
+	WaitForPeer(string, time.Duration) error
+	ListUnspent(int32, int32) ([]lndrpc.UTXO, error)
+	OpenChannel(lndrpc.ChannelOpenRequest) lndrpc.ChannelOpenResult
+}
+
+type ChannelOpenInput struct {
+	Pubkey, Host              string
+	AmountSats                int64
+	FundMax, Private, Taproot bool
+	SatPerVbyte               int64
+	Outpoints                 []string
+}
+
+// PreparedChannelOpen owns the reviewed request. Selected coins are the allowed
+// funding pool; LND can use a subset and determines fees, capacity and change.
+// Preparation does not reserve coins or construct a funding transaction.
+type PreparedChannelOpen struct {
+	request lndrpc.ChannelOpenRequest
+	host    string
+	total   int64
+}
+
+func (p PreparedChannelOpen) Request() lndrpc.ChannelOpenRequest {
+	r := p.request
+	r.Outpoints = slices.Clone(r.Outpoints)
+	return r
+}
+
+func (p PreparedChannelOpen) SelectedTotal() int64 { return p.total }
+
+func ValidateChannelPeer(pubkey, host string) (string, string, error) {
+	pubkey, host = strings.TrimSpace(pubkey), strings.TrimSpace(host)
+	raw, err := hex.DecodeString(pubkey)
+	if err != nil || len(raw) != 33 {
+		return "", "", errors.New("Enter a compressed node public key (66 hex characters)")
+	}
+	key, err := btcec.ParsePubKey(raw)
+	if err != nil {
+		return "", "", errors.New("Enter a valid node public key")
+	}
+	name, port, err := net.SplitHostPort(host)
+	n, portErr := strconv.Atoi(port)
+	if err != nil || name == "" || strings.ContainsAny(name, " \t\r\n") || portErr != nil || n < 1 || n > 65535 {
+		return "", "", errors.New("Enter a peer host and port (host:port)")
+	}
+	return hex.EncodeToString(key.SerializeCompressed()), host, nil
+}
+
+func ValidateChannelAmount(amount int64) error {
+	if amount < 20000 || amount > 1000000000 {
+		return errors.New("Enter a channel size between 20,000 and 1,000,000,000 sats")
+	}
+	return nil
+}
+
+func PrepareChannelOpen(input ChannelOpenInput, available []lndrpc.UTXO) (PreparedChannelOpen, error) {
+	pubkey, host, err := ValidateChannelPeer(input.Pubkey, input.Host)
+	if err != nil {
+		return PreparedChannelOpen{}, err
+	}
+	if input.Taproot && !input.Private {
+		return PreparedChannelOpen{}, errors.New("Taproot channels must be private")
+	}
+	// Zero retains the existing automatic fee policy. Bound conversion to sat/kvB.
+	if input.SatPerVbyte < 0 || input.SatPerVbyte > math.MaxInt64/1000 {
+		return PreparedChannelOpen{}, errors.New("Enter a valid fee rate")
+	}
+	if len(input.Outpoints) == 0 {
+		return PreparedChannelOpen{}, errors.New("Select UTXOs in Coin control first")
+	}
+	coins, err := resolveCoins(input.Outpoints, available)
+	if err != nil {
+		return PreparedChannelOpen{}, err
+	}
+	var total int64
+	for _, coin := range coins {
+		if coin.AmountSats <= 0 || coin.AmountSats > btcutil.MaxSatoshi-total {
+			return PreparedChannelOpen{}, errors.New("Invalid selected coin value")
+		}
+		total += coin.AmountSats
+	}
+	amount := input.AmountSats
+	if input.FundMax {
+		amount = 0
+		if total < 20000 {
+			return PreparedChannelOpen{}, errors.New("Select at least 20,000 sats; LND must also cover fees and reserves")
+		}
+	} else {
+		if err := ValidateChannelAmount(amount); err != nil {
+			return PreparedChannelOpen{}, err
+		}
+		if amount >= total {
+			return PreparedChannelOpen{}, errors.New("Selected coins must cover the channel amount plus fees; use Max to let LND determine capacity")
+		}
+	}
+	return PreparedChannelOpen{
+		host: host, total: total,
+		request: lndrpc.ChannelOpenRequest{
+			Pubkey: pubkey, AmountSats: amount, FundMax: input.FundMax,
+			Private: input.Private, Taproot: input.Taproot,
+			SatPerVbyte: uint64(input.SatPerVbyte),
+			Outpoints:   slices.Clone(input.Outpoints), MinConfs: 0, SpendUnconfirmed: true,
+		},
+	}, nil
+}
+
+type ChannelOpenState int
+
+const (
+	ChannelNotSubmitted ChannelOpenState = iota
+	ChannelBroadcast
+	ChannelOutcomeUnknown
+)
+
+type ChannelOpenResult struct {
+	State       ChannelOpenState
+	Txid        string
+	OutputIndex uint32
+	Err         error
+}
+
+// OpenChannel checks peer readiness and selected availability before one funding
+// call. Preflight reserves nothing; LND checks coins under its wallet lock.
+func OpenChannel(client ChannelOpenClient, prepared PreparedChannelOpen) ChannelOpenResult {
+	if prepared.request.Pubkey == "" || len(prepared.request.Outpoints) == 0 {
+		return ChannelOpenResult{Err: errors.New("Review the channel before opening")}
+	}
+	if client == nil {
+		return ChannelOpenResult{Err: errors.New("LND not connected")}
+	}
+	req := prepared.Request()
+	// Persistent connection requests may return before the peer connects.
+	connectErr := client.ConnectPeer(req.Pubkey, prepared.host)
+	if err := client.WaitForPeer(req.Pubkey, 60*time.Second); err != nil {
+		if connectErr != nil {
+			err = fmt.Errorf("%v; peer readiness: %w", connectErr, err)
+		}
+		return ChannelOpenResult{Err: fmt.Errorf("Could not connect: %w", err)}
+	}
+	available, err := client.ListUnspent(req.MinConfs, math.MaxInt32)
+	if err == nil {
+		_, err = resolveCoins(req.Outpoints, available)
+	}
+	if err != nil {
+		return ChannelOpenResult{Err: err}
+	}
+	result := client.OpenChannel(req)
+	if !result.Submitted {
+		return ChannelOpenResult{Err: result.Err}
+	}
+	if result.Err != nil || result.FundingTxID == "" {
+		err := result.Err
+		if err == nil {
+			err = errors.New("LND returned no funding transaction ID")
+		}
+		return ChannelOpenResult{State: ChannelOutcomeUnknown, Err: err}
+	}
+	return ChannelOpenResult{State: ChannelBroadcast, Txid: result.FundingTxID, OutputIndex: result.OutputIndex}
+}

--- a/internal/app/channel_open_test.go
+++ b/internal/app/channel_open_test.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type channelClient struct {
+	coins                        []lndrpc.UTXO
+	calls                        []string
+	sent                         []lndrpc.ChannelOpenRequest
+	connectErr, waitErr, listErr error
+	wait                         func()
+	result                       lndrpc.ChannelOpenResult
+}
+
+func (c *channelClient) ConnectPeer(string, string) error {
+	c.calls = append(c.calls, "connect")
+	return c.connectErr
+}
+func (c *channelClient) WaitForPeer(string, time.Duration) error {
+	c.calls = append(c.calls, "wait")
+	if c.wait != nil {
+		c.wait()
+	}
+	return c.waitErr
+}
+func (c *channelClient) ListUnspent(min, max int32) ([]lndrpc.UTXO, error) {
+	c.calls = append(c.calls, "coins")
+	if min != 0 || max != 2147483647 {
+		return nil, errors.New("wrong confirmation policy")
+	}
+	return c.coins, c.listErr
+}
+func (c *channelClient) OpenChannel(req lndrpc.ChannelOpenRequest) lndrpc.ChannelOpenResult {
+	c.calls = append(c.calls, "fund")
+	c.sent = append(c.sent, req)
+	return c.result
+}
+
+func channelInput() (ChannelOpenInput, []lndrpc.UTXO) {
+	coin := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 50000}
+	return ChannelOpenInput{
+		Pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		Host:   "peer.onion:9735", AmountSats: 30000, Private: true, Taproot: true,
+		SatPerVbyte: 9, Outpoints: []string{coin.Txid + ":0"},
+	}, []lndrpc.UTXO{coin}
+}
+
+func TestChannelPreparationRejectsInvalidIntent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(*ChannelOpenInput)
+	}{
+		{"empty selection", func(i *ChannelOpenInput) { i.Outpoints = nil }},
+		{"missing coin", func(i *ChannelOpenInput) { i.Outpoints[0] = strings.Repeat("b", 64) + ":0" }},
+		{"duplicate coin", func(i *ChannelOpenInput) { i.Outpoints = append(i.Outpoints, i.Outpoints[0]) }},
+		{"invalid curve point", func(i *ChannelOpenInput) { i.Pubkey = "02" + strings.Repeat("ff", 32) }},
+		{"invalid host", func(i *ChannelOpenInput) { i.Host = "peer.onion" }},
+		{"public Taproot", func(i *ChannelOpenInput) { i.Private = false }},
+		{"below minimum", func(i *ChannelOpenInput) { i.AmountSats = 19999 }},
+		{"above maximum", func(i *ChannelOpenInput) { i.AmountSats = 1000000001 }},
+		{"no room for fees", func(i *ChannelOpenInput) { i.AmountSats = 50000 }},
+		{"negative fee", func(i *ChannelOpenInput) { i.SatPerVbyte = -1 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input, coins := channelInput()
+			tc.edit(&input)
+			if _, err := PrepareChannelOpen(input, coins); err == nil {
+				t.Fatal("invalid intent accepted")
+			}
+		})
+	}
+}
+
+func TestChannelPreparedRequestIsOwnedAndMaxIsAnIntent(t *testing.T) {
+	for _, max := range []bool{false, true} {
+		input, coins := channelInput()
+		input.FundMax = max
+		if max {
+			input.SatPerVbyte = 0
+		}
+		prepared, err := PrepareChannelOpen(input, coins)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := prepared.Request()
+		input.Outpoints[0] = "edited"
+		copy := prepared.Request()
+		copy.Outpoints[0] = "edited accessor"
+		coins[0].AmountSats = 1
+		if !reflect.DeepEqual(prepared.Request(), want) || prepared.SelectedTotal() != 50000 {
+			t.Fatal("prepared intent aliases mutable data")
+		}
+		if max && (want.AmountSats != 0 || !want.FundMax || want.SatPerVbyte != 0) {
+			t.Fatal("Max or automatic fee was replaced by a guessed value")
+		}
+	}
+}
+
+func TestChannelSubmissionPreflightAndOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*channelClient)
+		state ChannelOpenState
+		calls []string
+	}{
+		{"broadcast", func(c *channelClient) {}, ChannelBroadcast, []string{"connect", "wait", "coins", "fund"}},
+		{"already connected despite connect error", func(c *channelClient) { c.connectErr = errors.New("already connected") }, ChannelBroadcast, []string{"connect", "wait", "coins", "fund"}},
+		{"peer unavailable", func(c *channelClient) { c.waitErr = errors.New("peer timeout") }, ChannelNotSubmitted, []string{"connect", "wait"}},
+		{"coin query fails", func(c *channelClient) { c.listErr = errors.New("wallet locked") }, ChannelNotSubmitted, []string{"connect", "wait", "coins"}},
+		{"coin disappears while connecting", func(c *channelClient) { c.wait = func() { c.coins = nil } }, ChannelNotSubmitted, []string{"connect", "wait", "coins"}},
+		{"local adapter refusal", func(c *channelClient) { c.result = lndrpc.ChannelOpenResult{Err: errors.New("not connected")} }, ChannelNotSubmitted, []string{"connect", "wait", "coins", "fund"}},
+		{"response lost", func(c *channelClient) {
+			c.result = lndrpc.ChannelOpenResult{Submitted: true, Err: errors.New("deadline exceeded")}
+		}, ChannelOutcomeUnknown, []string{"connect", "wait", "coins", "fund"}},
+		{"no funding ID", func(c *channelClient) { c.result = lndrpc.ChannelOpenResult{Submitted: true} }, ChannelOutcomeUnknown, []string{"connect", "wait", "coins", "fund"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input, coins := channelInput()
+			p, err := PrepareChannelOpen(input, coins)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c := &channelClient{coins: coins, result: lndrpc.ChannelOpenResult{Submitted: true, FundingTxID: strings.Repeat("c", 64), OutputIndex: 7}}
+			tc.setup(c)
+			result := OpenChannel(c, p)
+			if result.State != tc.state || !reflect.DeepEqual(c.calls, tc.calls) {
+				t.Fatalf("result=%+v calls=%v", result, c.calls)
+			}
+			if len(c.sent) > 1 {
+				t.Fatal("funding was retried")
+			}
+			if len(c.sent) == 1 && !reflect.DeepEqual(c.sent[0], p.Request()) {
+				t.Fatal("submission differs from review")
+			}
+			if tc.state != ChannelBroadcast && result.Err == nil {
+				t.Fatal("failure lost its diagnostic")
+			}
+			if tc.state == ChannelBroadcast && (result.Txid == "" || result.OutputIndex != 7) {
+				t.Fatal("lost channel point")
+			}
+		})
+	}
+	c := &channelClient{}
+	if r := OpenChannel(c, PreparedChannelOpen{}); r.State != ChannelNotSubmitted || r.Err == nil || len(c.calls) != 0 {
+		t.Fatal("unprepared request started work")
+	}
+}

--- a/internal/lndrpc/channel_open_test.go
+++ b/internal/lndrpc/channel_open_test.go
@@ -1,0 +1,100 @@
+package lndrpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+type channelOpenRPC struct {
+	lnrpc.LightningClient
+	requests []*lnrpc.OpenChannelRequest
+	response *lnrpc.ChannelPoint
+	err      error
+}
+
+func (c *channelOpenRPC) OpenChannelSync(_ context.Context, req *lnrpc.OpenChannelRequest, _ ...grpc.CallOption) (*lnrpc.ChannelPoint, error) {
+	c.requests = append(c.requests, req)
+	return c.response, c.err
+}
+
+func TestChannelFundingWireBoundary(t *testing.T) {
+	rpc := &channelOpenRPC{}
+	client := &Client{lightning: rpc}
+	input := ChannelOpenRequest{
+		Pubkey:     "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		AmountSats: 250000, Private: true, Taproot: true, SatPerVbyte: 12,
+		Outpoints: []string{strings.Repeat("ab", 32) + ":7"}, SpendUnconfirmed: true,
+	}
+	for _, max := range []bool{false, true} {
+		input.FundMax = max
+		if max {
+			input.AmountSats = 0
+			input.SatPerVbyte = 0
+			input.Taproot = false
+			input.Private = false
+		}
+		client.OpenChannel(input)
+		req := rpc.requests[len(rpc.requests)-1]
+		wantType := lnrpc.CommitmentType_TAPROOT
+		if max {
+			wantType = lnrpc.CommitmentType_UNKNOWN_COMMITMENT_TYPE
+		}
+		if req.CommitmentType != wantType || req.FundMax != max || req.LocalFundingAmount != input.AmountSats ||
+			req.SatPerVbyte != input.SatPerVbyte || req.Private != input.Private || req.ScidAlias != input.Private ||
+			req.MinConfs != 0 || !req.SpendUnconfirmed || len(req.Outpoints) != 1 ||
+			req.Outpoints[0].TxidStr != strings.Repeat("ab", 32) || req.Outpoints[0].OutputIndex != 7 {
+			t.Fatalf("wire request changed the funding intent: %+v", req)
+		}
+	}
+	for _, invalid := range []ChannelOpenRequest{
+		{Pubkey: input.Pubkey},
+		{Pubkey: input.Pubkey, Outpoints: []string{input.Outpoints[0], "malformed"}},
+		{Pubkey: input.Pubkey, Outpoints: []string{input.Outpoints[0], input.Outpoints[0]}},
+		{Pubkey: input.Pubkey, Outpoints: input.Outpoints, Taproot: true},
+		{Pubkey: "invalid", Outpoints: input.Outpoints},
+		{Pubkey: input.Pubkey, Outpoints: input.Outpoints, FundMax: true, AmountSats: 250000},
+	} {
+		result := client.OpenChannel(invalid)
+		if result.Submitted || result.Err == nil || len(rpc.requests) != 2 {
+			t.Fatalf("invalid request reached funding RPC: %+v", result)
+		}
+	}
+}
+
+func TestChannelFundingResultBoundary(t *testing.T) {
+	raw := make([]byte, 32)
+	raw[0], raw[31] = 1, 2
+	valid := &lnrpc.ChannelPoint{FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{FundingTxidBytes: raw}, OutputIndex: 7}
+	input := ChannelOpenRequest{Pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", AmountSats: 250000,
+		Outpoints: []string{strings.Repeat("ab", 32) + ":7"}}
+	for _, tc := range []struct {
+		name     string
+		response *lnrpc.ChannelPoint
+		err      error
+		success  bool
+	}{
+		{"broadcast", valid, nil, true}, {"lost response", nil, errors.New("connection lost"), false},
+		{"empty response", nil, nil, false}, {"missing ID", &lnrpc.ChannelPoint{}, nil, false},
+		{"short ID", &lnrpc.ChannelPoint{FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{FundingTxidBytes: []byte{1}}}, nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := &channelOpenRPC{response: tc.response, err: tc.err}
+			result := (&Client{lightning: rpc}).OpenChannel(input)
+			if !result.Submitted || len(rpc.requests) != 1 {
+				t.Fatal("lost funding call ownership")
+			}
+			if tc.success {
+				if result.Err != nil || result.OutputIndex != 7 || result.FundingTxID != "02"+strings.Repeat("00", 30)+"01" {
+					t.Fatalf("bad funding result: %+v", result)
+				}
+			} else if result.Err == nil || result.FundingTxID != "" {
+				t.Fatalf("invalid response reported as broadcast: %+v", result)
+			}
+		})
+	}
+}

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -43,23 +43,6 @@ func TestWalletBalanceFields(t *testing.T) {
 	}
 }
 
-func TestChannelFields(t *testing.T) {
-	ch := Channel{Capacity: 1000000, LocalBalance: 600000, Active: true, PeerAlias: "ACINQ"}
-	if ch.Capacity != 1000000 {
-		t.Errorf("Capacity: got %d", ch.Capacity)
-	}
-	if ch.PeerAlias != "ACINQ" {
-		t.Errorf("PeerAlias: got %q", ch.PeerAlias)
-	}
-}
-
-func TestPendingChannelInfoFields(t *testing.T) {
-	info := &PendingChannelInfo{PendingOpen: 2}
-	if info.PendingOpen != 2 {
-		t.Errorf("PendingOpen: got %d", info.PendingOpen)
-	}
-}
-
 func TestSatStr(t *testing.T) {
 	tests := []struct {
 		input int64
@@ -100,7 +83,7 @@ func TestNilClientSafety(t *testing.T) {
 	if err := c.ConnectPeer("a", "b"); err == nil {
 		t.Error("should error")
 	}
-	if _, err := c.OpenChannel("a", 100000, false, false, nil, false, 0); err == nil {
+	if result := c.OpenChannel(ChannelOpenRequest{}); result.Err == nil || result.Submitted {
 		t.Error("should error")
 	}
 	if _, err := c.SendPayment("lnbc1"); err == nil {
@@ -184,57 +167,6 @@ func TestParseOutpoint(t *testing.T) {
 		if _, err := parseOutpoint(s); err == nil {
 			t.Errorf("accepted %q", s)
 		}
-	}
-}
-
-func TestBuildOpenChannelRequestUsesFinalTaproot(t *testing.T) {
-	txid := strings.Repeat("ab", 32)
-	req, err := buildOpenChannelRequest(
-		[]byte{2, 3, 4}, 250000, true, true,
-		[]string{txid + ":7"}, false, 12,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.CommitmentType != lnrpc.CommitmentType_TAPROOT {
-		t.Fatalf("commitment type=%v want=%v",
-			req.CommitmentType, lnrpc.CommitmentType_TAPROOT)
-	}
-	if req.LocalFundingAmount != 250000 || !req.Private ||
-		!req.ScidAlias || req.FundMax || req.SatPerVbyte != 12 {
-		t.Fatalf("unexpected open request: %+v", req)
-	}
-	if len(req.Outpoints) != 1 ||
-		req.Outpoints[0].TxidStr != txid ||
-		req.Outpoints[0].OutputIndex != 7 {
-		t.Fatalf("unexpected outpoints: %+v", req.Outpoints)
-	}
-}
-
-func TestBuildOpenChannelRequestDefaults(t *testing.T) {
-	req, err := buildOpenChannelRequest(
-		[]byte{2, 3, 4}, 250000, false, false,
-		nil, true, 0,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.CommitmentType != lnrpc.CommitmentType_UNKNOWN_COMMITMENT_TYPE {
-		t.Fatalf("commitment type=%v want default", req.CommitmentType)
-	}
-	if !req.FundMax || req.LocalFundingAmount != 0 {
-		t.Fatalf("fund-max request carries amount: %+v", req)
-	}
-}
-
-func TestBuildOpenChannelRequestRejectsPublicTaproot(t *testing.T) {
-	_, err := buildOpenChannelRequest(
-		[]byte{2, 3, 4}, 250000, false, true,
-		nil, false, 12,
-	)
-	if err == nil || !strings.Contains(err.Error(),
-		"taproot channels must be private") {
-		t.Fatalf("public Taproot request error=%v", err)
 	}
 }
 

--- a/internal/lndrpc/queries.go
+++ b/internal/lndrpc/queries.go
@@ -114,8 +114,23 @@ const (
 	WalletStateActive  WalletState = "SERVER_ACTIVE"
 )
 
+type ChannelOpenRequest struct {
+	Pubkey                    string
+	AmountSats                int64
+	Private, Taproot, FundMax bool
+	Outpoints                 []string
+	SatPerVbyte               uint64
+	MinConfs                  int32
+	SpendUnconfirmed          bool
+}
+
+// Submitted means the funding RPC was attempted, even if its response was lost.
+// It does not imply that LND accepted or broadcast the transaction.
 type ChannelOpenResult struct {
 	FundingTxID string
+	OutputIndex uint32
+	Submitted   bool
+	Err         error
 }
 
 type PeerInfo struct {
@@ -449,6 +464,7 @@ func (c *Client) ConnectPeer(pubkey, host string) error {
 		if strings.Contains(errStr, "already connected") {
 			return nil
 		}
+		logger.Status("LND peer connect warning: %v", err)
 		return err
 	}
 	return nil
@@ -472,87 +488,75 @@ func (c *Client) WaitForPeer(pubkey string, timeout time.Duration) error {
 	return fmt.Errorf("peer did not connect within %s", timeout)
 }
 
-// OpenChannel opens a channel to a peer. This is a fund-moving operation.
-// The caller MUST verify the peer is connected and show a confirmation
-// dialog before calling this. When outpoints is non-empty, only those
-// UTXOs are used to fund the channel (coin control). When fundMax is
-// true, the entire selected balance (minus fees) funds the channel,
-// producing no change output.
-func (c *Client) OpenChannel(pubkey string, localAmount int64, private bool, taproot bool, outpoints []string, fundMax bool, satPerVbyte uint64) (*ChannelOpenResult, error) {
+// OpenChannel submits one funding request. The explicit outpoints restrict LND's
+// funding pool; LND determines which coins to use and whether change is needed.
+func (c *Client) OpenChannel(input ChannelOpenRequest) ChannelOpenResult {
 	rpc := c.rpc()
 	if rpc == nil {
-		return nil, errNotConnected
+		return ChannelOpenResult{Err: errNotConnected}
 	}
-
-	pubkeyBytes, err := hex.DecodeString(pubkey)
+	req, err := buildOpenChannelRequest(input)
 	if err != nil {
-		return nil, fmt.Errorf("invalid pubkey: %w", err)
+		return ChannelOpenResult{Err: err}
 	}
-	req, err := buildOpenChannelRequest(
-		pubkeyBytes, localAmount, private, taproot, outpoints,
-		fundMax, satPerVbyte,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	ctx, cancel := c.callCtx(120 * time.Second)
 	defer cancel()
-
 	resp, err := rpc.OpenChannelSync(ctx, req)
+	result := ChannelOpenResult{Submitted: true, Err: err}
 	if err != nil {
 		c.handleError(err)
-		return nil, err
+		return result
 	}
-
 	txidBytes := resp.GetFundingTxidBytes()
-	txid := fmt.Sprintf("%x", txidBytes)
-	if len(txidBytes) == 32 {
-		reversed := make([]byte, 32)
-		for i := 0; i < 32; i++ {
-			reversed[i] = txidBytes[31-i]
-		}
-		txid = fmt.Sprintf("%x", reversed)
+	if len(txidBytes) != 32 {
+		result.Err = fmt.Errorf("LND returned an invalid funding transaction ID")
+		return result
 	}
-	return &ChannelOpenResult{FundingTxID: txid}, nil
+	reversed := make([]byte, 32)
+	for i := range reversed {
+		reversed[i] = txidBytes[31-i]
+	}
+	result.FundingTxID = hex.EncodeToString(reversed)
+	result.OutputIndex = resp.GetOutputIndex()
+	return result
 }
 
-func buildOpenChannelRequest(
-	pubkeyBytes []byte, localAmount int64, private, taproot bool,
-	outpoints []string, fundMax bool, satPerVbyte uint64,
-) (*lnrpc.OpenChannelRequest, error) {
-	if taproot && !private {
+func buildOpenChannelRequest(input ChannelOpenRequest) (*lnrpc.OpenChannelRequest, error) {
+	if input.Taproot && !input.Private {
 		return nil, fmt.Errorf("taproot channels must be private")
 	}
-
+	pubkey, err := hex.DecodeString(input.Pubkey)
+	if err != nil || len(pubkey) != 33 {
+		return nil, fmt.Errorf("invalid node public key")
+	}
+	if len(input.Outpoints) == 0 {
+		return nil, fmt.Errorf("channel funding requires explicit coin selection")
+	}
+	if input.FundMax && input.AmountSats != 0 {
+		return nil, fmt.Errorf("fund-max request must not carry a fixed amount")
+	}
 	req := &lnrpc.OpenChannelRequest{
-		NodePubkey:       pubkeyBytes,
-		Private:          private,
-		MinConfs:         0,
-		SpendUnconfirmed: true,
-		ScidAlias:        private,
-		FundMax:          fundMax,
+		NodePubkey: pubkey, LocalFundingAmount: input.AmountSats,
+		Private: input.Private, MinConfs: input.MinConfs,
+		SpendUnconfirmed: input.SpendUnconfirmed, ScidAlias: input.Private,
+		FundMax: input.FundMax, SatPerVbyte: input.SatPerVbyte,
 	}
-	if !fundMax {
-		req.LocalFundingAmount = localAmount
-	}
-	if taproot {
+	if input.Taproot {
 		req.CommitmentType = lnrpc.CommitmentType_TAPROOT
 	}
-	if satPerVbyte > 0 {
-		req.SatPerVbyte = satPerVbyte
-	}
-
-	// Coin control: restrict inputs to the selected UTXOs. A
-	// malformed outpoint aborts the whole operation — silently
-	// skipping one would widen coin selection past what the
-	// operator chose.
-	for _, op := range outpoints {
-		outPoint, err := parseOutpoint(op)
+	// Reject the entire selection if any outpoint is malformed or duplicated.
+	seen := make(map[string]bool, len(input.Outpoints))
+	for _, op := range input.Outpoints {
+		outpoint, err := parseOutpoint(op)
 		if err != nil {
 			return nil, err
 		}
-		req.Outpoints = append(req.Outpoints, outPoint)
+		identity := fmt.Sprintf("%s:%d", strings.ToLower(outpoint.TxidStr), outpoint.OutputIndex)
+		if seen[identity] {
+			return nil, fmt.Errorf("duplicate selected outpoint: %s", op)
+		}
+		seen[identity] = true
+		req.Outpoints = append(req.Outpoints, outpoint)
 	}
 	return req, nil
 }

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -107,38 +107,14 @@ func removeSyncthingDeviceCmd(
 
 // ── LND queries & fund-moving ────────────────────────────
 
-func openChannelCmd(
-	client *lndrpc.Client, pubkey, host string,
-	amount int64, private bool, taproot bool,
-	outpoints []string, fundMax bool,
-	satPerVbyte uint64,
-) tea.Cmd {
+type channelOpenAttempt struct {
+	prepared app.PreparedChannelOpen
+	alias    string
+}
+
+func openChannelCmd(client app.ChannelOpenClient, attempt *channelOpenAttempt) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return channelOpenResultMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		if host != "" {
-			if err := client.ConnectPeer(
-				pubkey, host); err != nil {
-				logger.TUI(
-					"Peer connect warning: %v", err)
-			}
-		}
-		if err := client.WaitForPeer(
-			pubkey, 60*time.Second); err != nil {
-			return channelOpenResultMsg{
-				err: fmt.Errorf(
-					"could not connect: %v", err)}
-		}
-		result, err := client.OpenChannel(
-			pubkey, amount, private, taproot,
-			outpoints, fundMax, satPerVbyte)
-		if err != nil {
-			return channelOpenResultMsg{err: err}
-		}
-		return channelOpenResultMsg{
-			txid: result.FundingTxID}
+		return channelOpenResultMsg{attempt: attempt, result: app.OpenChannel(client, attempt.prepared)}
 	}
 }
 

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -107,16 +107,6 @@ func formatFeeHints(tiers [4]feeTier) string {
 	return strings.Join(parts, "  ·  ")
 }
 
-// estimateSimpleFee estimates the transaction fee in
-// sats given the number of inputs, outputs, and the
-// fee rate in sat/vB. Uses simplified vbyte estimation.
-func estimateSimpleFee(
-	numInputs, numOutputs int, satPerVB int64,
-) int64 {
-	vbytes := int64(10 + numInputs*68 + numOutputs*31)
-	return vbytes * satPerVB
-}
-
 // renderViewport creates a local viewport, sets content,
 // auto-scrolls to keep cursorLine visible, and returns the
 // rendered view with scroll indicators overlaid.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -145,8 +145,8 @@ type syncthingDevicesMsg struct {
 	err     error
 }
 type channelOpenResultMsg struct {
-	txid string
-	err  error
+	attempt *channelOpenAttempt
+	result  app.ChannelOpenResult
 }
 type newAddressMsg struct {
 	address string

--- a/internal/tui/screen_channels_open.go
+++ b/internal/tui/screen_channels_open.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -70,7 +71,6 @@ type ChannelOpenScreen struct {
 	// Amount selection
 	amountIdx   int // 0=coin control btn, 1=amount
 	amountInput AmountInput
-	amount      int64
 	fundMax     bool
 
 	// Fee rate
@@ -83,15 +83,15 @@ type ChannelOpenScreen struct {
 	toggleIdx int
 
 	// UTXO selection (coin control)
-	utxos             []lndrpc.UTXO
-	txs               []lndrpc.OnChainTx
-	utxoSelected      map[int]bool
-	utxoSelectedTotal int64
-	utxoOutpoints     []string
-	utxoCursor        int
-	utxoFetched       bool // lazy fetch guard
-	ccZone            int  // sub-step focus zone
-	ccBtnIdx          int  // sub-step button index
+	utxos       []lndrpc.UTXO
+	txs         []lndrpc.OnChainTx
+	selection   app.CoinSelection
+	refresh     *channelOpenRefresh
+	utxoErr     error
+	utxoCursor  int
+	utxoFetched bool
+	ccZone      int // sub-step focus zone
+	ccBtnIdx    int // sub-step button index
 
 	// Selection state (✓ indicators)
 	peerConfirmed   bool
@@ -107,9 +107,10 @@ type ChannelOpenScreen struct {
 	confirmBtnIdx int
 
 	// Result
-	inFlight bool
-	txid     string
-	error    string
+	client  app.ChannelOpenClient
+	attempt *channelOpenAttempt
+	result  app.ChannelOpenResult
+	error   string
 }
 
 func NewChannelOpenScreen(
@@ -127,7 +128,9 @@ func NewChannelOpenScreen(
 		pubkeyInput:  newChanPubkeyInput(),
 		hostInput:    newChanHostInput(),
 		customBtnIdx: 1,
-		utxoSelected: make(map[int]bool),
+	}
+	if ctx.LndClient != nil {
+		s.client = ctx.LndClient
 	}
 	return s
 }
@@ -135,10 +138,7 @@ func NewChannelOpenScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *ChannelOpenScreen) Init() tea.Cmd {
-	return tea.Batch(
-		fetchChannelUtxosCmd(s.ctx.LndClient),
-		fetchChannelTxsCmd(s.ctx.LndClient),
-		fetchFeeTiersCmd(s.ctx.Cfg))
+	return tea.Batch(s.refreshCoins(), fetchFeeTiersCmd(s.ctx.Cfg))
 }
 
 func (s *ChannelOpenScreen) HandleKey(
@@ -166,13 +166,10 @@ func (s *ChannelOpenScreen) HandleMsg(
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tabActivatedMsg:
-		// Always refetch on tab re-focus so data
-		// reflects any changes since last viewed,
-		// matching channel history's pattern.
-		return s, tea.Batch(
-			fetchChannelUtxosCmd(s.ctx.LndClient),
-			fetchChannelTxsCmd(s.ctx.LndClient),
-			fetchFeeTiersCmd(s.ctx.Cfg))
+		if s.step >= coStepOpening {
+			return s, nil
+		}
+		return s, tea.Batch(s.refreshCoins(), fetchFeeTiersCmd(s.ctx.Cfg))
 	case tea.PasteMsg:
 		return s.handlePaste(msg)
 	case channelOpenResultMsg:
@@ -200,7 +197,7 @@ func (s *ChannelOpenScreen) View(w, h int) string {
 	case coStepOpening:
 		return s.viewOpening(w, h)
 	case coStepResult:
-		return s.viewResult(w)
+		return s.viewResult(w, h)
 	}
 	return ""
 }
@@ -217,7 +214,7 @@ func (s *ChannelOpenScreen) HelpBindings() []key.Binding {
 		return actionButtonBindings(
 			s.confirmBtnIdx, s.ctx.HasTabs)
 	case coStepOpening:
-		return inFlightBindings()
+		return []key.Binding{kSidebar, kUpShiftTabBar}
 	case coStepResult:
 		return resultBindings(s.ctx.HasTabs)
 	}
@@ -499,9 +496,8 @@ func (s *ChannelOpenScreen) handleButtonKey(
 	case "enter":
 		switch s.btnIdx {
 		case 0: // Clear
-			return s.clearForm(), tea.Batch(
-				fetchChannelUtxosCmd(s.ctx.LndClient),
-				fetchChannelTxsCmd(s.ctx.LndClient))
+			s.clearForm()
+			return s, s.refreshCoins()
 		case 1: // Open Channel
 			return s.submitOpenChannel()
 		}
@@ -600,24 +596,18 @@ func (s *ChannelOpenScreen) handlePaste(
 func (s *ChannelOpenScreen) handleOpenResult(
 	msg channelOpenResultMsg,
 ) (Screen, tea.Cmd) {
-	s.inFlight = false
-	if msg.err != nil {
-		s.error = msg.err.Error()
-	} else {
-		s.txid = msg.txid
-		s.error = ""
+	if s.step != coStepOpening || s.attempt == nil || msg.attempt != s.attempt {
+		return s, nil
 	}
+	s.result = msg.result
 	s.step = coStepResult
-	if msg.err == nil {
-		return s, emitRefreshStatus
-	}
-	return s, nil
+	return s, emitRefreshStatus
 }
 
 func (s *ChannelOpenScreen) handleFeeTiers(
 	msg feeTiersMsg,
 ) (Screen, tea.Cmd) {
-	if msg.err != nil {
+	if msg.err != nil || s.step >= coStepConfirm {
 		return s, nil
 	}
 	s.feeTiers = msg.tiers
@@ -632,21 +622,10 @@ func (s *ChannelOpenScreen) handleFeeTiers(
 
 // ── Form actions ───────────────────────────────────────
 
-// validateCustomAmount checks the custom amount field is
-// non-empty and within the 20,000 — 1,000,000,000 sats
-// channel-size bounds. The upper bound matches LND's wumbo
-// channel limit (10 BTC) enabled via protocol.wumbo-channels
-// in lnd.conf.
 func (s *ChannelOpenScreen) validateCustomAmount() (int64, string) {
-	if s.amountInput.Empty() {
-		return 0, "empty amount"
-	}
 	n := s.amountInput.Sats()
-	if n < 20000 {
-		return 0, "min 20,000 sats"
-	}
-	if n > 1000000000 {
-		return 0, "max 1,000,000,000 sats (10 BTC)"
+	if err := app.ValidateChannelAmount(n); err != nil {
+		return 0, err.Error()
 	}
 	return n, ""
 }
@@ -661,10 +640,9 @@ func (s *ChannelOpenScreen) confirmAmountAndAdvance() bool {
 		return false
 	}
 	s.error = ""
-	s.amount = n
 	// FundMax when amount matches selected UTXO total
-	s.fundMax = len(s.utxoSelected) > 0 &&
-		n == s.utxoSelectedTotal
+	total, err := s.selection.Total(s.utxos)
+	s.fundMax = err == nil && s.selection.Len() > 0 && n == total
 	s.amountConfirmed = true
 	s.amountInput.Blur()
 	s.focusZone = coZoneFee
@@ -672,36 +650,13 @@ func (s *ChannelOpenScreen) confirmAmountAndAdvance() bool {
 	return true
 }
 
-// ── Backward-entry helpers ─────────────────────────────
-//
-// When focus returns to a zone from forward (via
-// shift+tab or up), that zone's "confirmed" state is
-// dropped — the user is re-entering to potentially make
-// changes. The cursor lands on the same item they
-// previously committed (so they can see where they were),
-// but there's no checkmark. Committing requires explicit
-// forward navigation (enter/tab/down).
-//
-// Each helper owns one zone's reset logic. Handlers in
-// other zones call these when their keystrokes cause a
-// backward transition, rather than inlining the reset.
-// See design-decisions.md: "Backward-entry helpers for
-// multi-zone form screens."
-
-// enterPeersBackward: focus returned to peers from the
-// amounts zone. Decommits the peer while keeping the
-// cursor on the previously-selected row.
+// Backward navigation keeps entered values but requires another explicit review.
 func (s *ChannelOpenScreen) enterPeersBackward() {
 	s.focusZone = coZonePeers
 	s.peerConfirmed = false
 	s.error = ""
 }
 
-// enterAmountsBackward: focus returned to amounts from
-// the fee zone. Decommits the amount but preserves the
-// value in the input for review/editing. If there's a
-// committed amount, populates the AmountInput so the
-// user can arrow left/right through the number.
 func (s *ChannelOpenScreen) enterAmountsBackward() {
 	s.focusZone = coZoneAmounts
 	s.amountConfirmed = false
@@ -710,26 +665,18 @@ func (s *ChannelOpenScreen) enterAmountsBackward() {
 	s.amountInput.Focus()
 }
 
-// enterFeeBackward: focus returned to fee from the
-// toggles zone. Refocuses the fee input for editing.
 func (s *ChannelOpenScreen) enterFeeBackward() {
 	s.focusZone = coZoneFee
 	s.feeInput.Focus()
 	s.error = ""
 }
 
-// enterTogglesBackward: focus returned to toggles from
-// the buttons zone. Toggles have no "draft vs committed"
-// distinction — each toggle is its own commit — so the
-// only state to reset is the error message. Included for
-// symmetry so the navigation handlers in the buttons zone
-// don't inline the focus assignment.
 func (s *ChannelOpenScreen) enterTogglesBackward() {
 	s.focusZone = coZoneToggles
 	s.error = ""
 }
 
-func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
+func (s *ChannelOpenScreen) clearForm() {
 	s.peerIdx = 0
 	s.peerConfirmed = false
 	s.customPubkey = ""
@@ -738,7 +685,6 @@ func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
 	s.amountIdx = 0
 	s.amountConfirmed = false
 	s.amountInput.Clear()
-	s.amount = 0
 	s.fundMax = false
 	s.feeInput = NewFeeInput()
 	if s.feeTiers[0].SatPerVB > 0 {
@@ -748,79 +694,46 @@ func (s *ChannelOpenScreen) clearForm() *ChannelOpenScreen {
 	s.private = true
 	s.taproot = true
 	s.toggleIdx = 0
-	s.utxoSelected = make(map[int]bool)
-	s.utxoSelectedTotal = 0
-	s.utxoOutpoints = nil
+	s.selection.Clear()
+	s.utxoErr = nil
+	s.attempt = nil
+	s.refresh = nil
 	s.utxoCursor = 0
 	s.utxoFetched = false
 	s.txs = nil
 	s.focusZone = coZonePeers
 	s.btnIdx = 1
 	s.error = ""
-	return s
 }
 
 func (s *ChannelOpenScreen) submitOpenChannel() (
 	Screen, tea.Cmd,
 ) {
-	if s.taproot && !s.private {
-		s.error = "Taproot channels must be private"
-		return s, nil
-	}
-
-	// Validate peer confirmed
 	if !s.peerConfirmed {
 		s.error = "Select a peer first"
 		return s, nil
 	}
-	pubkey := s.selectedPubkey()
-	if pubkey == "" {
-		s.error = "Select a peer first"
-		return s, nil
-	}
-
-	// Mandatory coin control
-	if len(s.utxoSelected) == 0 {
-		s.error = "Select UTXOs in Coin control first"
-		return s, nil
-	}
-
-	// Validate amount confirmed
 	if !s.amountConfirmed {
 		s.error = "Select a channel size first"
 		return s, nil
 	}
-
-	// Validate amount value
-	if !s.fundMax {
-		n, errMsg := s.validateCustomAmount()
-		if errMsg != "" {
-			s.error = errMsg
-			return s, nil
-		}
-		s.amount = n
-	}
-
-	// FundMax minimum check
-	if s.fundMax && s.utxoSelectedTotal < 20000 {
-		s.error = "min 20,000 sats"
+	if s.utxoErr != nil {
+		s.error = s.utxoErr.Error()
 		return s, nil
 	}
-
-	// Custom amount vs selected UTXOs check
-	feeRate := s.feeInput.Sats()
-	if !s.fundMax {
-		estFee := estimateSimpleFee(
-			len(s.utxoSelected), 2, feeRate)
-		if s.amount+estFee > s.utxoSelectedTotal {
-			s.error = "Amount plus fee exceeds " +
-				"selected UTXOs"
-			return s, nil
-		}
+	prepared, err := app.PrepareChannelOpen(app.ChannelOpenInput{
+		Pubkey: s.selectedPubkey(), Host: s.selectedHost(),
+		AmountSats: s.amountInput.Sats(), FundMax: s.fundMax,
+		Private: s.private, Taproot: s.taproot, SatPerVbyte: s.feeInput.Sats(),
+		Outpoints: s.selection.Outpoints(),
+	}, s.utxos)
+	if err != nil {
+		s.error = err.Error()
+		return s, nil
 	}
-
+	s.attempt = &channelOpenAttempt{prepared: prepared, alias: s.selectedAlias()}
 	s.error = ""
-	s.confirmBtnIdx = 1
+	s.confirmBtnIdx = 0
 	s.step = coStepConfirm
 	return s, nil
 }
@@ -968,14 +881,9 @@ func (s *ChannelOpenScreen) viewInput(
 		ccPrefix = theme.NavActive.Render("▸")
 		ccStyle = theme.Action
 	}
-	var ccLabel string
-	if len(s.utxoSelected) > 0 {
-		ccLabel = fmt.Sprintf(
-			"[Coin control: %d UTXO (%s sats)]",
-			len(s.utxoSelected),
-			formatSats(s.utxoSelectedTotal))
-	} else {
-		ccLabel = "[Coin control]"
+	ccLabel := "[Coin control]"
+	if s.selection.Len() > 0 {
+		ccLabel = "[Coin control: " + s.selectionSummary() + "]"
 	}
 	p.line(fmt.Sprintf("%s %s",
 		ccPrefix, ccStyle.Render(ccLabel)))
@@ -993,45 +901,18 @@ func (s *ChannelOpenScreen) viewInput(
 		amtStyle = theme.Action
 	}
 
-	hasCoinCtrl := len(s.utxoSelected) > 0
 	if s.amountConfirmed && !s.amountInput.Focused() {
-		// Auto-confirmed or committed state
-		annotation := ""
-		if hasCoinCtrl &&
-			s.amount == s.utxoSelectedTotal {
-			annotation = theme.Dim.Render(
-				"  full UTXO(s), no change")
+		label := formatSats(s.amountInput.Sats()) + " sats"
+		if s.fundMax {
+			label = "Max (capacity determined by LND)"
 		}
-		p.line(fmt.Sprintf("%s %s%s",
-			amtPrefix,
-			amtStyle.Render(
-				formatSats(s.amount)+" sats"),
-			annotation))
+		p.line(fmt.Sprintf("%s %s", amtPrefix, amtStyle.Render(label)))
 	} else {
-		// Editing state with input field
-		inputW := w - 14
-		if inputW > 20 {
-			inputW = 20
+		s.amountInput.SetWidth(min(w-14, 20))
+		p.line(fmt.Sprintf("%s %s %s", amtPrefix, amtStyle.Render("Amount:"), s.amountInput.View()))
+		if total, err := s.selection.Total(s.utxos); err == nil && total > 0 && s.amountInput.Sats() == total {
+			p.dim(" Max: LND determines capacity and any change.")
 		}
-		s.amountInput.SetWidth(inputW)
-		amtLine := fmt.Sprintf("%s %s %s",
-			amtPrefix,
-			amtStyle.Render("Amount:"),
-			s.amountInput.View())
-		// Change annotation
-		if hasCoinCtrl && !s.amountInput.Empty() {
-			typed := s.amountInput.Sats()
-			if typed == s.utxoSelectedTotal {
-				amtLine += theme.Dim.Render(
-					"  full UTXO(s), no change")
-			} else if typed < s.utxoSelectedTotal {
-				change := s.utxoSelectedTotal - typed
-				amtLine += theme.Warning.Render(
-					fmt.Sprintf("  ~%s sats change",
-						formatSats(change)))
-			}
-		}
-		p.line(amtLine)
 	}
 	p.blank()
 

--- a/internal/tui/screen_channels_open_confirm.go
+++ b/internal/tui/screen_channels_open_confirm.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -42,30 +44,33 @@ func (s *ChannelOpenScreen) handleConfirmKey(
 			s.backToInput()
 			return s, nil
 		case 1: // Confirm
-			if s.inFlight {
+			if s.attempt == nil {
 				return s, nil
 			}
-			s.inFlight = true
+			if !slices.Equal(s.selection.Outpoints(), s.attempt.prepared.Request().Outpoints) {
+				s.backToInput()
+				s.error = "Coin selection changed. Review the channel again"
+				return s, nil
+			}
+			if s.utxoErr != nil {
+				s.error = s.utxoErr.Error()
+				return s, nil
+			}
+			if _, err := s.selection.Total(s.utxos); err != nil {
+				s.error = err.Error()
+				return s, nil
+			}
+			s.refresh = nil
 			s.error = ""
 			s.step = coStepOpening
-			feeRate := s.feeInput.Sats()
-			return s, openChannelCmd(
-				s.ctx.LndClient,
-				s.selectedPubkey(),
-				s.selectedHost(),
-				s.amount,
-				s.private,
-				s.taproot,
-				s.utxoOutpoints,
-				s.fundMax,
-				uint64(feeRate),
-			)
+			return s, openChannelCmd(s.client, s.attempt)
 		}
 	}
 	return s, nil
 }
 
 func (s *ChannelOpenScreen) backToInput() {
+	s.attempt = nil
 	s.step = coStepInput
 	s.error = ""
 	s.confirmBtnIdx = 0
@@ -78,7 +83,12 @@ func (s *ChannelOpenScreen) backToInput() {
 func (s *ChannelOpenScreen) handleOpeningKey(
 	keyStr string,
 ) (Screen, tea.Cmd) {
-	// Fund-moving operation in progress — block all keys.
+	switch keyStr {
+	case "left":
+		return s, emitFocusSidebar
+	case "up", "shift+tab":
+		return s, emitFocusTabBar
+	}
 	return s, nil
 }
 
@@ -91,9 +101,7 @@ func (s *ChannelOpenScreen) handleResultKey(
 	case "ctrl+c":
 		return s, tea.Quit
 	case "enter":
-		return s, tea.Batch(
-			emitCloseTab,
-			emitRefreshStatus)
+		return s, func() tea.Msg { return closeChannelOpenMsg{screen: s} }
 	case "left":
 		return s, emitFocusSidebar
 	case "up", "shift+tab":
@@ -106,146 +114,76 @@ func (s *ChannelOpenScreen) handleResultKey(
 	return s, nil
 }
 
-// ── Confirm view ───────────────────────────────────────
+type closeChannelOpenMsg struct{ screen *ChannelOpenScreen }
 
-func (s *ChannelOpenScreen) viewConfirm(
-	w, h int,
-) string {
+func channelOpenBusy(screen Screen) bool {
+	s, ok := screen.(*ChannelOpenScreen)
+	return ok && s.step == coStepOpening
+}
+
+func (s *ChannelOpenScreen) viewConfirm(w, h int) string {
 	p := newPane(w)
 	p.title(theme.Warning, "Confirm Channel Open")
-
-	p.field("Peer:    ", s.selectedAlias())
-
-	// Estimate fee for display
-	feeRate := s.feeInput.Sats()
-	numInputs := len(s.utxoSelected)
-	numOutputs := 1
-	if !s.fundMax {
-		numOutputs = 2 // channel + change
-	}
-	estFee := estimateSimpleFee(
-		numInputs, numOutputs, feeRate)
-
-	if s.fundMax {
-		chanAmt := s.utxoSelectedTotal - estFee
-		if chanAmt < 0 {
-			chanAmt = 0
-		}
-		p.field("Amount:  ",
-			fmt.Sprintf("~%s sats (full UTXO(s) minus fee)",
-				formatSats(chanAmt)))
+	req := s.attempt.prepared.Request()
+	p.field("Peer: ", s.attempt.alias)
+	p.monoWrap(req.Pubkey)
+	if req.FundMax {
+		p.line("Capacity: Max (determined by LND)")
 	} else {
-		p.field("Amount:  ",
-			formatSats(s.amount)+" sats")
+		p.line("Capacity: " + formatSats(req.AmountSats) + " sats")
 	}
-
-	chanType := "public"
-	if s.private {
-		chanType = "private"
+	kind := "public"
+	if req.Private {
+		kind = "private"
 	}
-	if s.taproot {
-		chanType += ", taproot"
+	if req.Taproot {
+		kind += ", taproot"
 	}
-	p.field("Type:    ", chanType)
-
-	if feeRate > 0 {
-		p.field("Fee:     ",
-			fmt.Sprintf("%d sat/vB (~%s sats)",
-				feeRate, formatSats(estFee)))
+	p.field("Type: ", kind)
+	p.line(fmt.Sprintf("Funding pool: %d selected (%s sats)", len(req.Outpoints), formatSats(s.attempt.prepared.SelectedTotal())))
+	p.line("LND may use a subset; no other coins are allowed.")
+	p.line("Unconfirmed inputs: allowed, subject to LND checks")
+	if req.SatPerVbyte == 0 {
+		p.line("Fee rate: auto (LND default)")
 	} else {
-		p.field("Fee:     ", "auto (LND default)")
+		p.line(fmt.Sprintf("Fee rate: %d sat/vB", req.SatPerVbyte))
 	}
-
-	if len(s.utxoSelected) > 0 {
-		p.field("UTXOs:   ",
-			fmt.Sprintf("%d selected (%s sats)",
-				len(s.utxoSelected),
-				formatSats(s.utxoSelectedTotal)))
+	p.line("Total fee and change: unavailable before funding")
+	if req.FundMax {
+		p.line("Max deducts fees and may leave change for reserves or limits.")
 	}
-
-	// Change warning for custom amount with coin control
-	if !s.fundMax && len(s.utxoSelected) > 0 &&
-		s.amount < s.utxoSelectedTotal {
-		change := s.utxoSelectedTotal -
-			s.amount - estFee
-		if change > 0 {
-			p.field("Change:  ",
-				theme.Warning.Render(
-					fmt.Sprintf("~%s sats",
-						formatSats(change))))
-		}
-	}
-
-	p.blank()
-
-	p.labelLine("Pubkey:")
-	p.mono(s.selectedPubkey())
-	p.blank()
-
-	if s.fundMax {
-		p.warn("Spend full UTXO(s) amount minus fee?")
-	} else {
-		p.warn("Spend " +
-			formatSats(s.amount) + " sats?")
-	}
-
 	p.appendError(s.error)
-
-	return p.renderWithBottomButtons(
-		[]string{"Go Back", "Confirm"},
-		s.confirmBtnIdx, s.ctx.ContentFocused, h)
+	return p.renderWithBottomButtons([]string{"Go Back", "Confirm"}, s.confirmBtnIdx, s.ctx.ContentFocused, h)
 }
 
-// ── Opening view ───────────────────────────────────────
-
-func (s *ChannelOpenScreen) viewOpening(
-	w, h int,
-) string {
+func (s *ChannelOpenScreen) viewOpening(w, h int) string {
 	p := newPane(w)
 	p.title(theme.Header, "Opening Channel...")
-	p.line(" " + theme.Value.Render(
-		"Connecting to peer and broadcasting tx."))
+	p.valueWrap("Connecting to peer, checking selected coins and requesting funding.")
 	p.blank()
-	p.dim("May take up to 2 minutes over Tor.")
+	p.dim("This may take several minutes over Tor.")
 	p.dim("Do not close the terminal.")
-	return p.renderWithBottomButtons(
-		[]string{"Opening..."}, 0, false, h)
+	return p.renderWithBottomButtons([]string{"Opening..."}, 0, false, h)
 }
 
-// ── Result view ────────────────────────────────────────
-
-func (s *ChannelOpenScreen) viewResult(
-	w int,
-) string {
+func (s *ChannelOpenScreen) viewResult(w, h int) string {
 	p := newPane(w)
-
-	if s.error != "" {
-		p.title(theme.Warning, "Channel Open Failed")
-		p.warnWrap(s.error)
-	} else {
+	switch s.result.State {
+	case app.ChannelBroadcast:
 		p.title(theme.Success, "Channel Opening")
-		p.line(" " + theme.Value.Render(
-			"Funding tx broadcast successfully."))
-		p.blank()
-		p.field("Peer:   ", s.selectedAlias())
-		if s.fundMax {
-			p.field("Amount: ",
-				fmt.Sprintf(
-					"Max (%s sats minus fee)",
-					formatSats(
-						s.utxoSelectedTotal)))
-		} else {
-			p.field("Amount: ",
-				formatSats(s.amount)+" sats")
-		}
-		if s.txid != "" {
-			p.blank()
-			p.labelLine("TX ID:")
-			p.monoWrap(s.txid)
-		}
-		p.blank()
-		p.dim("Channel will appear as pending.")
+		p.line("Funding tx broadcast successfully.")
+		p.field("Peer: ", s.attempt.alias)
+		p.labelLine("TX ID:")
+		p.monoWrap(s.result.Txid)
+		p.dim("Channel is pending; it is not active yet.")
+	case app.ChannelOutcomeUnknown:
+		p.title(theme.Warning, "Channel Open Outcome Unknown")
+		p.warnWrapWords("Check pending channels and transaction history before attempting another open. Funding may still complete.")
+	default:
+		p.title(theme.Warning, "Channel Not Submitted")
 	}
-
-	return p.render()
+	if s.result.Err != nil {
+		p.warnWrap(s.result.Err.Error())
+	}
+	return p.renderWithBottomButtons([]string{"Done"}, 0, s.ctx.ContentFocused, h)
 }

--- a/internal/tui/screen_channels_open_custom.go
+++ b/internal/tui/screen_channels_open_custom.go
@@ -1,11 +1,10 @@
 package tui
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -193,20 +192,9 @@ func (s *ChannelOpenScreen) handleCustomButtonKey(
 func (s *ChannelOpenScreen) submitCustomPeer() (
 	Screen, tea.Cmd,
 ) {
-	pubkey := strings.TrimSpace(
-		s.pubkeyInput.Value())
-	host := strings.TrimSpace(
-		s.hostInput.Value())
-	if pubkey == "" {
-		s.error = "Pubkey is required"
-		return s, nil
-	}
-	if len(pubkey) != 66 {
-		s.error = "Pubkey must be 66 hex chars"
-		return s, nil
-	}
-	if host == "" {
-		s.error = "Host required"
+	pubkey, host, err := app.ValidateChannelPeer(s.pubkeyInput.Value(), s.hostInput.Value())
+	if err != nil {
+		s.error = err.Error()
 		return s, nil
 	}
 	s.customPubkey = pubkey

--- a/internal/tui/screen_channels_open_test.go
+++ b/internal/tui/screen_channels_open_test.go
@@ -1,6 +1,18 @@
 package tui
 
-import "testing"
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"errors"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestChannelOpenRejectsInvalidTaprootPrivacyToggles(t *testing.T) {
 	t.Run("public while Taproot", func(t *testing.T) {
@@ -28,4 +40,210 @@ func TestChannelOpenRejectsInvalidTaprootPrivacyToggles(t *testing.T) {
 				s.taproot, s.error)
 		}
 	})
+}
+
+type screenChannelClient struct {
+	coins  []lndrpc.UTXO
+	sent   []lndrpc.ChannelOpenRequest
+	result lndrpc.ChannelOpenResult
+}
+
+func (c *screenChannelClient) ConnectPeer(string, string) error                { return nil }
+func (c *screenChannelClient) WaitForPeer(string, time.Duration) error         { return nil }
+func (c *screenChannelClient) ListUnspent(int32, int32) ([]lndrpc.UTXO, error) { return c.coins, nil }
+func (c *screenChannelClient) OpenChannel(req lndrpc.ChannelOpenRequest) lndrpc.ChannelOpenResult {
+	c.sent = append(c.sent, req)
+	return c.result
+}
+
+func channelScreen(t *testing.T) (*ChannelOpenScreen, *screenChannelClient) {
+	t.Helper()
+	coin := lndrpc.UTXO{Txid: strings.Repeat("a", 64), AmountSats: 50000}
+	c := &screenChannelClient{coins: []lndrpc.UTXO{coin}, result: lndrpc.ChannelOpenResult{Submitted: true, FundingTxID: strings.Repeat("c", 64)}}
+	s := NewChannelOpenScreen(&ScreenContext{Cfg: config.Default(), State: &RuntimeState{}})
+	s.client = c
+	s.peerIdx = len(s.peerList)
+	s.customPubkey = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+	s.customHost = "peer.onion:9735"
+	s.customAlias = "reviewed peer"
+	s.peerConfirmed = true
+	s.refreshCoins()
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, utxos: c.coins})
+	s.toggleUtxoSelection(0)
+	s.returnFromCoinControl(true)
+	s.feeInput.SetSats(9)
+	return s, c
+}
+
+func confirmChannel(t *testing.T, s *ChannelOpenScreen) tea.Cmd {
+	t.Helper()
+	s.submitOpenChannel()
+	if s.step != coStepConfirm {
+		t.Fatalf("preparation failed: %s", s.error)
+	}
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil {
+		t.Fatalf("submission not scheduled: %s", s.error)
+	}
+	return cmd
+}
+
+func TestChannelSelectionRefreshAndReview(t *testing.T) {
+	s, c := channelScreen(t)
+	original := c.coins[0]
+	other := lndrpc.UTXO{Txid: strings.Repeat("b", 64), AmountSats: 50000}
+	s.submitOpenChannel()
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, utxos: []lndrpc.UTXO{other, original}})
+	if !s.selection.Contains(original) || s.selection.Contains(other) {
+		t.Fatal("insert/reorder substituted the selected coin")
+	}
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, utxos: nil})
+	s.confirmBtnIdx = 1
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd != nil || s.selection.Len() != 1 || len(c.sent) != 0 {
+		t.Fatal("missing coin became automatic selection")
+	}
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, utxos: []lndrpc.UTXO{other, original}})
+	s.selection.Toggle(other)
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd != nil || s.step != coStepInput {
+		t.Fatal("changed selection bypassed renewed review")
+	}
+	s.clearForm()
+	if s.selection.Len() != 0 {
+		t.Fatal("Clear could not reset selected identities")
+	}
+	s.peerConfirmed = true
+	s.amountConfirmed = true
+	s.submitOpenChannel()
+	if s.step == coStepConfirm {
+		t.Fatal("empty selection accepted")
+	}
+}
+
+func TestChannelConfirmationOwnsIntentAndUnknownTotals(t *testing.T) {
+	theme.Init(true)
+	for _, max := range []bool{false, true} {
+		s, c := channelScreen(t)
+		s.fundMax = max
+		if !max {
+			s.amountInput.SetSats(30000)
+		} else {
+			s.feeInput.Clear()
+		}
+		s.submitOpenChannel()
+		before := s.View(67, 30)
+		want := s.attempt.prepared.Request()
+		for _, text := range []string{"Total fee and change: unavailable", "no other coins are allowed", "Unconfirmed inputs: allowed"} {
+			if !strings.Contains(before, text) {
+				t.Fatalf("missing review contract: %s", text)
+			}
+		}
+		if max && (!strings.Contains(before, "may leave change") || !strings.Contains(before, "Fee rate: auto")) {
+			t.Fatal("Max or automatic fee contract missing")
+		}
+		if lipgloss.Width(before) > 67 || len(strings.Split(before, "\n")) > 30 {
+			t.Fatal("confirmation exceeds pane")
+		}
+		s.amountInput.SetSats(49999)
+		s.feeInput.Clear()
+		s.customPubkey = "edited"
+		s.customAlias = "edited"
+		s.fundMax = !max
+		s.HandleMsg(feeTiersMsg{tiers: [4]feeTier{{SatPerVB: 99}}})
+		if s.View(67, 30) != before {
+			t.Fatal("late suggestion or mutable form changed reviewed intent")
+		}
+		s.confirmBtnIdx = 1
+		_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+		if cmd == nil {
+			t.Fatal("no submission")
+		}
+		if _, duplicate := s.HandleKey("enter", tea.KeyPressMsg{}); duplicate != nil {
+			t.Fatal("duplicate confirmation scheduled funding")
+		}
+		s.HandleMsg(cmd())
+		if len(c.sent) != 1 || !reflect.DeepEqual(c.sent[0], want) {
+			t.Fatal("submission differs from frozen confirmation")
+		}
+	}
+}
+
+func TestChannelRefreshAndResultOwnership(t *testing.T) {
+	s, _ := channelScreen(t)
+	oldRefresh := s.refresh
+	s.refreshCoins()
+	s.HandleMsg(coUtxoListMsg{refresh: oldRefresh, err: errors.New("old error")})
+	if s.utxoErr != nil {
+		t.Fatal("older refresh replaced current state")
+	}
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, err: errors.New("current error")})
+	s.submitOpenChannel()
+	if s.step == coStepConfirm {
+		t.Fatal("failed current fetch allowed preparation")
+	}
+	s.HandleMsg(coUtxoListMsg{refresh: s.refresh, utxos: s.utxos})
+	cmd := confirmChannel(t, s)
+	msg := cmd()
+	current, _ := channelScreen(t)
+	currentCmd := confirmChannel(t, current)
+	current.HandleMsg(msg)
+	if current.step != coStepOpening {
+		t.Fatal("old attempt completed another screen")
+	}
+	m := Model{nav: NewNavSidebar(), screenCtx: current.ctx, activeTab: 1, tabs: []openTab{{Kind: tabOpenChannel, Section: secChannels, Screen: current}}}
+	closed, _ := m.closeTab(1)
+	if len(closed.(Model).tabs) != 1 {
+		t.Fatal("closed a pending channel submission")
+	}
+	replaced, _ := m.Update(openTabMsg{Kind: tabOpenChannel, Screen: s, Replace: true})
+	m = replaced.(Model)
+	if m.tabs[0].Screen != current {
+		t.Fatal("replaced a pending channel submission")
+	}
+	// Hide Channels so completion must reach the retained tab across sections.
+	m.nav.ActiveItem = secSystem
+	result := currentCmd()
+	updated, refresh := m.Update(result)
+	m = updated.(Model)
+	if current.step != coStepResult || current.result.State != app.ChannelBroadcast || refresh == nil {
+		t.Fatal("hidden channel tab lost completion")
+	}
+	if _, duplicate := m.Update(result); duplicate != nil {
+		t.Fatal("duplicate completion repeated refresh")
+	}
+	current.HandleMsg(coUtxoListMsg{refresh: oldRefresh, err: errors.New("late failure")})
+	current.HandleMsg(coTxListMsg{refresh: oldRefresh, txs: []lndrpc.OnChainTx{{Txid: "stale"}}})
+	if strings.Contains(current.View(67, 30), "Failed") || current.result.State != app.ChannelBroadcast || len(current.txs) != 0 {
+		t.Fatal("late reads overwrote completion")
+	}
+	_, done := current.HandleKey("enter", tea.KeyPressMsg{})
+	// A delayed Done must close its originating screen, even after focus moves.
+	other := NewChannelOpenScreen(s.ctx)
+	m.tabs = append(m.tabs, openTab{Kind: tabReceive, Section: secWallet, Screen: other})
+	m.nav.ActiveItem = secWallet
+	updated, _ = m.Update(done())
+	m = updated.(Model)
+	if len(m.tabs) != 1 || m.tabs[0].Screen != other {
+		t.Fatal("Done closed another tab")
+	}
+	m.tabs = append(m.tabs, openTab{Kind: tabOpenChannel, Section: secChannels, Screen: s})
+	updated, _ = m.Update(done())
+	if len(updated.(Model).tabs) != 2 {
+		t.Fatal("duplicate Done closed a replacement")
+	}
+
+}
+
+func TestChannelUnknownOutcomeGuidance(t *testing.T) {
+	theme.Init(true)
+	s, c := channelScreen(t)
+	c.result = lndrpc.ChannelOpenResult{Submitted: true, Err: errors.New("deadline exceeded")}
+	s.HandleMsg(confirmChannel(t, s)())
+	view := s.View(67, 30)
+	if !strings.Contains(view, "Outcome Unknown") || !strings.Contains(view, "Funding may still complete") || strings.Contains(view, "Channel Open Failed") {
+		t.Fatal("unknown outcome rendered as definite failure")
+	}
+	if len(c.sent) != 1 {
+		t.Fatal("submission was retried")
+	}
 }

--- a/internal/tui/screen_channels_open_utxos.go
+++ b/internal/tui/screen_channels_open_utxos.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -12,78 +13,77 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
-// ── UTXO + transaction fetch for channel open ─────────
-// Separate message types so the Model-level utxoListMsg
-// and onChainTxMsg handlers (which populate OnChainContext)
-// are unaffected. Both routed via dispatchToTab(tabOpenChannel)
-// in update.go. Fetched in parallel via tea.Batch,
-// matching the previewSection(secOnChain) pattern.
+// Each refresh belongs to one screen and supersedes its previous requests.
+// A completed or submitted attempt no longer accepts these presentation reads.
+type channelOpenRefresh struct{ screen *ChannelOpenScreen }
 
 type coUtxoListMsg struct {
-	utxos []lndrpc.UTXO
-	err   error
+	refresh *channelOpenRefresh
+	utxos   []lndrpc.UTXO
+	err     error
 }
-
 type coTxListMsg struct {
-	txs []lndrpc.OnChainTx
-	err error
+	refresh *channelOpenRefresh
+	txs     []lndrpc.OnChainTx
+	err     error
 }
 
-func fetchChannelUtxosCmd(
-	client *lndrpc.Client,
-) tea.Cmd {
+func (s *ChannelOpenScreen) refreshCoins() tea.Cmd {
+	s.refresh = &channelOpenRefresh{screen: s}
+	return tea.Batch(fetchChannelUtxosCmd(s.ctx.LndClient, s.refresh), fetchChannelTxsCmd(s.ctx.LndClient, s.refresh))
+}
+
+func fetchChannelUtxosCmd(client *lndrpc.Client, refresh *channelOpenRefresh) tea.Cmd {
 	return func() tea.Msg {
 		if client == nil {
-			return coUtxoListMsg{err: fmt.Errorf(
-				"LND not connected")}
+			return coUtxoListMsg{refresh: refresh, err: fmt.Errorf("LND not connected")}
 		}
-		utxos, err := client.ListUnspent(0, 999999)
-		return coUtxoListMsg{utxos: utxos, err: err}
+		utxos, err := client.ListUnspent(0, math.MaxInt32)
+		return coUtxoListMsg{refresh: refresh, utxos: utxos, err: err}
 	}
 }
 
-func fetchChannelTxsCmd(
-	client *lndrpc.Client,
-) tea.Cmd {
+func fetchChannelTxsCmd(client *lndrpc.Client, refresh *channelOpenRefresh) tea.Cmd {
 	return func() tea.Msg {
 		if client == nil {
-			return coTxListMsg{err: fmt.Errorf(
-				"LND not connected")}
+			return coTxListMsg{refresh: refresh, err: fmt.Errorf("LND not connected")}
 		}
 		txs, err := client.GetTransactions()
-		return coTxListMsg{txs: txs, err: err}
+		return coTxListMsg{refresh: refresh, txs: txs, err: err}
 	}
 }
 
-func (s *ChannelOpenScreen) handleUtxoList(
-	msg coUtxoListMsg,
-) (Screen, tea.Cmd) {
+func (s *ChannelOpenScreen) handleUtxoList(msg coUtxoListMsg) (Screen, tea.Cmd) {
+	if msg.refresh == nil || msg.refresh != s.refresh || s.step >= coStepOpening {
+		return s, nil
+	}
+	if s.utxoErr != nil && s.error == s.utxoErr.Error() {
+		s.error = ""
+	}
+	s.utxoErr = msg.err
 	if msg.err != nil {
 		s.error = msg.err.Error()
 		return s, nil
 	}
 	s.utxos = msg.utxos
 	s.utxoFetched = true
-	// Prune selections beyond new UTXO range
-	for idx := range s.utxoSelected {
-		if idx >= len(s.utxos) {
-			delete(s.utxoSelected, idx)
-		}
-	}
-	s.recalcUtxoTotal()
+	s.utxoCursor = max(0, min(s.utxoCursor, len(s.utxos)-1))
 	return s, nil
 }
 
-func (s *ChannelOpenScreen) handleTxList(
-	msg coTxListMsg,
-) (Screen, tea.Cmd) {
-	if msg.err != nil {
-		// Non-fatal: table still works without
-		// date and label columns.
-		return s, nil
+func (s *ChannelOpenScreen) handleTxList(msg coTxListMsg) (Screen, tea.Cmd) {
+	if msg.refresh != nil && msg.refresh == s.refresh && s.step < coStepOpening && msg.err == nil {
+		s.txs = msg.txs
 	}
-	s.txs = msg.txs
 	return s, nil
+}
+
+func (s *ChannelOpenScreen) selectionSummary() string {
+	total, err := s.selection.Total(s.utxos)
+	if err != nil {
+		return fmt.Sprintf("%d selected; unavailable coins", s.selection.Len())
+	}
+	return fmt.Sprintf("%d selected (%s sats)", s.selection.Len(), formatSats(total))
 }
 
 // ── Transaction lookup helpers ────────────────────────
@@ -234,10 +234,15 @@ func (s *ChannelOpenScreen) returnFromCoinControl(
 	s.step = coStepInput
 	s.error = ""
 
-	if confirm && len(s.utxoSelected) > 0 {
+	if confirm && s.selection.Len() > 0 {
 		// Pre-fill amount, auto-confirm, advance
-		s.amount = s.utxoSelectedTotal
-		s.amountInput.SetSats(s.amount)
+		total, err := s.selection.Total(s.utxos)
+		if err != nil {
+			s.error = err.Error()
+			s.step = coStepCoinControl
+			return s, nil
+		}
+		s.amountInput.SetSats(total)
 		s.fundMax = true
 		s.amountConfirmed = true
 		s.amountIdx = 1
@@ -247,11 +252,10 @@ func (s *ChannelOpenScreen) returnFromCoinControl(
 		return s, nil
 	}
 
-	// No selection or cancelled
-	if len(s.utxoSelected) == 0 {
-		s.amount = 0
+	// Returning without confirmation requires another amount review.
+	s.amountConfirmed = false
+	if s.selection.Len() == 0 {
 		s.fundMax = false
-		s.amountConfirmed = false
 		s.amountInput.Clear()
 	}
 	s.focusZone = coZoneAmounts
@@ -261,33 +265,9 @@ func (s *ChannelOpenScreen) returnFromCoinControl(
 
 // ── Selection helpers ──────────────────────────────────
 
-func (s *ChannelOpenScreen) toggleUtxoSelection(
-	idx int,
-) {
-	if idx < 0 || idx >= len(s.utxos) {
-		return
-	}
-	if s.utxoSelected[idx] {
-		delete(s.utxoSelected, idx)
-	} else {
-		s.utxoSelected[idx] = true
-	}
-	s.recalcUtxoTotal()
-}
-
-func (s *ChannelOpenScreen) recalcUtxoTotal() {
-	s.utxoSelectedTotal = 0
-	s.utxoOutpoints = nil
-	for idx := range s.utxoSelected {
-		if idx < len(s.utxos) {
-			s.utxoSelectedTotal +=
-				s.utxos[idx].AmountSats
-			s.utxoOutpoints = append(
-				s.utxoOutpoints,
-				fmt.Sprintf("%s:%d",
-					s.utxos[idx].Txid,
-					s.utxos[idx].Vout))
-		}
+func (s *ChannelOpenScreen) toggleUtxoSelection(idx int) {
+	if idx >= 0 && idx < len(s.utxos) {
+		s.selection.Toggle(s.utxos[idx])
 	}
 }
 
@@ -299,12 +279,8 @@ func (s *ChannelOpenScreen) viewCoinControl(
 	p := newPane(w)
 	p.title(theme.Header, "Coin Control")
 
-	// Selection summary
-	if len(s.utxoSelected) > 0 {
-		p.field("Selected: ",
-			fmt.Sprintf("%d UTXO(s) (%s sats)",
-				len(s.utxoSelected),
-				formatSats(s.utxoSelectedTotal)))
+	if s.selection.Len() > 0 {
+		p.field("Selected: ", s.selectionSummary())
 	} else {
 		p.dim(" Select UTXOs for the channel open.")
 	}
@@ -390,7 +366,7 @@ func (s *ChannelOpenScreen) viewUtxoTable(
 	for i := startIdx; i < endIdx; i++ {
 		u := s.utxos[i]
 		isCursor := focused && s.utxoCursor == i
-		isChecked := s.utxoSelected[i]
+		isChecked := s.selection.Contains(u)
 
 		// Date from tx lookup
 		dateStr := s.utxoDate(u.Txid)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -154,24 +154,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.screen == nil || msg.screen.step != ocStepResult {
 			return m, nil
 		}
-		// Done belongs to its screen even if navigation changes before delivery.
-		for i, tab := range m.tabs {
-			if tab.Screen != msg.screen || onChainSendBusy(tab.Screen) {
-				continue
-			}
-			if tab.Section == m.nav.ActiveSection() {
-				for index, visible := range m.effectiveTabs() {
-					if visible.Screen == msg.screen {
-						return m.closeTab(index)
-					}
-				}
-			} else {
-				m.tabs = append(m.tabs[:i], m.tabs[i+1:]...)
-				m.sectionFocus[tab.Section] = 0
-				return m, nil
-			}
+		return m.closeScreenTab(msg.screen)
+	case closeChannelOpenMsg:
+		if msg.screen == nil || msg.screen.step != coStepResult {
+			return m, nil
 		}
-		return m, nil
+		return m.closeScreenTab(msg.screen)
 	case focusSidebarMsg:
 		m.focusSidebar()
 		return m, nil
@@ -262,7 +250,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					t.Section == sec {
 					m.activeTab = i
 					m.rememberTabPosition()
-					if msg.Replace && onChainSendBusy(t.Screen) {
+					if msg.Replace && (onChainSendBusy(t.Screen) || channelOpenBusy(t.Screen)) {
 						return m, nil
 					}
 					if msg.Replace &&
@@ -883,6 +871,27 @@ func (m Model) handleTabBarKey(
 	return m, nil
 }
 
+// Done belongs to its originating screen even if navigation changes before delivery.
+func (m Model) closeScreenTab(screen Screen) (tea.Model, tea.Cmd) {
+	for i, tab := range m.tabs {
+		if tab.Screen != screen {
+			continue
+		}
+		if tab.Section == m.nav.ActiveSection() {
+			for index, visible := range m.effectiveTabs() {
+				if visible.Screen == screen {
+					return m.closeTab(index)
+				}
+			}
+		} else {
+			m.tabs = append(m.tabs[:i], m.tabs[i+1:]...)
+			m.sectionFocus[tab.Section] = 0
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
 func (m Model) closeTab(
 	tabIdx int,
 ) (tea.Model, tea.Cmd) {
@@ -892,8 +901,8 @@ func (m Model) closeTab(
 	}
 
 	closingTab := tabs[tabIdx]
-	// Keep a submitted send reachable until its bounded RPC returns.
-	if onChainSendBusy(closingTab.Screen) {
+	// Keep submitted funding operations reachable until their bounded calls return.
+	if onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) {
 		return m, nil
 	}
 
@@ -1044,12 +1053,12 @@ func (m *Model) setTabScreen(
 	}
 }
 
-// Payment, invoice, and on-chain send results reach their open tabs across sections.
+// Payment, invoice, on-chain send and channel-open results reach their open tabs across sections.
 // Other workflows retain visible-section routing until their lifecycle is reviewed.
 func (m Model) routeToScreen(kind tabKind, msg tea.Msg) (Model, tea.Cmd, bool) {
 	section := m.nav.ActiveSection()
 	for i, tab := range m.tabs {
-		if tab.Section != section && kind != tabSend && kind != tabReceive && kind != tabOnChain {
+		if tab.Section != section && kind != tabSend && kind != tabReceive && kind != tabOnChain && kind != tabOpenChannel {
 			continue
 		}
 		if tab.Kind == kind && tab.Screen != nil {


### PR DESCRIPTION
Channel opening could change selected coins after refresh, submit mutable
confirmation fields, and display fee or Max totals that were not known.

Move preparation and submission into the application layer. Preserve
outpoint identity, freeze the reviewed request, recheck selected coins
before submission, and distinguish broadcast, not-submitted and unknown
outcomes. Keep asynchronous results attached to their originating tab.

### Validation

- Full local Go 1.26.8 gates passed: tests, race, vet, build,
  tidy-diff and diff checks.
- Candidate `4d4b2fb` produced matching Linux binaries on
  Signet VPSs.
- Fixed-amount and Fund Max opens confirmed using exactly the selected
  coins; funding fees were 538 and 228 sats.
- Confirmation/back-navigation and hidden-section error delivery passed.
  Hidden-section success delivery is covered by deterministic tests.
- Both nodes retain three active private Taproot channels, including
  the original channel, with no pending channels or HTLCs.

The first Max attempt encountered LND’s pending-channel limit. After
the earlier channel activated and unchanged coins were verified, the
reviewed retry succeeded.