### PR TITLE
fix: preserve reviewed channel-close intent

### DIFF
--- a/internal/app/channel_close.go
+++ b/internal/app/channel_close.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"errors"
+	"math"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type ChannelCloseClient interface {
+	ChannelCloseState(string) (lndrpc.ChannelCloseState, error)
+	CloseChannel(lndrpc.ChannelCloseRequest) lndrpc.ChannelCloseResult
+}
+
+type ChannelCloseInput struct {
+	ChannelPoint string
+	Force        bool
+	SatPerVbyte  int64
+}
+
+// PreparedChannelClose owns the channel, mode and fee policy shown for approval.
+type PreparedChannelClose struct{ request lndrpc.ChannelCloseRequest }
+
+func (p PreparedChannelClose) Request() lndrpc.ChannelCloseRequest { return p.request }
+
+func PrepareChannelClose(input ChannelCloseInput) (PreparedChannelClose, error) {
+	point, err := lndrpc.NormalizeChannelPoint(input.ChannelPoint)
+	if err != nil {
+		return PreparedChannelClose{}, err
+	}
+	if input.SatPerVbyte < 0 || input.SatPerVbyte > math.MaxInt64/1000 || (input.Force && input.SatPerVbyte != 0) {
+		return PreparedChannelClose{}, errors.New("Invalid close fee policy")
+	}
+	return PreparedChannelClose{request: lndrpc.ChannelCloseRequest{
+		ChannelPoint: point,
+		Force:        input.Force, SatPerVbyte: uint64(input.SatPerVbyte),
+	}}, nil
+}
+
+type ChannelCloseOutcome int
+
+const (
+	CloseNotSubmitted ChannelCloseOutcome = iota
+	ClosePending
+	CloseConfirmed
+	CloseOutcomeUnknown
+)
+
+type ChannelCloseResult struct {
+	State ChannelCloseOutcome
+	Txid  string
+	Err   error
+}
+
+// CloseChannel rechecks the initial-close state before one RPC. Other operators
+// and peers can still change LND state between the reads and submission.
+func CloseChannel(client ChannelCloseClient, prepared PreparedChannelClose) ChannelCloseResult {
+	req := prepared.Request()
+	if req.ChannelPoint == "" {
+		return ChannelCloseResult{Err: errors.New("Review the channel before closing")}
+	}
+	if client == nil {
+		return ChannelCloseResult{Err: errors.New("LND not connected")}
+	}
+	state, err := client.ChannelCloseState(req.ChannelPoint)
+	if err != nil {
+		return ChannelCloseResult{Err: err}
+	}
+	if state.Closing || !state.Found || state.StatusFlags != "ChanStatusDefault" {
+		return ChannelCloseResult{Err: errors.New("Channel is unavailable or already closing. Check pending channels and history")}
+	}
+	if !req.Force && (!state.Active || state.PendingHTLCs != 0) {
+		return ChannelCloseResult{Err: errors.New("Cooperative close requires an active peer and no pending HTLCs. Review channel state")}
+	}
+	result := client.CloseChannel(req)
+	if !result.Submitted {
+		return ChannelCloseResult{Err: result.Err}
+	}
+	if result.Err != nil || result.ClosingTxid == "" {
+		err := result.Err
+		if err == nil {
+			err = errors.New("LND returned no closing transaction ID")
+		}
+		return ChannelCloseResult{State: CloseOutcomeUnknown, Err: err}
+	}
+	outcome := ClosePending
+	if result.Confirmed {
+		outcome = CloseConfirmed
+	}
+	return ChannelCloseResult{State: outcome, Txid: result.ClosingTxid}
+}

--- a/internal/app/channel_close_test.go
+++ b/internal/app/channel_close_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type closeClient struct {
+	state    lndrpc.ChannelCloseState
+	err      error
+	result   lndrpc.ChannelCloseResult
+	checked  string
+	requests []lndrpc.ChannelCloseRequest
+}
+
+func (c *closeClient) ChannelCloseState(point string) (lndrpc.ChannelCloseState, error) {
+	c.checked = point
+	return c.state, c.err
+}
+func (c *closeClient) CloseChannel(req lndrpc.ChannelCloseRequest) lndrpc.ChannelCloseResult {
+	c.requests = append(c.requests, req)
+	return c.result
+}
+func readyCloseClient() *closeClient {
+	return &closeClient{state: lndrpc.ChannelCloseState{Found: true, Active: true, StatusFlags: "ChanStatusDefault"}, result: lndrpc.ChannelCloseResult{Submitted: true, ClosingTxid: strings.Repeat("b", 64)}}
+}
+func TestClosePreparationAndIntent(t *testing.T) {
+	point := strings.Repeat("a", 64) + ":7"
+	for _, input := range []ChannelCloseInput{
+		{ChannelPoint: point, SatPerVbyte: -1}, {ChannelPoint: point, SatPerVbyte: math.MaxInt64/1000 + 1},
+		{ChannelPoint: point, Force: true, SatPerVbyte: 1}, {ChannelPoint: ""}, {ChannelPoint: strings.Repeat("a", 64) + ":4294967296"},
+	} {
+		if _, err := PrepareChannelClose(input); err == nil {
+			t.Fatalf("accepted invalid intent: %+v", input)
+		}
+	}
+	for _, input := range []ChannelCloseInput{{ChannelPoint: point}, {ChannelPoint: point, SatPerVbyte: 12}, {ChannelPoint: point, Force: true}} {
+		prepared, err := PrepareChannelClose(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		copy := prepared.Request()
+		copy.ChannelPoint = strings.Repeat("c", 64) + ":1"
+		copy.Force = !copy.Force
+		copy.SatPerVbyte = 999
+		c := readyCloseClient()
+		result := CloseChannel(c, prepared)
+		if result.State != ClosePending || len(c.requests) != 1 || c.checked != point {
+			t.Fatalf("lost close identity: %+v", result)
+		}
+		req := c.requests[0]
+		if req.ChannelPoint != input.ChannelPoint || req.Force != input.Force || req.SatPerVbyte != uint64(input.SatPerVbyte) {
+			t.Fatalf("changed reviewed intent: %+v", req)
+		}
+	}
+	c := readyCloseClient()
+	if result := CloseChannel(c, PreparedChannelClose{}); result.Err == nil || c.checked != "" || len(c.requests) != 0 {
+		t.Fatal("unprepared close reached client")
+	}
+	prepared, _ := PrepareChannelClose(ChannelCloseInput{ChannelPoint: point})
+	if result := CloseChannel(nil, prepared); result.State != CloseNotSubmitted || result.Err == nil {
+		t.Fatal("nil client was not refused")
+	}
+}
+func TestClosePreflightRefusesStaleOrIneligibleState(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		change         func(*closeClient)
+		force, allowed bool
+	}{
+		{"missing", func(c *closeClient) { c.state.Found = false }, false, false},
+		{"pending", func(c *closeClient) { c.state.Closing = true }, false, false},
+		{"pending force", func(c *closeClient) { c.state.Closing = true }, true, false},
+		{"abnormal", func(c *closeClient) { c.state.StatusFlags = "ChanStatusLocalDataLoss" }, true, false},
+		{"unknown flags", func(c *closeClient) { c.state.StatusFlags = "" }, false, false},
+		{"lookup failed", func(c *closeClient) { c.err = errors.New("state read failed") }, false, false},
+		{"offline cooperative", func(c *closeClient) { c.state.Active = false }, false, false},
+		{"offline force", func(c *closeClient) { c.state.Active = false }, true, true},
+		{"HTLC cooperative", func(c *closeClient) { c.state.PendingHTLCs = 1 }, false, false},
+		{"HTLC force", func(c *closeClient) { c.state.PendingHTLCs = 1 }, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := readyCloseClient()
+			tc.change(c)
+			prepared, _ := PrepareChannelClose(ChannelCloseInput{ChannelPoint: strings.Repeat("a", 64) + ":0", Force: tc.force})
+			result := CloseChannel(c, prepared)
+			if tc.allowed {
+				if len(c.requests) != 1 || c.requests[0].Force != tc.force {
+					t.Fatal("lost explicit force intent")
+				}
+				return
+			}
+			if len(c.requests) != 0 || result.State != CloseNotSubmitted || result.Err == nil {
+				t.Fatalf("ineligible state submitted: %+v", result)
+			}
+		})
+	}
+}
+func TestCloseOutcomeDoesNotInventFailureOrRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result lndrpc.ChannelCloseResult
+		want   ChannelCloseOutcome
+	}{
+		{"not attempted", lndrpc.ChannelCloseResult{Err: errors.New("disconnected")}, CloseNotSubmitted},
+		{"lost stream", lndrpc.ChannelCloseResult{Submitted: true, Err: errors.New("deadline exceeded")}, CloseOutcomeUnknown},
+		{"missing txid", lndrpc.ChannelCloseResult{Submitted: true}, CloseOutcomeUnknown},
+		{"candidate", lndrpc.ChannelCloseResult{Submitted: true, ClosingTxid: strings.Repeat("b", 64)}, ClosePending},
+		{"confirmed", lndrpc.ChannelCloseResult{Submitted: true, Confirmed: true, ClosingTxid: strings.Repeat("b", 64)}, CloseConfirmed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := readyCloseClient()
+			c.result = tc.result
+			prepared, _ := PrepareChannelClose(ChannelCloseInput{ChannelPoint: strings.Repeat("a", 64) + ":0"})
+			result := CloseChannel(c, prepared)
+			if result.State != tc.want || len(c.requests) != 1 {
+				t.Fatalf("wrong outcome or retried RPC: %+v", result)
+			}
+		})
+	}
+}

--- a/internal/lndrpc/client_test.go
+++ b/internal/lndrpc/client_test.go
@@ -89,8 +89,7 @@ func TestNilClientSafety(t *testing.T) {
 	if _, err := c.SendPayment("lnbc1"); err == nil {
 		t.Error("should error")
 	}
-	if _, err := c.CloseChannel(
-		strings.Repeat("ab", 32)+":0", false, 0); err == nil {
+	if result := c.CloseChannel(ChannelCloseRequest{ChannelPoint: strings.Repeat("ab", 32) + ":0"}); result.Err == nil || result.Submitted {
 		t.Error("should error")
 	}
 }

--- a/internal/lndrpc/close.go
+++ b/internal/lndrpc/close.go
@@ -1,103 +1,175 @@
 package lndrpc
 
 import (
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"math"
+	"strings"
 	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
-// CloseChannelResult holds the outcome of a channel
-// close request.
-type CloseChannelResult struct {
-	ClosingTxid string
+type ChannelCloseRequest struct {
+	ChannelPoint string
+	Force        bool
+	SatPerVbyte  uint64
 }
 
-// CloseChannel initiates a channel close. If force is
-// true, a unilateral close is performed. The function
-// blocks until the closing transaction is broadcast
-// (ClosePending update) and returns the closing txid.
-func (c *Client) CloseChannel(
-	channelPoint string,
-	force bool,
-	satPerVbyte uint64,
-) (*CloseChannelResult, error) {
+// Submitted means the RPC was attempted, not that LND accepted the close.
+// A pending transaction is a candidate, and confirmation does not prove that
+// force-close outputs have matured or been swept.
+type ChannelCloseResult struct {
+	Submitted   bool
+	Confirmed   bool
+	ClosingTxid string
+	Err         error
+}
+
+type ChannelCloseState struct {
+	Found        bool
+	Active       bool
+	StatusFlags  string
+	PendingHTLCs int
+	Closing      bool
+}
+
+// ChannelCloseState reads only close eligibility facts, without alias lookups.
+// Both reads share a timeout, but they are not an atomic snapshot or a lock.
+func (c *Client) ChannelCloseState(point string) (ChannelCloseState, error) {
+	var state ChannelCloseState
+	if c == nil {
+		return state, errNotConnected
+	}
+	if _, err := parseOutpoint(point); err != nil {
+		return state, err
+	}
 	rpc := c.rpc()
 	if rpc == nil {
-		return nil, errNotConnected
+		return state, errNotConnected
 	}
-
-	// The channel point goes through the same strict parser
-	// as every other fund-moving call site: a close must
-	// target exactly the output the operator chose, so a
-	// value that does not parse aborts the request instead
-	// of being reinterpreted. LND accepts the txid in its
-	// display form here, so no byte order handling is
-	// needed.
-	op, err := parseOutpoint(channelPoint)
+	ctx, cancel := c.callCtx(defaultTimeout)
+	defer cancel()
+	pending, err := rpc.PendingChannels(ctx, &lnrpc.PendingChannelsRequest{})
 	if err != nil {
-		return nil, err
+		c.handleError(err)
+		return state, err
 	}
+	if pending == nil {
+		return state, errors.New("LND returned no pending-channel state")
+	}
+	for _, ch := range pending.GetWaitingCloseChannels() {
+		if ch.GetChannel().GetChannelPoint() == point {
+			state.Closing = true
+		}
+	}
+	for _, ch := range pending.GetPendingForceClosingChannels() {
+		if ch.GetChannel().GetChannelPoint() == point {
+			state.Closing = true
+		}
+	}
+	channels, err := rpc.ListChannels(ctx, &lnrpc.ListChannelsRequest{})
+	if err != nil {
+		c.handleError(err)
+		return state, err
+	}
+	if channels == nil {
+		return state, errors.New("LND returned no channel state")
+	}
+	for _, ch := range channels.GetChannels() {
+		if ch.GetChannelPoint() == point {
+			state.Found = true
+			state.Active = ch.GetActive()
+			state.StatusFlags = ch.GetChanStatusFlags()
+			state.PendingHTLCs = len(ch.GetPendingHtlcs())
+			break
+		}
+	}
+	return state, nil
+}
 
+// CloseChannel makes one bounded submission and waits for a pending or confirmed
+// transaction. Canceling the stream is not evidence that LND canceled the close.
+func (c *Client) CloseChannel(input ChannelCloseRequest) ChannelCloseResult {
+	if c == nil {
+		return ChannelCloseResult{Err: errNotConnected}
+	}
+	rpc := c.rpc()
+	if rpc == nil {
+		return ChannelCloseResult{Err: errNotConnected}
+	}
+	op, err := parseOutpoint(input.ChannelPoint)
+	if err != nil {
+		return ChannelCloseResult{Err: err}
+	}
+	if input.SatPerVbyte > math.MaxInt64/1000 || (input.Force && input.SatPerVbyte != 0) {
+		return ChannelCloseResult{Err: errors.New("Invalid close fee policy")}
+	}
 	req := &lnrpc.CloseChannelRequest{
 		ChannelPoint: &lnrpc.ChannelPoint{
-			FundingTxid: &lnrpc.ChannelPoint_FundingTxidStr{
-				FundingTxidStr: op.TxidStr,
-			},
+			FundingTxid: &lnrpc.ChannelPoint_FundingTxidStr{FundingTxidStr: op.TxidStr},
 			OutputIndex: op.OutputIndex,
 		},
-		Force: force,
+		Force: input.Force, SatPerVbyte: input.SatPerVbyte,
 	}
-	if satPerVbyte > 0 {
-		req.SatPerVbyte = satPerVbyte
-	}
-
-	// Use a long timeout — force closes can take
-	// time and cooperative closes need peer
-	// communication over Tor
 	ctx, cancel := c.callCtx(120 * time.Second)
 	defer cancel()
-
+	result := ChannelCloseResult{Submitted: true}
 	stream, err := rpc.CloseChannel(ctx, req)
 	if err != nil {
 		c.handleError(err)
-		return nil, fmt.Errorf(
-			"close channel: %w", err)
+		result.Err = fmt.Errorf("close channel: %w", err)
+		return result
 	}
-
-	// Wait for the first update (ClosePending)
-	// which contains the closing transaction txid
-	for {
-		update, err := stream.Recv()
-		if err != nil {
-			return nil, fmt.Errorf(
-				"close stream: %w", err)
-		}
-
-		switch u := update.Update.(type) {
-		case *lnrpc.CloseStatusUpdate_ClosePending:
-			txid := u.ClosePending.GetTxid()
-			// Reverse bytes for display
-			txidDisplay := fmt.Sprintf("%x", txid)
-			if len(txid) == 32 {
-				reversed := make([]byte, 32)
-				for i := 0; i < 32; i++ {
-					reversed[i] = txid[31-i]
-				}
-				txidDisplay = fmt.Sprintf(
-					"%x", reversed)
-			}
-			return &CloseChannelResult{
-				ClosingTxid: txidDisplay,
-			}, nil
-
-		case *lnrpc.CloseStatusUpdate_ChanClose:
-			// Channel fully resolved — shouldn't
-			// happen before ClosePending but handle
-			// it gracefully
-			return &CloseChannelResult{
-				ClosingTxid: "resolved",
-			}, nil
-		}
+	if stream == nil {
+		result.Err = errors.New("LND returned no close stream")
+		return result
 	}
+	update, err := stream.Recv()
+	if err != nil {
+		c.handleError(err)
+		result.Err = fmt.Errorf("close stream: %w", err)
+		return result
+	}
+	if update == nil {
+		result.Err = errors.New("LND returned an empty close update")
+		return result
+	}
+	var raw []byte
+	switch u := update.Update.(type) {
+	case *lnrpc.CloseStatusUpdate_ClosePending:
+		raw = u.ClosePending.GetTxid()
+	case *lnrpc.CloseStatusUpdate_ChanClose:
+		if !u.ChanClose.GetSuccess() {
+			result.Err = errors.New("LND did not report a successful close")
+			return result
+		}
+		raw = u.ChanClose.GetClosingTxid()
+		result.Confirmed = true
+	default:
+		result.Err = errors.New("LND returned an unexpected close update")
+		return result
+	}
+	if len(raw) != 32 {
+		result.Confirmed = false
+		result.Err = errors.New("LND returned an invalid closing transaction ID")
+		return result
+	}
+	var reversed [32]byte
+	for i := range raw {
+		reversed[31-i] = raw[i]
+	}
+	result.ClosingTxid = hex.EncodeToString(reversed[:])
+	return result
+}
+
+// NormalizeChannelPoint validates an exact funding outpoint and returns its
+// canonical display form for request and identity comparisons.
+func NormalizeChannelPoint(point string) (string, error) {
+	op, err := parseOutpoint(point)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%d", strings.ToLower(op.TxidStr), op.OutputIndex), nil
 }

--- a/internal/lndrpc/close_test.go
+++ b/internal/lndrpc/close_test.go
@@ -1,0 +1,178 @@
+package lndrpc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+type closeRPC struct {
+	lnrpc.LightningClient
+	requests                []*lnrpc.CloseChannelRequest
+	stream                  lnrpc.Lightning_CloseChannelClient
+	err                     error
+	closeCtx                context.Context
+	pending                 *lnrpc.PendingChannelsResponse
+	channels                *lnrpc.ListChannelsResponse
+	pendingErr, channelsErr error
+	pendingCtx, channelsCtx context.Context
+}
+
+func (r *closeRPC) CloseChannel(ctx context.Context, req *lnrpc.CloseChannelRequest, _ ...grpc.CallOption) (lnrpc.Lightning_CloseChannelClient, error) {
+	r.requests = append(r.requests, req)
+	r.closeCtx = ctx
+	return r.stream, r.err
+}
+func (r *closeRPC) PendingChannels(ctx context.Context, _ *lnrpc.PendingChannelsRequest, _ ...grpc.CallOption) (*lnrpc.PendingChannelsResponse, error) {
+	r.pendingCtx = ctx
+	return r.pending, r.pendingErr
+}
+func (r *closeRPC) ListChannels(ctx context.Context, _ *lnrpc.ListChannelsRequest, _ ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error) {
+	r.channelsCtx = ctx
+	return r.channels, r.channelsErr
+}
+
+type closeStream struct {
+	grpc.ClientStream
+	update *lnrpc.CloseStatusUpdate
+	err    error
+}
+
+func (s *closeStream) Recv() (*lnrpc.CloseStatusUpdate, error) { return s.update, s.err }
+
+func TestCloseWireIntentAndBounds(t *testing.T) {
+	point := strings.Repeat("ab", 32) + ":7"
+	rpc := &closeRPC{stream: &closeStream{err: io.EOF}}
+	client := &Client{lightning: rpc}
+	for _, input := range []ChannelCloseRequest{{ChannelPoint: point}, {ChannelPoint: point, SatPerVbyte: 21}, {ChannelPoint: point, Force: true}} {
+		result := client.CloseChannel(input)
+		req := rpc.requests[len(rpc.requests)-1]
+		if !result.Submitted || result.Err == nil || req.ChannelPoint.GetFundingTxidStr() != strings.Repeat("ab", 32) || req.ChannelPoint.OutputIndex != 7 || req.Force != input.Force || req.SatPerVbyte != input.SatPerVbyte {
+			t.Fatalf("changed close intent: %+v", req)
+		}
+		if req.NoWait || req.TargetConf != 0 || req.MaxFeePerVbyte != 0 || req.DeliveryAddress != "" {
+			t.Fatal("introduced an unapproved close policy")
+		}
+		deadline, ok := rpc.closeCtx.Deadline()
+		if !ok || time.Until(deadline) > 120*time.Second || rpc.closeCtx.Err() != context.Canceled {
+			t.Fatal("close stream lost bounded lifetime")
+		}
+	}
+	for _, input := range []ChannelCloseRequest{{ChannelPoint: "bad"}, {ChannelPoint: point, Force: true, SatPerVbyte: 1}, {ChannelPoint: point, SatPerVbyte: math.MaxInt64/1000 + 1}} {
+		result := client.CloseChannel(input)
+		if result.Submitted || result.Err == nil || len(rpc.requests) != 3 {
+			t.Fatal("invalid close reached RPC")
+		}
+	}
+}
+func TestCloseStreamOutcomes(t *testing.T) {
+	raw := make([]byte, 32)
+	raw[0] = 1
+	raw[31] = 2
+	want := "02" + strings.Repeat("00", 30) + "01"
+	pending := func(tx []byte) *lnrpc.CloseStatusUpdate {
+		return &lnrpc.CloseStatusUpdate{Update: &lnrpc.CloseStatusUpdate_ClosePending{ClosePending: &lnrpc.PendingUpdate{Txid: tx}}}
+	}
+	confirmed := func(success bool) *lnrpc.CloseStatusUpdate {
+		return &lnrpc.CloseStatusUpdate{Update: &lnrpc.CloseStatusUpdate_ChanClose{ChanClose: &lnrpc.ChannelCloseUpdate{ClosingTxid: raw, Success: success}}}
+	}
+	for _, tc := range []struct {
+		name             string
+		stream           *closeStream
+		rpcErr           error
+		valid, confirmed bool
+	}{
+		{"pending", &closeStream{update: pending(raw)}, nil, true, false},
+		{"confirmed", &closeStream{update: confirmed(true)}, nil, true, true},
+		{"unsuccessful final", &closeStream{update: confirmed(false)}, nil, false, false},
+		{"short ID", &closeStream{update: pending([]byte{1})}, nil, false, false},
+		{"empty ID", &closeStream{update: pending(nil)}, nil, false, false},
+		{"EOF", &closeStream{err: io.EOF}, nil, false, false},
+		{"deadline", &closeStream{err: context.DeadlineExceeded}, nil, false, false},
+		{"RPC error", nil, errors.New("daemon refused"), false, false},
+		{"missing stream", nil, nil, false, false},
+		{"empty update", &closeStream{}, nil, false, false},
+		{"unexpected update", &closeStream{update: &lnrpc.CloseStatusUpdate{Update: &lnrpc.CloseStatusUpdate_CloseInstant{CloseInstant: &lnrpc.InstantUpdate{}}}}, nil, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := &closeRPC{err: tc.rpcErr}
+			if tc.stream != nil {
+				rpc.stream = tc.stream
+			}
+			result := (&Client{lightning: rpc}).CloseChannel(ChannelCloseRequest{ChannelPoint: strings.Repeat("a", 64) + ":0"})
+			if !result.Submitted || len(rpc.requests) != 1 {
+				t.Fatal("lost attempted submission or retried")
+			}
+			if tc.valid {
+				if result.Err != nil || result.ClosingTxid != want || result.Confirmed != tc.confirmed {
+					t.Fatalf("bad closing transaction: %+v", result)
+				}
+			} else if result.Err == nil || result.ClosingTxid != "" || result.Confirmed {
+				t.Fatalf("malformed/failed update claimed success: %+v", result)
+			}
+		})
+	}
+}
+func TestCloseStateReadsExactChannelAndFailsClosed(t *testing.T) {
+	point := strings.Repeat("a", 64) + ":7"
+	for _, tc := range []struct {
+		name          string
+		change        func(*closeRPC)
+		closing, fail bool
+	}{
+		{"normal", func(*closeRPC) {}, false, false},
+		{"waiting", func(r *closeRPC) {
+			r.pending.WaitingCloseChannels = []*lnrpc.PendingChannelsResponse_WaitingCloseChannel{{Channel: &lnrpc.PendingChannelsResponse_PendingChannel{ChannelPoint: point}}}
+		}, true, false},
+		{"force", func(r *closeRPC) {
+			r.pending.PendingForceClosingChannels = []*lnrpc.PendingChannelsResponse_ForceClosedChannel{{Channel: &lnrpc.PendingChannelsResponse_PendingChannel{ChannelPoint: point}}}
+		}, true, false},
+		{"pending error", func(r *closeRPC) { r.pendingErr = errors.New("read failed") }, false, true},
+		{"channels error", func(r *closeRPC) { r.channelsErr = errors.New("read failed") }, false, true},
+		{"empty pending", func(r *closeRPC) { r.pending = nil }, false, true},
+		{"empty channels", func(r *closeRPC) { r.channels = nil }, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := &closeRPC{pending: &lnrpc.PendingChannelsResponse{}, channels: &lnrpc.ListChannelsResponse{Channels: []*lnrpc.Channel{
+				{ChannelPoint: strings.Repeat("a", 64) + ":0", Active: true, ChanStatusFlags: "other"},
+				{ChannelPoint: point, Active: false, ChanStatusFlags: "ChanStatusDefault", PendingHtlcs: []*lnrpc.HTLC{{}}},
+			}}}
+			tc.change(rpc)
+			state, err := (&Client{lightning: rpc}).ChannelCloseState(point)
+			if tc.fail {
+				if err == nil {
+					t.Fatal("failed read became eligible")
+				}
+				return
+			}
+			if err != nil || !state.Found || state.Active || state.StatusFlags != "ChanStatusDefault" || state.PendingHTLCs != 1 || state.Closing != tc.closing {
+				t.Fatalf("wrong channel state: %+v %v", state, err)
+			}
+			if rpc.pendingCtx != rpc.channelsCtx || rpc.pendingCtx.Err() != context.Canceled {
+				t.Fatal("state reads lost shared bounded lifetime")
+			}
+			state, err = (&Client{lightning: rpc}).ChannelCloseState(strings.Repeat("c", 64) + ":7")
+			if err != nil || state.Found || state.Closing {
+				t.Fatal("substituted another channel")
+			}
+		})
+	}
+	rpc := &closeRPC{}
+	if _, err := (&Client{lightning: rpc}).ChannelCloseState("bad"); err == nil || rpc.pendingCtx != nil {
+		t.Fatal("invalid identity reached read RPC")
+	}
+	var disconnected *Client
+	if _, err := disconnected.ChannelCloseState(point); err == nil {
+		t.Fatal("nil client read accepted")
+	}
+	if result := disconnected.CloseChannel(ChannelCloseRequest{ChannelPoint: point}); result.Submitted || result.Err == nil {
+		t.Fatal("nil client submission accepted")
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -118,24 +118,29 @@ func openChannelCmd(client app.ChannelOpenClient, attempt *channelOpenAttempt) t
 	}
 }
 
-func closeChannelCmd(
-	client *lndrpc.Client,
-	chanPoint string,
-	force bool,
-	satPerVbyte uint64,
-) tea.Cmd {
+type channelCloseAttempt struct {
+	prepared               app.PreparedChannelClose
+	alias                  string
+	capacity, localBalance int64
+}
+
+type channelCloseFeesMsg struct {
+	screen *ChannelCloseScreen
+	tiers  [4]feeTier
+	err    error
+}
+
+func closeChannelCmd(client app.ChannelCloseClient, attempt *channelCloseAttempt) tea.Cmd {
 	return func() tea.Msg {
-		if client == nil {
-			return closeChannelMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		result, err := client.CloseChannel(
-			chanPoint, force, satPerVbyte)
-		if err != nil {
-			return closeChannelMsg{err: err}
-		}
-		return closeChannelMsg{
-			txid: result.ClosingTxid}
+		return channelCloseResultMsg{attempt: attempt, result: app.CloseChannel(client, attempt.prepared)}
+	}
+}
+
+func closeFeeTiersCmd(screen *ChannelCloseScreen) tea.Cmd {
+	fetch := fetchFeeTiersCmd(screen.ctx.Cfg)
+	return func() tea.Msg {
+		msg := fetch().(feeTiersMsg)
+		return channelCloseFeesMsg{screen: screen, tiers: msg.tiers, err: msg.err}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -66,7 +66,8 @@ const (
 type openTab struct {
 	Kind  tabKind
 	Label string
-	Index int // channel index, payment index, etc.
+	Index int    // row identity for other detail tabs
+	Key   string // funding outpoint for channel detail tabs
 	// Section is the sticky owner of this tab — set
 	// at construction from m.nav.ActiveSection() and
 	// must never be mutated afterward. effectiveTabs,
@@ -202,9 +203,9 @@ type onChainTxMsg struct {
 	err error
 }
 
-type closeChannelMsg struct {
-	txid string
-	err  error
+type channelCloseResultMsg struct {
+	attempt *channelCloseAttempt
+	result  app.ChannelCloseResult
 }
 
 type closedChannelsMsg struct {

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -113,7 +113,8 @@ type closeTabMsg struct{}
 type openTabMsg struct {
 	Kind        tabKind
 	Label       string
-	Index       int // for detail tabs (dedup key)
+	Index       int    // for other detail tabs (dedup key)
+	Key         string // funding outpoint for channel detail tabs
 	Screen      Screen
 	FocusTabBar bool    // true = tab bar focused on open
 	Replace     bool    // true = replace existing screen on dedup

--- a/internal/tui/screen_channels_close.go
+++ b/internal/tui/screen_channels_close.go
@@ -6,61 +6,55 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
-
-// ── Close screen steps ──────────────────────────────────
 
 type closeStep int
 
 const (
 	closeStepType    closeStep = iota // cooperative / force
-	closeStepConfirm                  // fee input + buttons
-	closeStepClosing                  // broadcasting
-	closeStepResult                   // success or error
+	closeStepFee                      // fee input + buttons
+	closeStepReview                   // immutable approval
+	closeStepClosing                  // checking and submitting
+	closeStepResult                   // submission outcome
 )
-
-// ── Type step focus zones ────────────────────────────────
 
 const (
 	closeTypeZoneOptions = 0
 	closeTypeZoneButtons = 1
 )
 
-// ── Confirm focus zones ────────────────────────────────
-
 const (
 	closeZoneFee     = 0
 	closeZoneButtons = 1
 )
 
-// ── ChannelCloseScreen ─────────────────────────────────
-
 type ChannelCloseScreen struct {
-	ctx  *ScreenContext
-	step closeStep
+	ctx    *ScreenContext
+	client app.ChannelCloseClient
+	step   closeStep
 
 	// Channel info (snapshot at creation)
 	chanPoint string
 	peerAlias string
 	capacity  int64
 	localBal  int64
-	remoteBal int64
 
 	// Type step
 	typeIdx    int // 0=cooperative, 1=force
 	typeBtnIdx int // 0=Go Back, 1=Confirm
 
-	// Confirm step
+	// Fee form and final approval
 	force         bool
 	feeInput      AmountInput
 	feeTiers      [4]feeTier
-	focusZone     int // type step: 0=options, 1=buttons; confirm step: 0=fee, 1=buttons
-	confirmBtnIdx int // 0=Go Back, 1=Close/Force Close
-	inFlight      bool
+	focusZone     int // type step: 0=options, 1=buttons; fee step: 0=fee, 1=buttons
+	confirmBtnIdx int // 0=Go Back, 1=Review or close action
+	attempt       *channelCloseAttempt
+	result        app.ChannelCloseResult
 
-	// Result step
-	txid  string
+	// Input validation error
 	error string
 
 	// Cancelled is set when the user presses Cancel
@@ -75,22 +69,17 @@ func NewChannelCloseScreen(
 	peerAlias string,
 	capacity int64,
 	localBal int64,
-	remoteBal int64,
-	feeTiers [4]feeTier,
 ) *ChannelCloseScreen {
 	return &ChannelCloseScreen{
 		ctx:       ctx,
+		client:    ctx.LndClient,
 		step:      closeStepType,
 		chanPoint: chanPoint,
 		peerAlias: peerAlias,
 		capacity:  capacity,
 		localBal:  localBal,
-		remoteBal: remoteBal,
-		feeTiers:  feeTiers,
 	}
 }
-
-// ── Screen interface ────────────────────────────────────
 
 func (s *ChannelCloseScreen) Init() tea.Cmd {
 	return nil
@@ -102,8 +91,10 @@ func (s *ChannelCloseScreen) HandleKey(
 	switch s.step {
 	case closeStepType:
 		return s.handleTypeKey(keyStr)
-	case closeStepConfirm:
-		return s.handleConfirmKey(keyStr, msg)
+	case closeStepFee:
+		return s.handleFeeKey(keyStr, msg)
+	case closeStepReview:
+		return s.handleReviewKey(keyStr)
 	case closeStepClosing:
 		return s.handleClosingKey(keyStr)
 	case closeStepResult:
@@ -116,15 +107,15 @@ func (s *ChannelCloseScreen) HandleMsg(
 	msg tea.Msg,
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
-	case closeChannelMsg:
+	case channelCloseResultMsg:
 		return s.handleCloseResult(msg)
-	case feeTiersMsg:
-		if msg.err == nil {
+	case channelCloseFeesMsg:
+		if msg.screen == s && msg.err == nil && s.step < closeStepReview {
 			s.feeTiers = msg.tiers
 		}
 		return s, nil
 	case tea.PasteMsg:
-		if s.step == closeStepConfirm &&
+		if s.step == closeStepFee &&
 			!s.force &&
 			s.focusZone == closeZoneFee {
 			cmd := s.feeInput.Update(msg)
@@ -141,8 +132,10 @@ func (s *ChannelCloseScreen) View(
 	switch s.step {
 	case closeStepType:
 		return s.viewType(w, h)
-	case closeStepConfirm:
-		return s.viewConfirm(w, h)
+	case closeStepFee:
+		return s.viewFee(w, h)
+	case closeStepReview:
+		return s.viewReview(w, h)
 	case closeStepClosing:
 		return s.viewClosing(w, h)
 	case closeStepResult:
@@ -155,17 +148,17 @@ func (s *ChannelCloseScreen) HelpBindings() []key.Binding {
 	switch s.step {
 	case closeStepType:
 		return s.typeBindings()
-	case closeStepConfirm:
-		return s.confirmBindings()
+	case closeStepFee:
+		return s.feeBindings()
+	case closeStepReview:
+		return actionButtonBindings(s.confirmBtnIdx, s.ctx.HasTabs)
 	case closeStepClosing:
-		return inFlightBindings()
+		return []key.Binding{kSidebar, kUpShiftTabBar}
 	case closeStepResult:
 		return resultBindings(s.ctx.HasTabs)
 	}
 	return nil
 }
-
-// ── Type step ──────────────────────────────────────────
 
 func (s *ChannelCloseScreen) handleTypeKey(
 	keyStr string,
@@ -197,7 +190,7 @@ func (s *ChannelCloseScreen) handleTypeKey(
 			s.typeIdx++
 			return s, nil
 		}
-		// At bottom of options — move to buttons
+		// Move from the last option to the buttons.
 		s.focusZone = closeTypeZoneButtons
 		s.typeBtnIdx = 1 // default to Confirm
 		return s, nil
@@ -256,7 +249,7 @@ func (s *ChannelCloseScreen) handleTypeBtnKey(
 			s.Cancelled = true
 			return s, nil
 		}
-		// Confirm — advance to confirm step
+		// Force close has no editable fee policy.
 		s.force = s.typeIdx == 1
 		s.confirmBtnIdx = 0
 		s.error = ""
@@ -271,33 +264,26 @@ func (s *ChannelCloseScreen) handleTypeBtnKey(
 			s.focusZone = closeZoneFee
 		} else {
 			s.focusZone = closeZoneButtons
+			return s.prepareClose()
 		}
 
-		s.step = closeStepConfirm
+		s.step = closeStepFee
 		return s, nil
 	}
 	return s, nil
 }
 
-// ── Confirm step ───────────────────────────────────────
-
-func (s *ChannelCloseScreen) handleConfirmKey(
+func (s *ChannelCloseScreen) handleFeeKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
-	// Force close: no fee input, buttons only
-	if s.force {
-		return s.handleConfirmBtnKey(keyStr)
-	}
-
-	// Cooperative close: fee input + buttons
 	if s.focusZone == closeZoneFee {
-		return s.handleConfirmFeeKey(keyStr, msg)
+		return s.handleFeeInputKey(keyStr, msg)
 	}
 
-	return s.handleConfirmBtnKey(keyStr)
+	return s.handleFeeBtnKey(keyStr)
 }
 
-func (s *ChannelCloseScreen) handleConfirmFeeKey(
+func (s *ChannelCloseScreen) handleFeeInputKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
 	switch keyStr {
@@ -320,7 +306,6 @@ func (s *ChannelCloseScreen) handleConfirmFeeKey(
 		return s, cmd
 
 	case "down", "tab", "enter":
-		// Advance to buttons (pattern 19)
 		s.feeInput.Blur()
 		s.focusZone = closeZoneButtons
 		s.confirmBtnIdx = 1 // default to action
@@ -339,7 +324,7 @@ func (s *ChannelCloseScreen) handleConfirmFeeKey(
 	}
 }
 
-func (s *ChannelCloseScreen) handleConfirmBtnKey(
+func (s *ChannelCloseScreen) handleFeeBtnKey(
 	keyStr string,
 ) (Screen, tea.Cmd) {
 	switch keyStr {
@@ -361,15 +346,8 @@ func (s *ChannelCloseScreen) handleConfirmBtnKey(
 		return s, nil
 
 	case "up", "shift+tab":
-		if !s.force {
-			// Go back to fee input
-			s.focusZone = closeZoneFee
-			s.feeInput.Focus()
-			return s, nil
-		}
-		if s.ctx.HasTabs {
-			return s, emitFocusTabBar
-		}
+		s.focusZone = closeZoneFee
+		s.feeInput.Focus()
 		return s, nil
 
 	case "down", "tab":
@@ -388,41 +366,24 @@ func (s *ChannelCloseScreen) handleConfirmBtnKey(
 			s.focusZone = closeTypeZoneOptions
 			s.error = ""
 			return s, nil
-		case 1: // Close / Force Close
-			if s.inFlight {
-				return s, nil
-			}
-			s.inFlight = true
-			s.error = ""
-			s.step = closeStepClosing
-
-			var feeRate uint64
-			if !s.force {
-				r := s.feeInput.Sats()
-				if r > 0 {
-					feeRate = uint64(r)
-				}
-			}
-
-			return s, closeChannelCmd(
-				s.ctx.LndClient,
-				s.chanPoint,
-				s.force,
-				feeRate)
+		case 1: // Review
+			return s.prepareClose()
 		}
 	}
 	return s, nil
 }
 
-// ── Closing step ───────────────────────────────────────
-
 func (s *ChannelCloseScreen) handleClosingKey(
 	keyStr string,
 ) (Screen, tea.Cmd) {
+	switch keyStr {
+	case "left":
+		return s, emitFocusSidebar
+	case "up", "shift+tab":
+		return s, emitFocusTabBar
+	}
 	return s, nil
 }
-
-// ── Result step ────────────────────────────────────────
 
 func (s *ChannelCloseScreen) handleResultKey(
 	keyStr string,
@@ -431,9 +392,7 @@ func (s *ChannelCloseScreen) handleResultKey(
 	case "ctrl+c":
 		return s, tea.Quit
 	case "enter":
-		return s, tea.Batch(
-			emitCloseTab,
-			emitRefreshStatus)
+		return s, func() tea.Msg { return closeChannelDoneMsg{screen: s} }
 	case "left":
 		return s, emitFocusSidebar
 	case "up", "shift+tab":
@@ -446,23 +405,111 @@ func (s *ChannelCloseScreen) handleResultKey(
 	return s, nil
 }
 
-// ── Async message handler ──────────────────────────────
-
-func (s *ChannelCloseScreen) handleCloseResult(
-	msg closeChannelMsg,
-) (Screen, tea.Cmd) {
-	s.inFlight = false
-	if msg.err != nil {
-		s.error = msg.err.Error()
-	} else {
-		s.txid = msg.txid
-		s.error = ""
+func (s *ChannelCloseScreen) handleCloseResult(msg channelCloseResultMsg) (Screen, tea.Cmd) {
+	if s.step != closeStepClosing || s.attempt == nil || msg.attempt != s.attempt {
+		return s, nil
 	}
+	s.result = msg.result
 	s.step = closeStepResult
+	return s, emitRefreshStatus
+}
+
+func (s *ChannelCloseScreen) prepareClose() (Screen, tea.Cmd) {
+	rate := s.feeInput.Sats()
+	if s.force {
+		rate = 0
+	}
+	prepared, err := app.PrepareChannelClose(app.ChannelCloseInput{ChannelPoint: s.chanPoint, Force: s.force, SatPerVbyte: rate})
+	if err != nil {
+		s.error = err.Error()
+		return s, nil
+	}
+	s.attempt = &channelCloseAttempt{prepared: prepared, alias: s.peerAlias, capacity: s.capacity, localBalance: s.localBal}
+	s.step = closeStepReview
+	s.confirmBtnIdx = 0
+	s.error = ""
 	return s, nil
 }
 
-// ── Views ──────────────────────────────────────────────
+func (s *ChannelCloseScreen) handleReviewKey(key string) (Screen, tea.Cmd) {
+	back := func() {
+		s.attempt = nil
+		s.confirmBtnIdx = 0
+		if s.force {
+			s.step = closeStepType
+			s.focusZone = closeTypeZoneOptions
+		} else {
+			s.step = closeStepFee
+			s.focusZone = closeZoneButtons
+		}
+	}
+	switch key {
+	case "ctrl+c":
+		return s, tea.Quit
+	case "left":
+		if s.confirmBtnIdx > 0 {
+			s.confirmBtnIdx--
+		} else {
+			return s, emitFocusSidebar
+		}
+	case "right":
+		s.confirmBtnIdx = 1
+	case "up", "shift+tab":
+		return s, emitFocusTabBar
+	case "backspace":
+		back()
+	case "enter":
+		if s.confirmBtnIdx == 0 {
+			back()
+			return s, nil
+		}
+		if s.attempt == nil {
+			return s, nil
+		}
+		s.step = closeStepClosing
+		return s, closeChannelCmd(s.client, s.attempt)
+	}
+	return s, nil
+}
+
+type closeChannelDoneMsg struct{ screen *ChannelCloseScreen }
+
+func channelCloseBusy(screen Screen) bool {
+	detail, ok := screen.(*ChannelDetailScreen)
+	return ok && detail.closeScreen != nil && detail.closeScreen.step == closeStepClosing
+}
+
+func (s *ChannelCloseScreen) viewReview(w, h int) string {
+	p := newPane(w)
+	req := s.attempt.prepared.Request()
+	p.title(theme.Warning, "Confirm Channel Close")
+	p.field("Peer: ", s.attempt.alias)
+	p.labelLine("Funding outpoint:")
+	p.monoWrap(req.ChannelPoint)
+	p.line("Capacity: " + formatSats(s.attempt.capacity) + " sats")
+	p.line("Local balance snapshot: " + formatSats(s.attempt.localBalance) + " sats")
+	if req.Force {
+		p.warn("Type: Force close (unilateral)")
+		p.line("Commitment fee is predefined; sweeps add fees.")
+		p.warnWrapWords("Recovery depends on channel timelocks, HTLCs and confirmations. Funds are not immediately available.")
+	} else {
+		p.line("Type: Cooperative close")
+		if req.SatPerVbyte == 0 {
+			p.line("Fee rate: auto (LND default)")
+		} else {
+			p.line(fmt.Sprintf("Requested fee rate: %d sat/vB", req.SatPerVbyte))
+		}
+		p.line("Total fee and returned amount: unknown before close")
+		p.line("Requires peer cooperation; confirmation is still needed.")
+	}
+	p.dim("The local balance is not a payout quote.")
+	p.warn("Closing a channel cannot be undone.")
+	action := "Close Channel"
+	if req.Force {
+		action = "Force Close"
+	}
+	return p.renderWithBottomButtons([]string{"Go Back", action}, s.confirmBtnIdx, s.ctx.ContentFocused, h)
+}
 
 func (s *ChannelCloseScreen) viewType(
 	w, h int,
@@ -500,8 +547,7 @@ func (s *ChannelCloseScreen) viewType(
 		coopPrefix,
 		coopStyle.Render("Cooperative close")))
 	p.line("  " + theme.Dim.Render(
-		"Requires peer online. Funds available"+
-			" immediately."))
+		"Requires peer cooperation and confirmation."))
 	p.blank()
 
 	forcePrefix := " "
@@ -517,93 +563,38 @@ func (s *ChannelCloseScreen) viewType(
 		forcePrefix,
 		forceStyle.Render("Force close")))
 	p.line("  " + theme.Dim.Render(
-		"Unilateral. Funds locked ~2 weeks."))
+		"Unilateral. Timelocks and recovery fees apply."))
 
+	p.appendError(s.error)
 	return p.renderWithBottomButtons(
 		[]string{"Go Back", "Confirm"},
 		s.typeBtnIdx, onButtons, h)
 }
 
-func (s *ChannelCloseScreen) viewConfirm(
-	w, h int,
-) string {
+func (s *ChannelCloseScreen) viewFee(w, h int) string {
 	p := newPane(w)
-
-	if s.force {
-		p.title(theme.Warning,
-			"⚠ Force Close Channel")
-	} else {
-		p.title(theme.Warning, "Close Channel")
-	}
-
-	p.field("Peer:     ", s.peerAlias)
-	p.field("Capacity: ",
-		formatSats(s.capacity)+" sats")
-	p.field("Your bal: ",
-		formatSats(s.localBal)+" sats")
+	p.title(theme.Header, "Cooperative Close Fee")
+	p.field("Peer: ", s.peerAlias)
+	p.labelLine("Funding outpoint:")
+	p.monoWrap(s.chanPoint)
 	p.blank()
-
-	if s.force {
-		p.warn("Force close will lock your funds")
-		p.warn("for up to 2,016 blocks (~2 weeks).")
-		p.warn("Use cooperative close when possible.")
+	p.input("Fee rate (sat/vB):", s.feeInput.View(), s.ctx.ContentFocused && s.focusZone == closeZoneFee)
+	p.dim("Blank or zero uses LND's automatic fee policy.")
+	p.dim("This is a requested rate, not a maximum total fee.")
+	p.dim("Total fee and returned amount are not yet known.")
+	if hints := formatFeeHints(s.feeTiers); hints != "" {
 		p.blank()
-	} else {
-		// Fee rate input
-		isFeeZone := s.ctx.ContentFocused &&
-			s.focusZone == closeZoneFee
-		p.input("Fee rate (sat/vB):",
-			s.feeInput.View(), isFeeZone)
-
-		// Estimated total fee
-		feeRate := s.feeInput.Sats()
-		if feeRate > 0 {
-			estFee := int64(feeRate * 170)
-			p.line(" " + theme.Dim.Render(
-				fmt.Sprintf("Est. fee: ~%s sats",
-					formatSats(estFee))))
-		}
-
-		// Fee reference hints
-		hints := formatFeeHints(s.feeTiers)
-		if hints != "" {
-			p.blank()
-			p.dim(hints)
-		}
-		p.blank()
+		p.dim(hints)
 	}
-
-	if s.force {
-		p.warn("Force close this channel?")
-	} else {
-		p.warn("Close this channel cooperatively?")
-	}
-
 	p.appendError(s.error)
-
-	// ── Buttons pinned to bottom ──
-	isBtnFocused := s.ctx.ContentFocused &&
-		s.focusZone == closeZoneButtons
-	if s.force {
-		isBtnFocused = s.ctx.ContentFocused
-	}
-
-	var labels []string
-	if s.force {
-		labels = []string{"Go Back", "Force Close"}
-	} else {
-		labels = []string{"Go Back", "Close Channel"}
-	}
-
-	return p.renderWithBottomButtons(
-		labels, s.confirmBtnIdx, isBtnFocused, h)
+	return p.renderWithBottomButtons([]string{"Go Back", "Review"}, s.confirmBtnIdx, s.ctx.ContentFocused && s.focusZone == closeZoneButtons, h)
 }
 
 func (s *ChannelCloseScreen) viewClosing(
 	w, h int,
 ) string {
 	p := newPane(w)
-	if s.force {
+	if s.attempt.prepared.Request().Force {
 		p.title(theme.Warning,
 			"Force Closing Channel...")
 	} else {
@@ -611,54 +602,48 @@ func (s *ChannelCloseScreen) viewClosing(
 			"Closing Channel...")
 	}
 	p.line(" " + theme.Value.Render(
-		"Broadcasting close transaction."))
+		"Checking channel state and requesting close."))
 	p.blank()
-	p.dim("May take up to 2 minutes over Tor.")
+	p.dim("This may take several minutes over Tor.")
 	p.dim("Do not close the terminal.")
 
 	return p.renderWithBottomButtons(
 		[]string{"Closing..."}, 0, false, h)
 }
 
-func (s *ChannelCloseScreen) viewResult(
-	w, h int,
-) string {
+func (s *ChannelCloseScreen) viewResult(w, h int) string {
 	p := newPane(w)
-
-	if s.error != "" {
-		p.title(theme.Warning,
-			"Channel Close Failed")
-		p.warnWrap(s.error)
-	} else {
-		if s.force {
-			p.title(theme.Warning,
-				"Force Close Broadcast")
-			p.line(" " + theme.Value.Render(
-				"Force close transaction broadcast."))
-			p.blank()
-			p.warn("Funds locked for ~2,016 blocks" +
-				" (~2 weeks).")
-		} else {
-			p.title(theme.Success,
-				"Channel Closing")
-			p.line(" " + theme.Value.Render(
-				"Cooperative close broadcast."))
-		}
+	switch s.result.State {
+	case app.ClosePending:
+		p.title(theme.Header, "Channel Closing")
+		p.line("LND reported a closing transaction; confirmation is pending.")
+		p.labelLine("Candidate closing TX:")
+		p.monoWrap(s.result.Txid)
+		p.dim("The candidate may change. Check pending channels and history.")
+	case app.CloseConfirmed:
+		p.title(theme.Success, "Close Transaction Confirmed")
+		p.labelLine("Confirmed closing TX:")
+		p.monoWrap(s.result.Txid)
+	case app.CloseOutcomeUnknown:
+		p.title(theme.Warning, "Channel Close Outcome Unknown")
+		p.warnWrapWords("The close may still complete. Check pending channels and history before another request; repeating a close can request a fee bump.")
+	default:
+		p.title(theme.Warning, "Channel Close Not Submitted")
+	}
+	if s.attempt != nil {
+		req := s.attempt.prepared.Request()
 		p.blank()
-		p.field("Peer:   ", s.peerAlias)
-		if s.txid != "" {
-			p.blank()
-			p.labelLine("Closing TX:")
-			p.monoWrap(s.txid)
+		p.labelLine("Funding outpoint:")
+		p.monoWrap(req.ChannelPoint)
+		if req.Force && s.result.State != app.CloseNotSubmitted {
+			p.warnWrapWords("Force-close outputs may still need timelocks, HTLC resolution and sweeps. Transaction confirmation is not full fund recovery.")
 		}
 	}
-
-	return p.renderWithBottomButtons(
-		[]string{"Done"}, 0,
-		s.ctx.ContentFocused, h)
+	if s.result.Err != nil {
+		p.warnWrap(s.result.Err.Error())
+	}
+	return p.renderWithBottomButtons([]string{"Done"}, 0, s.ctx.ContentFocused, h)
 }
-
-// ── Helpbar bindings ───────────────────────────────────
 
 func (s *ChannelCloseScreen) typeBindings() []key.Binding {
 	var binds []key.Binding
@@ -679,28 +664,13 @@ func (s *ChannelCloseScreen) typeBindings() []key.Binding {
 	return binds
 }
 
-func (s *ChannelCloseScreen) confirmBindings() []key.Binding {
-	var binds []key.Binding
-	if !s.force && s.focusZone == closeZoneFee {
-		binds = append(binds,
-			kTabNext, kEnterNext, kSidebar)
+func (s *ChannelCloseScreen) feeBindings() []key.Binding {
+	if s.focusZone == closeZoneFee {
+		binds := []key.Binding{kTabNext, kEnterNext, kSidebar}
 		if s.ctx.HasTabs {
 			binds = append(binds, kShiftTabBar)
 		}
-	} else {
-		binds = append(binds,
-			kLeftRightButtons, kEnter)
-		if !s.force {
-			binds = append(binds,
-				bind("⇧tab", "fee", "shift+tab"))
-		} else {
-			binds = append(binds, kSidebar)
-			if s.ctx.HasTabs {
-				binds = append(binds, kUpTabBar)
-			}
-		}
-		binds = append(binds, kBack)
+		return append(binds, kQuit)
 	}
-	binds = append(binds, kQuit)
-	return binds
+	return []key.Binding{kLeftRightButtons, kEnter, bind("⇧tab", "fee", "shift+tab"), kSidebar, kBack, kQuit}
 }

--- a/internal/tui/screen_channels_close_test.go
+++ b/internal/tui/screen_channels_close_test.go
@@ -1,0 +1,270 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type screenCloseClient struct {
+	sent   []lndrpc.ChannelCloseRequest
+	result lndrpc.ChannelCloseResult
+}
+
+func (c *screenCloseClient) ChannelCloseState(string) (lndrpc.ChannelCloseState, error) {
+	return lndrpc.ChannelCloseState{Found: true, Active: true, StatusFlags: "ChanStatusDefault"}, nil
+}
+func (c *screenCloseClient) CloseChannel(req lndrpc.ChannelCloseRequest) lndrpc.ChannelCloseResult {
+	c.sent = append(c.sent, req)
+	return c.result
+}
+func closeScreenFixture(point string) (*ChannelDetailScreen, *screenCloseClient) {
+	ctx := &ScreenContext{Cfg: config.Default(), HasTabs: true, ContentFocused: true}
+	ch := channelInfo{ChannelPoint: point, PeerAlias: "same peer", RemotePubkey: strings.Repeat("a", 66), Capacity: 30000, LocalBalance: 20000, Active: true}
+	detail := NewChannelDetailScreen(ctx, ch)
+	detail.launchClose()
+	c := &screenCloseClient{result: lndrpc.ChannelCloseResult{Submitted: true, ClosingTxid: strings.Repeat("c", 64)}}
+	detail.closeScreen.client = c
+	return detail, c
+}
+func reviewClose(t *testing.T, s *ChannelCloseScreen, force bool, rate int64) {
+	t.Helper()
+	s.focusZone = closeTypeZoneButtons
+	s.typeBtnIdx = 1
+	if force {
+		s.typeIdx = 1
+	}
+	s.HandleKey("enter", tea.KeyPressMsg{})
+	if !force {
+		if s.step != closeStepFee {
+			t.Fatal("cooperative close skipped fee form")
+		}
+		s.feeInput.SetSats(rate)
+		s.focusZone = closeZoneButtons
+		s.confirmBtnIdx = 1
+		s.HandleKey("enter", tea.KeyPressMsg{})
+	}
+	if s.step != closeStepReview || s.attempt == nil {
+		t.Fatalf("no immutable review: %s", s.error)
+	}
+}
+func submitClose(t *testing.T, s *ChannelCloseScreen) tea.Cmd {
+	t.Helper()
+	s.confirmBtnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil || s.step != closeStepClosing {
+		t.Fatal("close was not scheduled")
+	}
+	return cmd
+}
+func TestChannelCloseFrozenReviewAndCopy(t *testing.T) {
+	theme.Init(true)
+	for _, tc := range []struct {
+		name  string
+		force bool
+		rate  int64
+	}{{"automatic", false, 0}, {"manual", false, 14}, {"force", true, 0}} {
+		t.Run(tc.name, func(t *testing.T) {
+			detail, c := closeScreenFixture(strings.Repeat("a", 64) + ":7")
+			s := detail.closeScreen
+			reviewClose(t, s, tc.force, tc.rate)
+			before := s.View(67, 30)
+			want := s.attempt.prepared.Request()
+			if !strings.Contains(before, "Funding outpoint:") || !strings.Contains(before, "not a payout quote") {
+				t.Fatal("missing confirmation identity/accounting")
+			}
+			if tc.force {
+				if !strings.Contains(before, "Force close") || !strings.Contains(before, "sweeps add fees") {
+					t.Fatal("force costs not disclosed")
+				}
+			} else if tc.rate == 0 && !strings.Contains(before, "auto (LND default)") {
+				t.Fatal("automatic policy hidden")
+			}
+			if lipgloss.Width(before) > 67 || len(strings.Split(before, "\n")) > 30 {
+				t.Fatal("review exceeds supported pane")
+			}
+			s.feeInput.SetSats(900)
+			s.force = !tc.force
+			s.chanPoint = strings.Repeat("b", 64) + ":2"
+			s.peerAlias = "changed"
+			s.localBal = 1
+			s.HandleMsg(channelCloseFeesMsg{screen: s, tiers: [4]feeTier{{SatPerVB: 99}}})
+			s.HandleMsg(tea.PasteMsg{Content: "999"})
+			if s.View(67, 30) != before {
+				t.Fatal("late input changed approved review")
+			}
+			cmd := submitClose(t, s)
+			if _, again := s.HandleKey("enter", tea.KeyPressMsg{}); again != nil {
+				t.Fatal("double confirmation scheduled another close")
+			}
+			s.HandleMsg(cmd())
+			if len(c.sent) != 1 || c.sent[0] != want {
+				t.Fatal("execution differed from review")
+			}
+		})
+	}
+}
+func TestChannelCloseBackRequiresNewReview(t *testing.T) {
+	for _, force := range []bool{false, true} {
+		detail, _ := closeScreenFixture(strings.Repeat("a", 64) + ":0")
+		s := detail.closeScreen
+		reviewClose(t, s, force, 10)
+		old := s.attempt
+		s.HandleKey("backspace", tea.KeyPressMsg{})
+		if s.attempt != nil || s.step == closeStepReview {
+			t.Fatal("back retained approval")
+		}
+		if force {
+			if s.step != closeStepType {
+				t.Fatal("force back did not return to type")
+			}
+		} else {
+			s.feeInput.SetSats(20)
+			s.confirmBtnIdx = 1
+			s.HandleKey("enter", tea.KeyPressMsg{})
+			if s.step != closeStepReview || s.attempt == old || s.attempt.prepared.Request().SatPerVbyte != 20 {
+				t.Fatal("edited policy did not get a new review")
+			}
+		}
+	}
+}
+func TestChannelTabIdentitySurvivesReorderAndRemoval(t *testing.T) {
+	a := channelInfo{ChannelPoint: strings.Repeat("a", 64) + ":0", RemotePubkey: strings.Repeat("c", 66), PeerAlias: "same peer", Capacity: 30000}
+	b := a
+	b.ChannelPoint = strings.Repeat("b", 64) + ":0"
+	ctx := &ScreenContext{Cfg: config.Default(), Status: &statusMsg{channels: []channelInfo{a, b}}}
+	home := NewChannelsHomeScreen(ctx)
+	home.focusZone = chanHomeZoneList
+	m := Model{nav: NewNavSidebar(), screenCtx: ctx}
+	m.nav.ActiveItem = secChannels
+	open := func(row int) {
+		t.Helper()
+		home.cursor = row
+		_, cmd := home.handleEnter()
+		updated, _ := m.Update(cmd())
+		m = updated.(Model)
+	}
+	open(1)
+	first := m.tabs[0].Screen
+	open(0)
+	if len(m.tabs) != 2 || m.tabs[1].Key != a.ChannelPoint {
+		t.Fatal("row zero reused a different channel")
+	}
+	ctx.Status.channels = []channelInfo{b, a}
+	open(0)
+	if len(m.tabs) != 2 || m.effectiveTabs()[m.activeTab].Screen != first {
+		t.Fatal("reorder changed channel tab identity")
+	}
+	ctx.Status.channels = []channelInfo{a}
+	m.activateTab()
+	stale := first.(*ChannelDetailScreen)
+	if !stale.unavailable {
+		t.Fatal("vanished channel still presented as available")
+	}
+	stale.launchClose()
+	if stale.closeScreen != nil {
+		t.Fatal("vanished channel launched a close")
+	}
+	updated, _ := m.closeTab(m.activeTab)
+	m = updated.(Model)
+	if len(m.tabs) != 1 || m.tabs[0].Key != a.ChannelPoint {
+		t.Fatal("closing one channel tab removed its sibling")
+	}
+}
+func TestChannelCloseOwnershipAcrossTabsAndSections(t *testing.T) {
+	a, _ := closeScreenFixture(strings.Repeat("a", 64) + ":0")
+	b, secondClient := closeScreenFixture(strings.Repeat("b", 64) + ":0")
+	secondClient.result = lndrpc.ChannelCloseResult{Submitted: true, Err: errors.New("close stream: deadline exceeded")}
+	m := Model{nav: NewNavSidebar(), screenCtx: a.ctx, activeTab: 1, tabs: []openTab{
+		{Kind: tabChannel, Key: a.channel.ChannelPoint, Section: secChannels, Screen: a},
+		{Kind: tabChannel, Key: b.channel.ChannelPoint, Section: secChannels, Screen: b},
+	}}
+	m.nav.ActiveItem = secChannels
+	m.Update(channelCloseFeesMsg{screen: b.closeScreen, tiers: [4]feeTier{{SatPerVB: 13}}})
+	if a.closeScreen.feeTiers[0].SatPerVB != 0 || b.closeScreen.feeTiers[0].SatPerVB != 13 {
+		t.Fatal("fee suggestion reached wrong tab")
+	}
+	reviewClose(t, a.closeScreen, false, 2)
+	reviewClose(t, b.closeScreen, true, 0)
+	first := submitClose(t, a.closeScreen)
+	closed, _ := m.closeTab(1)
+	if len(closed.(Model).tabs) != 2 {
+		t.Fatal("submitted close tab could be removed")
+	}
+	replacement, _ := closeScreenFixture(a.channel.ChannelPoint)
+	updated, _ := m.Update(openTabMsg{Kind: tabChannel, Key: a.channel.ChannelPoint, Screen: replacement, Replace: true})
+	m = updated.(Model)
+	if m.tabs[0].Screen != a {
+		t.Fatal("submitted close tab was replaced")
+	}
+	// Hide Channels while the first attempt finishes and another is only reviewed.
+	m.nav.ActiveItem = secWallet
+	result := first()
+	updated, refresh := m.Update(result)
+	m = updated.(Model)
+	if a.closeScreen.step != closeStepResult || b.closeScreen.step != closeStepReview || refresh == nil {
+		t.Fatal("hidden completion lost ownership")
+	}
+	second := submitClose(t, b.closeScreen)
+	if _, cmd := m.Update(result); cmd != nil || b.closeScreen.step != closeStepClosing {
+		t.Fatal("old completion affected another attempt")
+	}
+	// Done must remove its owning detail tab even after navigation changes.
+	_, done := a.closeScreen.HandleKey("enter", tea.KeyPressMsg{})
+	updated, _ = m.Update(done())
+	m = updated.(Model)
+	if len(m.tabs) != 1 || m.tabs[0].Screen != b {
+		t.Fatal("Done removed the wrong tab")
+	}
+	updated, _ = m.Update(done())
+	m = updated.(Model)
+	if len(m.tabs) != 1 {
+		t.Fatal("duplicate Done removed another tab")
+	}
+	updated, refresh = m.Update(second())
+	m = updated.(Model)
+	if b.closeScreen.step != closeStepResult || b.closeScreen.result.State != app.CloseOutcomeUnknown || refresh == nil {
+		t.Fatal("second close lost completion")
+	}
+}
+func TestChannelCloseResultsAreHonestAndFit(t *testing.T) {
+	theme.Init(true)
+	for _, tc := range []struct {
+		name  string
+		state app.ChannelCloseOutcome
+		force bool
+		want  string
+	}{
+		{"candidate", app.ClosePending, false, "Candidate closing TX"},
+		{"confirmed", app.CloseConfirmed, true, "not full fund recovery"},
+		{"unknown", app.CloseOutcomeUnknown, false, "repeating a close"},
+		{"force unknown", app.CloseOutcomeUnknown, true, "repeating a close"},
+		{"not submitted", app.CloseNotSubmitted, false, "Not Submitted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			detail, _ := closeScreenFixture(strings.Repeat("a", 64) + ":0")
+			s := detail.closeScreen
+			reviewClose(t, s, tc.force, 0)
+			submitClose(t, s)
+			result := app.ChannelCloseResult{State: tc.state, Txid: strings.Repeat("c", 64)}
+			if tc.state == app.CloseOutcomeUnknown {
+				result.Err = errors.New("close stream: deadline exceeded")
+			}
+			s.HandleMsg(channelCloseResultMsg{attempt: s.attempt, result: result})
+			view := s.View(67, 30)
+			if !strings.Contains(view, tc.want) || strings.Contains(view, "2,016") || strings.Contains(view, "Close Failed") {
+				t.Fatalf("misleading close result: %s", view)
+			}
+			if lipgloss.Width(view) > 67 || len(strings.Split(view, "\n")) > 30 {
+				t.Fatal("result exceeds supported pane")
+			}
+		})
+	}
+}

--- a/internal/tui/screen_channels_detail.go
+++ b/internal/tui/screen_channels_detail.go
@@ -10,31 +10,17 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
-// ── ChannelDetailScreen ────────────────────────────────
-// Channel detail view. Displays channel info and a Close
-// Channel button. When the user presses Close, the screen
-// delegates to an embedded ChannelCloseScreen rather than
-// opening a separate tab — the close flow, result, and
-// tab close all happen within this detail tab. No stale
-// detail tab after channel closure.
-//
-// The close screen is a separate type composed via a
-// pointer field (option 2 in the design discussion). The
-// detail screen acts as a thin router: when closeScreen
-// is non-nil, all interface methods delegate to it. The
-// close screen stays independently testable.
-
+// ChannelDetailScreen retains the selected funding outpoint and owns its close
+// flow. The embedded screen owns approval and the result for that channel.
 type ChannelDetailScreen struct {
-	ctx     *ScreenContext
-	channel channelInfo
+	ctx         *ScreenContext
+	channel     channelInfo
+	unavailable bool
 
 	// Button index for detail view (0=Cancel, 1=Close)
 	viewBtnIdx int
 
-	// Fee tiers snapshot for passing to close screen
-	feeTiers [4]feeTier
-
-	// Close flow delegation — nil means detail view,
+	// A nil close screen means the detail view is active;
 	// non-nil means the close flow is active and all
 	// input/rendering delegates to it.
 	closeScreen *ChannelCloseScreen
@@ -43,12 +29,10 @@ type ChannelDetailScreen struct {
 func NewChannelDetailScreen(
 	ctx *ScreenContext,
 	ch channelInfo,
-	feeTiers [4]feeTier,
 ) *ChannelDetailScreen {
 	return &ChannelDetailScreen{
-		ctx:      ctx,
-		channel:  ch,
-		feeTiers: feeTiers,
+		ctx:     ctx,
+		channel: ch,
 	}
 }
 
@@ -72,8 +56,8 @@ func (s *ChannelDetailScreen) HandleKey(
 		return s, cmd
 	}
 
-	// Pending channels: view-only, no button
-	if s.channel.Pending {
+	// Pending or unavailable channels have no close action.
+	if s.channel.Pending || s.unavailable {
 		switch keyStr {
 		case "ctrl+c":
 			return s, tea.Quit
@@ -123,25 +107,22 @@ func (s *ChannelDetailScreen) HandleMsg(
 		s.closeScreen = newClose.(*ChannelCloseScreen)
 		return s, cmd
 	}
-	switch msg := msg.(type) {
+	switch msg.(type) {
 	case tabActivatedMsg:
 		// Re-find the channel in live status data
 		// so the detail view reflects any changes
 		// since this tab was last viewed (e.g.
 		// balance change after payment settlement).
 		if s.ctx.Status != nil {
+			s.unavailable = true
 			for _, ch := range s.ctx.Status.channels {
 				if ch.ChannelPoint ==
 					s.channel.ChannelPoint {
+					s.unavailable = false
 					s.channel = ch
 					break
 				}
 			}
-		}
-		return s, nil
-	case feeTiersMsg:
-		if msg.err == nil {
-			s.feeTiers = msg.tiers
 		}
 		return s, nil
 	}
@@ -160,7 +141,10 @@ func (s *ChannelDetailScreen) View(
 
 	name := ch.PeerAlias
 	if name == "" {
-		name = ch.RemotePubkey[:16] + "..."
+		name = ch.RemotePubkey
+		if len(name) > 16 {
+			name = name[:16] + "..."
+		}
 	}
 	p.title(theme.Header, name)
 
@@ -170,6 +154,9 @@ func (s *ChannelDetailScreen) View(
 	}
 	if ch.Pending {
 		status = theme.Dim.Render("pending")
+	}
+	if s.unavailable {
+		status = theme.Warning.Render("unavailable; check pending channels and history")
 	}
 
 	p.line(" " + theme.Label.Render("Status:    ") +
@@ -215,8 +202,8 @@ func (s *ChannelDetailScreen) View(
 			fmt.Sprintf("%d", ch.ChanID))
 	}
 
-	// Cancel / Close Channel pinned to bottom (not for pending)
-	if !ch.Pending {
+	// Only available open channels offer a close action.
+	if !ch.Pending && !s.unavailable {
 		btnFocused := s.ctx.ContentFocused
 		return p.renderWithBottomButtons(
 			[]string{"Cancel", "Close Channel"},
@@ -230,7 +217,7 @@ func (s *ChannelDetailScreen) HelpBindings() []key.Binding {
 	if s.closeScreen != nil {
 		return s.closeScreen.HelpBindings()
 	}
-	if s.channel.Pending {
+	if s.channel.Pending || s.unavailable {
 		return viewDetailBindings(s.ctx.HasTabs)
 	}
 	return detailActionBindings(
@@ -242,13 +229,14 @@ func (s *ChannelDetailScreen) HelpBindings() []key.Binding {
 func (s *ChannelDetailScreen) launchClose() (
 	Screen, tea.Cmd,
 ) {
+	if s.unavailable || s.channel.Pending {
+		return s, nil
+	}
 	s.closeScreen = NewChannelCloseScreen(
 		s.ctx,
 		s.channel.ChannelPoint,
 		s.channel.PeerAlias,
 		s.channel.Capacity,
-		s.channel.LocalBalance,
-		s.channel.RemoteBalance,
-		s.feeTiers)
-	return s, fetchFeeTiersCmd(s.ctx.Cfg)
+		s.channel.LocalBalance)
+	return s, closeFeeTiersCmd(s.closeScreen)
 }

--- a/internal/tui/screen_channels_home.go
+++ b/internal/tui/screen_channels_home.go
@@ -161,19 +161,21 @@ func (s *ChannelsHomeScreen) handleEnter() (
 		ch := channels[s.cursor]
 		label := ch.PeerAlias
 		if label == "" {
-			label = ch.RemotePubkey[:12] + ".."
+			label = ch.RemotePubkey
+			if len(label) > 12 {
+				label = label[:12] + ".."
+			}
 		}
 		if len(label) > 17 {
 			label = label[:17] + "..."
 		}
 		screen := NewChannelDetailScreen(
-			s.ctx, ch, s.feeTiers())
-		idx := s.cursor
+			s.ctx, ch)
 		return s, func() tea.Msg {
 			return openTabMsg{
 				Kind:   tabChannel,
 				Label:  label,
-				Index:  idx,
+				Key:    ch.ChannelPoint,
 				Screen: screen,
 			}
 		}
@@ -538,14 +540,6 @@ func (s *ChannelsHomeScreen) channels() []channelInfo {
 		return nil
 	}
 	return s.ctx.Status.channels
-}
-
-func (s *ChannelsHomeScreen) feeTiers() [4]feeTier {
-	// Fee tiers are stored on OnChainContext but the
-	// screen doesn't have access to it. Return zero
-	// tiers — ChannelDetailScreen will receive them
-	// via feeTiersMsg routed by Model.
-	return [4]feeTier{}
 }
 
 func (s *ChannelsHomeScreen) clampCursor() {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -160,6 +160,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.closeScreenTab(msg.screen)
+	case closeChannelDoneMsg:
+		if msg.screen == nil || msg.screen.step != closeStepResult {
+			return m, nil
+		}
+		for _, tab := range m.tabs {
+			if detail, ok := tab.Screen.(*ChannelDetailScreen); ok && detail.closeScreen == msg.screen {
+				return m.closeScreenTab(detail)
+			}
+		}
+		return m, nil
 	case focusSidebarMsg:
 		m.focusSidebar()
 		return m, nil
@@ -223,8 +233,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case refreshStatusMsg:
 		return m, fetchStatus(m.cfg, m.state, m.lndClient)
 	case openTabMsg:
+		if msg.Kind == tabChannel {
+			detail, ok := msg.Screen.(*ChannelDetailScreen)
+			if !ok || msg.Key == "" || detail.channel.ChannelPoint != msg.Key || m.nav.ActiveSection() != secChannels {
+				return m, nil
+			}
+			for i, tab := range m.effectiveTabs() {
+				if tab.Kind == tabChannel && tab.Key == msg.Key {
+					m.activeTab = i
+					m.rememberTabPosition()
+					m.focusContent()
+					return m, m.activateTab()
+				}
+			}
+		}
 		// Dedup by kind + index if Index is set
-		if msg.Index != 0 {
+		if msg.Kind != tabChannel && msg.Index != 0 {
 			tabs := m.effectiveTabs()
 			for i, t := range tabs {
 				if t.Kind == msg.Kind &&
@@ -242,7 +266,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Dedup flow tabs by kind + section
-		if msg.Index == 0 {
+		if msg.Kind != tabChannel && msg.Index == 0 {
 			sec := m.nav.ActiveSection()
 			tabs := m.effectiveTabs()
 			for i, t := range tabs {
@@ -278,6 +302,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Kind:    msg.Kind,
 			Label:   msg.Label,
 			Index:   msg.Index,
+			Key:     msg.Key,
 			Section: m.nav.ActiveSection(),
 			Parent:  msg.Parent,
 			Screen:  msg.Screen,
@@ -392,29 +417,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case sendCoinsResultMsg:
 		return m.dispatchToTab(tabOnChain, msg)
-	case closeChannelMsg:
-		// Broadcast to all channel detail tabs — only
-		// the one with an active close flow (embedded
-		// ChannelCloseScreen) will consume the message.
-		// Broadcast is needed because multiple detail
-		// tabs can be open simultaneously, and
-		// dispatchToTab's first-match would miss the
-		// active close flow if it's not on the first
-		// detail tab.
-		tabs := m.effectiveTabs()
+	case channelCloseResultMsg, channelCloseFeesMsg:
 		var cmds []tea.Cmd
-		for i, tab := range tabs {
-			if tab.Kind == tabChannel &&
-				tab.Screen != nil {
-				m.screenCtx.HasTabs = m.hasDetailTabs()
-				m.screenCtx.ContentFocused =
-					m.contentFocused
-				newScreen, cmd :=
-					tab.Screen.HandleMsg(msg)
-				m.setTabScreen(i, newScreen)
-				if cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+		for i, tab := range m.tabs {
+			if tab.Kind != tabChannel || tab.Screen == nil {
+				continue
+			}
+			m.screenCtx.HasTabs = true
+			m.screenCtx.ContentFocused = m.contentFocused && tab.Section == m.nav.ActiveSection()
+			screen, cmd := tab.Screen.HandleMsg(msg)
+			m.tabs[i].Screen = screen
+			if cmd != nil {
+				cmds = append(cmds, cmd)
 			}
 		}
 		return m, tea.Batch(cmds...)
@@ -439,7 +453,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Keep each screen update and batch the resulting commands.
 		var cmds []tea.Cmd
 		for _, kind := range []tabKind{
-			tabChannel, tabOnChain, tabOpenChannel,
+			tabOnChain, tabOpenChannel,
 		} {
 			rm, cmd, ok := m.routeToScreen(kind, msg)
 			if !ok {
@@ -901,8 +915,8 @@ func (m Model) closeTab(
 	}
 
 	closingTab := tabs[tabIdx]
-	// Keep submitted funding operations reachable until their bounded calls return.
-	if onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) {
+	// Keep submitted operations reachable until their bounded calls return.
+	if onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) || channelCloseBusy(closingTab.Screen) {
 		return m, nil
 	}
 
@@ -917,7 +931,7 @@ func (m Model) closeTab(
 			return false
 		}
 		if t.Kind == closingTab.Kind &&
-			t.Index == closingTab.Index {
+			t.Index == closingTab.Index && t.Key == closingTab.Key {
 			return true
 		}
 		// Cascade: remove children whose Parent is
@@ -1046,6 +1060,7 @@ func (m *Model) setTabScreen(
 	for i := range m.tabs {
 		if m.tabs[i].Kind == target.Kind &&
 			m.tabs[i].Index == target.Index &&
+			m.tabs[i].Key == target.Key &&
 			m.tabs[i].Section == target.Section {
 			m.tabs[i].Screen = s
 			return


### PR DESCRIPTION
Channel tabs previously used list positions as identity, and close results could reach the wrong flow or disappear after changing sections.

This change:
- Identifies channel tabs by funding outpoint.
- Preserves the reviewed channel, close mode and fee policy through submission.
- Checks current channel state before submitting.
- Delivers results and Done actions to the owning tab.
- Removes unsupported fee and fund-availability promises.

Validation:
- Local Go 1.26.8 formatting, module, tests, race tests, vet and build checks passed.
- Two-node Signet testing covered reviewed settings, cooperative close, stale-channel refusal, force-close submission and correct tab dismissal.
- Automated tests cover cross-section result delivery. The live navigation timing check is deferred.

During testing, we reproduced an independent LND force-close recovery failure after restart, reported in [lightningnetwork/lnd#11182](https://github.com/lightningnetwork/lnd/issues/11182). This PR validates close submission and result handling; complete force-close recovery remains unresolved upstream.