### PR TITLE
refactor: own wallet creation and completion

### DIFF
--- a/internal/app/wallet_creation.go
+++ b/internal/app/wallet_creation.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type WalletPresence int
+
+const (
+	WalletUnknown WalletPresence = iota
+	WalletAbsent
+	WalletPresent
+)
+
+// WalletExecution records process evidence separately from terminal restoration.
+// A failed command does not establish that InitWallet was rejected by LND.
+type WalletExecution struct {
+	Created          bool
+	SeedAcknowledged bool
+	Err              error
+}
+
+type WalletCreationResult struct {
+	Presence          WalletPresence
+	CredentialsStaged bool
+	SeedAcknowledged  bool
+	Err               error
+}
+
+func (r WalletCreationResult) CanRetryFinalization() bool {
+	return r.Presence == WalletUnknown || (r.Presence == WalletPresent && !r.CredentialsStaged)
+}
+
+// WalletCreation owns bounded readiness and finalization calls for one TUI.
+// Interactive password and seed input stays with the terminal adapter. Close
+// cancels local observation, not an accepted LND or helper mutation.
+type WalletCreation struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	mu      sync.Mutex
+	workers sync.WaitGroup
+	read    func(context.Context) (lndrpc.WalletState, error)
+	stage   func(context.Context) error
+}
+
+func NewWalletCreation() *WalletCreation {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WalletCreation{ctx: ctx, cancel: cancel,
+		read: lndrpc.ReadWalletSetupState,
+		stage: func(ctx context.Context) error {
+			session, err := helper.StartContext(ctx, helper.VerbStageLNDMacaroon, nil)
+			if err != nil {
+				return err
+			}
+			defer session.Close()
+			return session.Wait(nil)
+		},
+	}
+}
+
+func (w *WalletCreation) Close() {
+	w.mu.Lock()
+	w.cancel()
+	w.mu.Unlock()
+	w.workers.Wait()
+}
+
+func (w *WalletCreation) begin(timeout time.Duration) (context.Context, func(), error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	w.workers.Add(1)
+	ctx, cancel := context.WithTimeout(w.ctx, timeout)
+	return ctx, func() { cancel(); w.workers.Done() }, nil
+}
+
+// Prepare returns the validated lncli network only after a fresh NON_EXISTING
+// observation. The deadline includes RPC duration and retry waits. Another
+// process may still create a wallet afterward; LND remains the final authority.
+func (w *WalletCreation) Prepare(network string) (string, error) {
+	profile, err := config.NetworkConfigFromName(network)
+	if err != nil {
+		return "", err
+	}
+	ctx, done, err := w.begin(120 * time.Second)
+	if err != nil {
+		return "", err
+	}
+	defer done()
+	for {
+		state, readErr := w.read(ctx)
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("waiting for wallet creation readiness: %w", ctx.Err())
+		}
+		if readErr == nil {
+			switch walletPresence(state) {
+			case WalletAbsent:
+				return profile.LNDNetwork, nil
+			case WalletPresent:
+				return "", errors.New("an LND wallet already exists; creation was not started")
+			default:
+				if state != "WAITING_TO_START" {
+					return "", fmt.Errorf("unrecognized LND wallet state %q; creation was not started", state)
+				}
+			}
+		}
+		timer := time.NewTimer(2 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", fmt.Errorf("waiting for wallet creation readiness: %w", errors.Join(ctx.Err(), readErr))
+		case <-timer.C:
+		}
+	}
+}
+
+// Finalize can be called again to reobserve and stage credentials. It never
+// invokes wallet creation or infers seed acknowledgement from wallet existence.
+func (w *WalletCreation) Finalize(execution WalletExecution) WalletCreationResult {
+	result := WalletCreationResult{SeedAcknowledged: execution.Created && execution.SeedAcknowledged}
+	ctx, done, err := w.begin(75 * time.Second)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	defer done()
+	state, readErr := w.read(ctx)
+	if readErr == nil {
+		result.Presence = walletPresence(state)
+	}
+	// A successful lncli InitWallet remains creation evidence if a later read
+	// is unavailable. An explicit conflicting absence requires investigation.
+	if execution.Created && result.Presence == WalletUnknown {
+		result.Presence = WalletPresent
+	}
+	if execution.Created && result.Presence == WalletAbsent {
+		result.Presence = WalletUnknown
+		result.Err = errors.New("LND reports no wallet after successful creation; wallet state needs investigation")
+		return result
+	}
+	switch result.Presence {
+	case WalletUnknown:
+		result.Err = fmt.Errorf("wallet state is unknown; do not repeat creation: %w",
+			errors.Join(execution.Err, readErr, errors.New("no conclusive wallet state")))
+		return result
+	case WalletAbsent:
+		result.Err = errors.Join(errors.New("LND reports that no wallet exists"), execution.Err)
+		return result
+	}
+	if err := ctx.Err(); err != nil {
+		result.Err = err
+		return result
+	}
+	if err := w.stage(ctx); err != nil {
+		result.Err = fmt.Errorf("the wallet exists, but its credentials could not be staged: %w", errors.Join(execution.Err, err))
+		return result
+	}
+	result.CredentialsStaged = true
+	result.Err = execution.Err
+	if !result.SeedAcknowledged {
+		result.Err = errors.Join(result.Err, errors.New("the wallet exists, but seed acknowledgement was not confirmed; preserve any seed you recorded and do not recreate the wallet"))
+	}
+	return result
+}
+
+func walletPresence(state lndrpc.WalletState) WalletPresence {
+	switch state {
+	case "NON_EXISTING":
+		return WalletAbsent
+	case "LOCKED", "UNLOCKED", "RPC_ACTIVE", "SERVER_ACTIVE":
+		return WalletPresent
+	default:
+		return WalletUnknown
+	}
+}

--- a/internal/app/wallet_creation_test.go
+++ b/internal/app/wallet_creation_test.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+func TestWalletCreationReadiness(t *testing.T) {
+	for _, state := range []lndrpc.WalletState{"NON_EXISTING", "LOCKED", "UNLOCKED", "RPC_ACTIVE", "SERVER_ACTIVE", "FUTURE_STATE"} {
+		t.Run(string(state), func(t *testing.T) {
+			w := NewWalletCreation()
+			defer w.Close()
+			w.read = func(context.Context) (lndrpc.WalletState, error) { return state, nil }
+			w.stage = func(context.Context) error { t.Fatal("readiness staged credentials"); return nil }
+			network, err := w.Prepare("public-signet")
+			if state == "NON_EXISTING" {
+				if err != nil || network != "signet" {
+					t.Fatalf("network=%q err=%v", network, err)
+				}
+			} else if err == nil {
+				t.Fatal("creation allowed without a known absent wallet")
+			}
+		})
+	}
+	w := NewWalletCreation()
+	defer w.Close()
+	w.read = func(context.Context) (lndrpc.WalletState, error) {
+		t.Fatal("invalid profile reached LND")
+		return "", nil
+	}
+	if _, err := w.Prepare("signet"); err == nil {
+		t.Fatal("raw signet profile accepted")
+	}
+}
+
+func TestWalletCreationReadinessBounds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWalletCreation()
+		defer w.Close()
+		calls := 0
+		w.read = func(ctx context.Context) (lndrpc.WalletState, error) {
+			calls++
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(5 * time.Second):
+				return "", errors.New("transport unavailable")
+			}
+		}
+		start := time.Now()
+		if _, err := w.Prepare("mainnet"); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("deadline: %v", err)
+		}
+		if time.Since(start) != 120*time.Second || calls < 2 {
+			t.Fatalf("duration=%s calls=%d", time.Since(start), calls)
+		}
+	})
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWalletCreation()
+		calls := 0
+		w.read = func(context.Context) (lndrpc.WalletState, error) {
+			calls++
+			if calls == 1 {
+				return "WAITING_TO_START", nil
+			}
+			return "NON_EXISTING", nil
+		}
+		if _, err := w.Prepare("mainnet"); err != nil || calls != 2 {
+			t.Fatalf("calls=%d err=%v", calls, err)
+		}
+		w.Close()
+		if _, err := w.Prepare("mainnet"); !errors.Is(err, context.Canceled) || calls != 2 {
+			t.Fatal("closed workflow started another probe")
+		}
+	})
+}
+
+func TestWalletFinalizationPreservesCreationEvidence(t *testing.T) {
+	failure := errors.New("injected failure")
+	for _, tc := range []struct {
+		name                        string
+		execution                   WalletExecution
+		state                       lndrpc.WalletState
+		readErr, stageErr           error
+		presence                    WalletPresence
+		stage, retry, complete, ack bool
+	}{
+		{"success", WalletExecution{Created: true, SeedAcknowledged: true}, "RPC_ACTIVE", nil, nil, WalletPresent, true, false, true, true},
+		{"stage failed", WalletExecution{Created: true, SeedAcknowledged: true}, "RPC_ACTIVE", nil, failure, WalletPresent, true, true, false, true},
+		{"lost process response", WalletExecution{Err: failure}, "LOCKED", nil, nil, WalletPresent, true, false, false, false},
+		{"terminal restore failed", WalletExecution{Created: true, SeedAcknowledged: true, Err: failure}, "RPC_ACTIVE", nil, nil, WalletPresent, true, false, false, true},
+		{"acknowledgement failed", WalletExecution{Created: true, Err: failure}, "RPC_ACTIVE", nil, nil, WalletPresent, true, false, false, false},
+		{"read unavailable after success", WalletExecution{Created: true, SeedAcknowledged: true}, "", failure, nil, WalletPresent, true, false, true, true},
+		{"unknown outcome", WalletExecution{Err: failure}, "", failure, nil, WalletUnknown, false, true, false, false},
+		{"known absent", WalletExecution{Err: failure}, "NON_EXISTING", nil, nil, WalletAbsent, false, false, false, false},
+		{"conflicting absence", WalletExecution{Created: true, SeedAcknowledged: true}, "NON_EXISTING", nil, nil, WalletUnknown, false, true, false, true},
+		{"false acknowledgement", WalletExecution{SeedAcknowledged: true}, "LOCKED", nil, nil, WalletPresent, true, false, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewWalletCreation()
+			defer w.Close()
+			w.read = func(context.Context) (lndrpc.WalletState, error) { return tc.state, tc.readErr }
+			staged := false
+			w.stage = func(context.Context) error { staged = true; return tc.stageErr }
+			r := w.Finalize(tc.execution)
+			if r.Presence != tc.presence || staged != tc.stage || r.CanRetryFinalization() != tc.retry || (r.Err == nil) != tc.complete {
+				t.Fatalf("result=%+v staged=%v", r, staged)
+			}
+			if r.CredentialsStaged != (tc.stage && tc.stageErr == nil) {
+				t.Fatal("staging result lost")
+			}
+			if r.SeedAcknowledged != tc.ack {
+				t.Fatalf("seed acknowledgement=%v, want %v", r.SeedAcknowledged, tc.ack)
+			}
+			if tc.execution.Err != nil && tc.name != "conflicting absence" && !errors.Is(r.Err, tc.execution.Err) {
+				t.Fatal("process/terminal failure lost")
+			}
+		})
+	}
+}
+
+func TestWalletFinalizationRetryAndShutdown(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		w := NewWalletCreation()
+		w.read = func(context.Context) (lndrpc.WalletState, error) { return "RPC_ACTIVE", nil }
+		calls := 0
+		w.stage = func(ctx context.Context) error {
+			calls++
+			if calls == 1 {
+				return errors.New("staging failed")
+			}
+			if calls == 2 {
+				return nil
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		execution := WalletExecution{Created: true, SeedAcknowledged: true}
+		if !w.Finalize(execution).CanRetryFinalization() {
+			t.Fatal("missing retry after staging failure")
+		}
+		if r := w.Finalize(execution); r.Err != nil || !r.CredentialsStaged {
+			t.Fatalf("retry: %+v", r)
+		}
+		done := make(chan WalletCreationResult, 1)
+		go func() { done <- w.Finalize(execution) }()
+		synctest.Wait()
+		w.Close()
+		if r := <-done; !errors.Is(r.Err, context.Canceled) {
+			t.Fatalf("shutdown: %+v", r)
+		}
+		w.Finalize(execution)
+		if calls != 3 {
+			t.Fatal("closed workflow staged again")
+		}
+	})
+}

--- a/internal/installer/lnd.go
+++ b/internal/installer/lnd.go
@@ -3,12 +3,10 @@
 package installer
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -517,32 +515,6 @@ func startLND() error {
 	return system.SudoRun("systemctl", "restart", "lnd")
 }
 
-func waitForLND() error {
-	for i := 0; i < 60; i++ {
-		client := buildLNDClient()
-		resp, err := client.Get(
-			"https://" + paths.LNDRESTEndpoint + "/v1/state")
-		if err == nil {
-			resp.Body.Close()
-			return nil
-		}
-		time.Sleep(2 * time.Second)
-	}
-	return fmt.Errorf("LND did not respond after 120 seconds")
-}
-
-// ── Exported wrappers for the tui package ───────────
-// These wrap the unexported helpers so the tui
-// package can call them from screens without leaking
-// the rest of the installer package.
-
-// WaitForLND blocks until LND's REST API responds, or
-// returns an error after 120 seconds. Safe to call as a
-// tea.Cmd from a screen.
-func WaitForLND() error {
-	return waitForLND()
-}
-
 // SetupAutoUnlock enables and synchronously proves wallet auto-unlock. As root
 // it runs the bounded transition directly; from the unprivileged TUI it asks
 // the typed helper operation. The password crosses only the root-owned local
@@ -575,31 +547,4 @@ func DisableAutoUnlock() (AutoUnlockResult, error) {
 	var result AutoUnlockResult
 	err := helper.Call(helper.VerbRemoveWalletPassword, nil, &result)
 	return result, err
-}
-
-// lndTLSCertBytes returns LND's TLS certificate for client
-// use: read directly where permitted (root; some setups leave
-// it world-readable), else from the staging board copy.
-func lndTLSCertBytes() ([]byte, error) {
-	if data, err := os.ReadFile(paths.LNDTLSCert); err == nil {
-		return data, nil
-	}
-	return helper.ReadBoard(paths.StateLNDTLSCert)
-}
-
-func buildLNDClient() *http.Client {
-	tlsConfig := &tls.Config{}
-	certData, err := lndTLSCertBytes()
-	if err != nil {
-		logger.System("LND REST client: %v", err)
-	} else {
-		pool := x509.NewCertPool()
-		if pool.AppendCertsFromPEM(certData) {
-			tlsConfig.RootCAs = pool
-		}
-	}
-	return &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsConfig},
-		Timeout:   5 * time.Second,
-	}
 }

--- a/internal/lndrpc/client.go
+++ b/internal/lndrpc/client.go
@@ -90,55 +90,10 @@ func (c *Client) dial(parent context.Context, allowHeal bool) error {
 	if err := parent.Err(); err != nil {
 		return err
 	}
-	// Read the staged TLS cert copy (fail-noisy: a missing
-	// staged fact names itself and points at the journal).
-	certData, err := helper.ReadBoard(paths.StateLNDTLSCert)
-	if err != nil {
-		return fmt.Errorf("read TLS cert: %w", err)
+	if err := c.loadStaged(); err != nil {
+		return err
 	}
-
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(certData) {
-		return fmt.Errorf("failed to parse TLS cert")
-	}
-
-	tlsCreds := credentials.NewClientTLSFromCert(certPool, "")
-
-	// Read the staged admin macaroon copy (staged at wallet
-	// creation; re-staged whenever an operation invalidates it).
-	macBytes, err := helper.ReadBoard(paths.StateLNDMacaroon)
-	if err != nil {
-		return fmt.Errorf("read macaroon: %w", err)
-	}
-	c.macaroonHex = hex.EncodeToString(macBytes)
-
-	// Connect. Keepalive bounds how long a silently dead TCP
-	// connection (LND restarted underneath the TUI, a network
-	// blip) can block calls and streams instead of blocking
-	// forever; LND disconnects clients that ping more often
-	// than every five seconds, and one minute stays far clear
-	// of that floor with pings only while calls are active.
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(tlsCreds),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50 * 1024 * 1024)),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:    time.Minute,
-			Timeout: 20 * time.Second,
-		}),
-	}
-
-	// Dial by the shared loopback constant — the same value
-	// lnd.conf binds to. Never by the name localhost: with
-	// IPv6 disabled on the node, that name can resolve to an
-	// IPv6 address the connection cannot use.
-	conn, err := grpc.NewClient(paths.LNDGRPCEndpoint, opts...)
-	if err != nil {
-		return fmt.Errorf("grpc connect: %w", err)
-	}
-
-	c.conn = conn
-	c.lightning = lnrpc.NewLightningClient(conn)
-	c.state = lnrpc.NewStateClient(conn)
+	conn := c.conn
 
 	// Test the connection with a longer timeout.
 	// During IBD, LND's GetInfo queries Bitcoin Core which can
@@ -150,7 +105,7 @@ func (c *Client) dial(parent context.Context, allowHeal bool) error {
 	ctx, cancel := context.WithTimeout(probeCtx, 30*time.Second)
 	defer cancel()
 
-	_, err = c.lightning.GetInfo(ctx, &lnrpc.GetInfoRequest{})
+	_, err := c.lightning.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err == nil {
 		logger.Status("LND gRPC connected and ready")
 		return nil
@@ -300,4 +255,66 @@ func (c *Client) stateRPC() lnrpc.StateClient {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.state
+}
+
+// NewStagedClient opens a lazy transport from credentials already staged by the
+// wallet workflow. It does no GetInfo probe or repair and does not claim RPC
+// readiness. Normal queries observe readiness using the existing client policy.
+func NewStagedClient() (*Client, error) {
+	c := &Client{}
+	if err := c.loadStaged(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func stagedTLSCredentials() (credentials.TransportCredentials, error) {
+	certData, err := helper.ReadBoard(paths.StateLNDTLSCert)
+	if err != nil {
+		return nil, fmt.Errorf("read TLS cert: %w", err)
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certData) {
+		return nil, fmt.Errorf("failed to parse TLS cert")
+	}
+
+	return credentials.NewClientTLSFromCert(certPool, ""), nil
+}
+
+func (c *Client) loadStaged() error {
+	tlsCreds, err := stagedTLSCredentials()
+	if err != nil {
+		return err
+	}
+
+	// Read the staged admin macaroon copy (staged at wallet
+	// creation; re-staged whenever an operation invalidates it).
+	macBytes, err := helper.ReadBoard(paths.StateLNDMacaroon)
+	if err != nil {
+		return fmt.Errorf("read macaroon: %w", err)
+	}
+	c.macaroonHex = hex.EncodeToString(macBytes)
+
+	// Preserve the normal client's receive limit and conservative keepalive.
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(tlsCreds),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50 * 1024 * 1024)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    time.Minute,
+			Timeout: 20 * time.Second,
+		}),
+	}
+
+	// Match LND's configured loopback listener without hostname resolution.
+	conn, err := grpc.NewClient(paths.LNDGRPCEndpoint, opts...)
+	if err != nil {
+		return fmt.Errorf("grpc connect: %w", err)
+	}
+
+	c.conn = conn
+	c.lightning = lnrpc.NewLightningClient(conn)
+	c.state = lnrpc.NewStateClient(conn)
+
+	return nil
 }

--- a/internal/lndrpc/wallet_setup.go
+++ b/internal/lndrpc/wallet_setup.go
@@ -1,0 +1,43 @@
+package lndrpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"google.golang.org/grpc"
+)
+
+// ReadWalletSetupState uses the unauthenticated State service. Wallet creation
+// cannot require a macaroon that only exists after the wallet is initialized.
+// It neither probes GetInfo nor requests credential repair.
+func ReadWalletSetupState(parent context.Context) (WalletState, error) {
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return WalletStateUnknown, err
+	}
+	creds, err := stagedTLSCredentials()
+	if err != nil {
+		return WalletStateUnknown, err
+	}
+	conn, err := grpc.NewClient(paths.LNDGRPCEndpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return WalletStateUnknown, err
+	}
+	defer conn.Close()
+	return readWalletSetupState(ctx, lnrpc.NewStateClient(conn))
+}
+
+func readWalletSetupState(ctx context.Context, client lnrpc.StateClient) (WalletState, error) {
+	resp, err := client.GetState(ctx, &lnrpc.GetStateRequest{})
+	if err != nil {
+		return WalletStateUnknown, err
+	}
+	if resp == nil {
+		return WalletStateUnknown, fmt.Errorf("LND returned no wallet state")
+	}
+	return walletStateName(resp.State), nil
+}

--- a/internal/lndrpc/wallet_setup_test.go
+++ b/internal/lndrpc/wallet_setup_test.go
@@ -1,0 +1,45 @@
+package lndrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+type setupStateClient struct {
+	lnrpc.StateClient
+	read func(context.Context) (*lnrpc.GetStateResponse, error)
+}
+
+func (s setupStateClient) GetState(ctx context.Context, _ *lnrpc.GetStateRequest, _ ...grpc.CallOption) (*lnrpc.GetStateResponse, error) {
+	return s.read(ctx)
+}
+
+func TestWalletSetupStateDoesNotInventAbsence(t *testing.T) {
+	failure := errors.New("state unavailable")
+	for _, tc := range []struct {
+		response *lnrpc.GetStateResponse
+		err      error
+		want     WalletState
+	}{
+		{nil, nil, WalletStateUnknown},
+		{nil, failure, WalletStateUnknown},
+		{&lnrpc.GetStateResponse{State: lnrpc.WalletState_NON_EXISTING}, nil, "NON_EXISTING"},
+		{&lnrpc.GetStateResponse{State: lnrpc.WalletState_WAITING_TO_START}, nil, "WAITING_TO_START"},
+		{&lnrpc.GetStateResponse{State: lnrpc.WalletState(99)}, nil, "99"},
+	} {
+		state, err := readWalletSetupState(t.Context(), setupStateClient{read: func(context.Context) (*lnrpc.GetStateResponse, error) { return tc.response, tc.err }})
+		if state != tc.want || (err == nil) != (tc.response != nil && tc.err == nil) {
+			t.Fatalf("state=%q err=%v", state, err)
+		}
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	state, err := ReadWalletSetupState(ctx)
+	if state != WalletStateUnknown || !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled probe: %q %v", state, err)
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -37,11 +37,13 @@ func fetchLatestVersionCmd() tea.Cmd {
 
 // ── Live-read node facts ─────────────────────────────────
 
-func fetchWalletStateCmd() tea.Cmd {
+func fetchWalletStateCmd(owner *ScreenContext) tea.Cmd {
+	owner.walletRevision++
+	revision := owner.walletRevision
 	return func() tea.Msg {
 		var state helper.WalletStateResult
 		err := helper.Call(helper.VerbReadWalletState, nil, &state)
-		return walletStateMsg{state: state, err: err}
+		return walletStateMsg{owner: owner, revision: revision, state: state, err: err}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -68,15 +68,7 @@ type openTab struct {
 	Label string
 	Index int    // row identity for other detail tabs
 	Key   string // funding outpoint for channel detail tabs
-	// Section is the sticky owner of this tab — set
-	// at construction from m.nav.ActiveSection() and
-	// must never be mutated afterward. effectiveTabs,
-	// closeTab's cascade guard, and the sectionFocus
-	// restore logic all depend on it remaining stable.
-	// The only in-place tab transformation in the
-	// codebase (walletCreatedMsg's wallet-create →
-	// auto-unlock swap in update.go) explicitly
-	// preserves this field for that reason.
+	// Section remains the tab's owner across wallet-to-auto-unlock transitions.
 	Section int
 	// Parent declares which tab kind owns this tab.
 	// Zero means "section home is the parent" (top-
@@ -124,8 +116,10 @@ type nodeAddressesMsg struct {
 }
 
 type walletStateMsg struct {
-	state helper.WalletStateResult
-	err   error
+	owner    *ScreenContext
+	revision uint64
+	state    helper.WalletStateResult
+	err      error
 }
 
 type keyVerificationStateMsg struct {
@@ -327,15 +321,6 @@ type Model struct {
 	// instead of jumping to the leftmost detail tab.
 	// Zero means "no memory yet, fall back to tab 1".
 	//
-	// Invariant: tabs in non-active sections are
-	// never added, removed, or reordered. The only
-	// in-place mutation is the wallet-create →
-	// auto-unlock transformation in walletCreatedMsg,
-	// which preserves both the index and the Section
-	// field, so the saved index stays valid. If that
-	// invariant ever changes, this field needs a
-	// validate-on-restore pass to detect stale
-	// indices.
 	sectionFocus [numSections]int
 }
 
@@ -344,17 +329,8 @@ func NewModel(
 	state *RuntimeState, version string,
 ) Model {
 	theme.Init(prefs.Theme != "light")
-	// Invariant — load-bearing for the wallet-create
-	// flow: lndClient stays nil until a wallet exists.
-	// The walletCreatedMsg handler in update.go is the
-	// only code path that creates lndClient post-launch,
-	// and it runs in the same Update tick that records the live wallet as
-	// present. Together these prevent
-	// statusMsg from racing walletCreatedMsg. If a future change
-	// ever needs lndClient earlier — e.g. to read a
-	// macaroon before wallet creation — the walletExec
-	// → walletCreatedMsg → tab transform sequence needs
-	// to be re-audited for the two handlers interleaving.
+	// Creation owns credential staging before client publication. Startup can
+	// initialize an existing wallet independently of that interactive workflow.
 	var client *lndrpc.Client
 	if cfg.HasLND() && state.WalletKnown && state.WalletExists {
 		client = lndrpc.New()
@@ -426,6 +402,9 @@ func Show(
 	// Bubble Tea does not cancel or join commands on exit. The workflow owner
 	// releases helper readers even when Run fails or provides no final model.
 	defer func() {
+		if m.screenCtx.WalletCreation != nil {
+			m.screenCtx.WalletCreation.Close()
+		}
 		m.screenCtx.HelperWorkflows.Close()
 		if m.screenCtx.LndClient != nil {
 			m.screenCtx.LndClient.Close()
@@ -473,7 +452,7 @@ func observeRuntimeState(cfg *config.AppConfig) *RuntimeState {
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		fetchStatus(m.cfg, m.state, m.lndClient),
-		fetchWalletStateCmd(),
+		fetchWalletStateCmd(m.screenCtx),
 		fetchKeyVerificationStateCmd(),
 		fetchLatestVersionCmd(),
 		tickEveryCmd(m.pollInterval()))

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -1,3 +1,4 @@
+// Package tui implements the unprivileged operator terminal interface.
 package tui
 
 import (
@@ -49,17 +50,28 @@ type Screen interface {
 // chain — zero refresh plumbing.
 
 type ScreenContext struct {
-	HelperWorkflows *app.HelperWorkflows
-	SSHAccess       *app.SSHAccess
-	sshAuthRevision uint64
-	Cfg             *config.AppConfig
-	State           *RuntimeState
-	LndClient       *lndrpc.Client
-	Status          *statusMsg
-	HasTabs         bool   // varies by section; Model sets before calling View/HelpBindings
-	ContentFocused  bool   // true when content pane has focus (not tab bar, not sidebar)
-	Version         string // set once at construction
-	LatestVersion   string // updated by latestVersionMsg handler
+	WalletCreation      *app.WalletCreation
+	walletCreationOwner *WalletCreateScreen
+	walletRevision      uint64
+	openWalletClient    func() (*lndrpc.Client, error)
+	HelperWorkflows     *app.HelperWorkflows
+	SSHAccess           *app.SSHAccess
+	sshAuthRevision     uint64
+	Cfg                 *config.AppConfig
+	State               *RuntimeState
+	LndClient           *lndrpc.Client
+	Status              *statusMsg
+	HasTabs             bool   // varies by section; Model sets before calling View/HelpBindings
+	ContentFocused      bool   // true when content pane has focus (not tab bar, not sidebar)
+	Version             string // set once at construction
+	LatestVersion       string // updated by latestVersionMsg handler
+}
+
+func (c *ScreenContext) walletCreation() *app.WalletCreation {
+	if c.WalletCreation == nil {
+		c.WalletCreation = app.NewWalletCreation()
+	}
+	return c.WalletCreation
 }
 
 // RuntimeState contains facts whose authority is the live system rather than

--- a/internal/tui/screen_channels_home.go
+++ b/internal/tui/screen_channels_home.go
@@ -122,7 +122,7 @@ func (s *ChannelsHomeScreen) HandleKey(
 	case "enter":
 		// No wallet → trigger wallet creation flow
 		if !s.ctx.walletKnown() {
-			return s, fetchWalletStateCmd()
+			return s, fetchWalletStateCmd(s.ctx)
 		}
 		if !s.ctx.walletExists() {
 			screen := NewWalletCreateScreen(s.ctx)

--- a/internal/tui/screen_offchain_home.go
+++ b/internal/tui/screen_offchain_home.go
@@ -113,7 +113,7 @@ func (s *WalletHomeScreen) HandleKey(
 	case "enter":
 		// No wallet → trigger wallet creation flow
 		if !s.ctx.walletKnown() {
-			return s, fetchWalletStateCmd()
+			return s, fetchWalletStateCmd(s.ctx)
 		}
 		if !s.ctx.walletExists() {
 			screen := NewWalletCreateScreen(s.ctx)

--- a/internal/tui/screen_onchain_home.go
+++ b/internal/tui/screen_onchain_home.go
@@ -103,7 +103,7 @@ func (s *OnChainHomeScreen) HandleKey(
 	case "enter":
 		// No wallet → trigger wallet creation flow
 		if !s.ctx.walletKnown() {
-			return s, fetchWalletStateCmd()
+			return s, fetchWalletStateCmd(s.ctx)
 		}
 		if !s.ctx.walletExists() {
 			screen := NewWalletCreateScreen(s.ctx)

--- a/internal/tui/screen_system_auto_unlock.go
+++ b/internal/tui/screen_system_auto_unlock.go
@@ -33,7 +33,7 @@ import (
 //   1. 'u' hotkey on the LND service row in System home
 //   2. Auto-launched after wallet creation completes
 //      (stage 2; the wallet creation flow swaps its tab
-//      into this screen via the walletCreatedMsg handler
+//      into this screen via the wallet finalization handler
 //      in update.go)
 
 type autoUnlockMode int

--- a/internal/tui/screen_system_wallet_create.go
+++ b/internal/tui/screen_system_wallet_create.go
@@ -2,50 +2,12 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
-
-	"github.com/virtualprivatenode/vpn/internal/helper"
-	"github.com/virtualprivatenode/vpn/internal/installer"
-	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
-
-// ── WalletCreateScreen ──────────────────────────────────
-// Three-step wallet creation flow that runs entirely
-// inside the TUI:
-//
-//   walletConfirm — privacy + seed warnings, Cancel /
-//                   Proceed buttons. The user reads the
-//                   warnings and explicitly opts in.
-//
-//   walletWaiting — "Waiting for LND..." centered in the
-//                   pane while WaitForLND polls the REST
-//                   API. Async, can fail with a 120s
-//                   timeout.
-//
-//   walletExec    — tea.ExecProcess hands the terminal
-//                   to a single bash command that runs
-//                   `lncli create` interactively, then
-//                   prompts the user to type
-//                   "I SAVED MY SEED" to confirm. SIGINT
-//                   is trapped after lncli succeeds so
-//                   ctrl+c cannot escape the seed
-//                   confirmation loop.
-//
-// On success, the screen emits walletCreatedMsg. The
-// Model handles that message by transforming this tab
-// in place into an AutoUnlockScreen — the user goes
-// straight from "I SAVED MY SEED" into auto-unlock
-// configuration without any tab juggling. See the
-// walletCreatedMsg case in update.go.
-//
-// On error (timeout, lncli failure, user ctrl+c during
-// lncli create itself), the screen transitions to an
-// error view with a Done button. No config changes
-// occur on the failure path.
 
 type walletCreateStep int
 
@@ -53,103 +15,110 @@ const (
 	walletConfirm walletCreateStep = iota
 	walletWaiting
 	walletExec
-	walletErr
+	walletFinalizing
+	walletResult
 )
 
-// Messages emitted by the wallet creation flow.
-// All three are unique to this screen so they don't
-// collide with anything else in the routing table.
+type walletCreationAttempt struct {
+	execution    app.WalletExecution
+	finalization uint64
+}
 
-// walletLNDReadyMsg is delivered when WaitForLND
-// returns. The screen uses err to decide whether to
-// proceed to the bash exec or show the timeout error.
-type walletLNDReadyMsg struct{ err error }
+type walletLNDReadyMsg struct {
+	owner   *WalletCreateScreen
+	attempt *walletCreationAttempt
+	network string
+	err     error
+}
 
-// walletExecDoneMsg is delivered by the tea.ExecProcess
-// callback when the bash wrapper exits. err is nil on
-// success (lncli created the wallet AND the user typed
-// "I SAVED MY SEED"). Non-nil if lncli failed, the user
-// ctrl+c'd during lncli create, or the SSH session was
-// killed.
-type walletExecDoneMsg struct{ err error }
+type walletExecDoneMsg struct {
+	owner     *WalletCreateScreen
+	attempt   *walletCreationAttempt
+	execution app.WalletExecution
+}
 
-// walletCreatedMsg tells Model that wallet creation
-// finished successfully. Model creates the lndClient
-// (it didn't exist before this point) and transforms
-// this tab in place into an AutoUnlockScreen. See
-// update.go for the handler.
-type walletCreatedMsg struct{}
+type walletFinalizedMsg struct {
+	owner    *WalletCreateScreen
+	attempt  *walletCreationAttempt
+	revision uint64
+	result   app.WalletCreationResult
+}
 
-// walletStageFailedMsg reports that the wallet exists but the
-// helper could not stage its credentials for this TUI.
-type walletStageFailedMsg struct{ err error }
+type closeWalletCreateMsg struct {
+	owner    *WalletCreateScreen
+	attempt  *walletCreationAttempt
+	revision uint64
+}
+type continueWalletCreateMsg struct {
+	owner   *WalletCreateScreen
+	attempt *walletCreationAttempt
+}
 
+// WalletCreateScreen owns presentation and terminal handoff. Application calls
+// own readiness and finalization; every result identifies its original attempt.
 type WalletCreateScreen struct {
-	ctx  *ScreenContext
-	step walletCreateStep
-
-	// Confirm step — 0=Cancel, 1=Proceed
-	btnIdx int
-
-	// Error captured from a failed step
-	resultErr error
+	ctx       *ScreenContext
+	step      walletCreateStep
+	btnIdx    int
+	attempt   *walletCreationAttempt
+	result    app.WalletCreationResult
+	clientErr error
 }
 
-func NewWalletCreateScreen(
-	ctx *ScreenContext,
-) *WalletCreateScreen {
-	return &WalletCreateScreen{
-		ctx:    ctx,
-		step:   walletConfirm,
-		btnIdx: 1, // default focus on Proceed
+func NewWalletCreateScreen(ctx *ScreenContext) *WalletCreateScreen {
+	return &WalletCreateScreen{ctx: ctx, btnIdx: 1}
+}
+
+func (s *WalletCreateScreen) Init() tea.Cmd { return nil }
+
+func walletCreationBusy(screen Screen) bool {
+	s, ok := screen.(*WalletCreateScreen)
+	return ok && s != nil && (s.step == walletWaiting || s.step == walletExec || s.step == walletFinalizing)
+}
+
+func (s *WalletCreateScreen) closeCmd() tea.Cmd {
+	attempt, revision := s.attempt, uint64(0)
+	if attempt != nil {
+		revision = attempt.finalization
 	}
+	return func() tea.Msg { return closeWalletCreateMsg{owner: s, attempt: attempt, revision: revision} }
 }
 
-// ── Screen interface ────────────────────────────────────
-
-func (s *WalletCreateScreen) Init() tea.Cmd {
-	return nil
-}
-
-func (s *WalletCreateScreen) HandleKey(
-	keyStr string, msg tea.KeyPressMsg,
-) (Screen, tea.Cmd) {
-	// Error state
-	if s.step == walletErr {
+func (s *WalletCreateScreen) HandleKey(keyStr string, msg tea.KeyPressMsg) (Screen, tea.Cmd) {
+	if keyStr == "ctrl+c" {
+		return s, tea.Quit
+	}
+	if walletCreationBusy(s) {
 		switch keyStr {
-		case "ctrl+c":
-			return s, tea.Quit
-		case "enter":
-			return s, emitCloseTab
 		case "left":
 			return s, emitFocusSidebar
 		case "up", "shift+tab":
-			if s.ctx.HasTabs {
-				return s, emitFocusTabBar
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	}
+	if s.step == walletResult {
+		switch keyStr {
+		case "left", "right":
+			if s.hasRecoveryAction() {
+				s.btnIdx = 1 - s.btnIdx
 			}
+		case "enter":
+			if s.btnIdx == 1 && s.hasRecoveryAction() {
+				if s.retrySetup() {
+					return s, s.finalizeCmd()
+				}
+				return s, func() tea.Msg { return continueWalletCreateMsg{owner: s, attempt: s.attempt} }
+			}
+			return s, s.closeCmd()
+		case "up", "shift+tab":
+			return s, emitFocusTabBar
 		case "backspace":
 			return s, emitFocusParent
 		}
 		return s, nil
 	}
-
-	// Waiting and exec steps — block all keys.
-	// During walletWaiting we're polling LND and there's
-	// nothing meaningful to interact with. During
-	// walletExec the bash command owns the terminal and
-	// the TUI isn't even visible — but ctrl+c here would
-	// quit the entire TUI, which we don't want either.
-	if s.step == walletWaiting || s.step == walletExec {
-		if keyStr == "ctrl+c" {
-			return s, tea.Quit
-		}
-		return s, nil
-	}
-
-	// Confirm step
 	switch keyStr {
-	case "ctrl+c":
-		return s, tea.Quit
 	case "left":
 		if s.btnIdx > 0 {
 			s.btnIdx--
@@ -157,232 +126,126 @@ func (s *WalletCreateScreen) HandleKey(
 		}
 		return s, emitFocusSidebar
 	case "right":
-		if s.btnIdx < 1 {
-			s.btnIdx++
-		}
-		return s, nil
-	case "up":
+		s.btnIdx = 1
+	case "up", "shift+tab":
 		if s.ctx.HasTabs {
 			return s, emitFocusTabBar
 		}
-		return s, nil
 	case "enter":
 		if s.btnIdx == 0 {
-			return s, emitCloseTab
+			return s, s.closeCmd()
 		}
-		return s.startWaitingForLND()
+		return s, s.startWaitingForLND()
 	case "backspace":
 		return s, emitFocusParent
 	}
 	return s, nil
 }
 
-func (s *WalletCreateScreen) startWaitingForLND() (
-	Screen, tea.Cmd,
-) {
-	if !s.ctx.walletKnown() {
-		s.step = walletErr
-		s.resultErr = fmt.Errorf(
-			"wallet state is unavailable; refusing to create a wallet")
-		return s, nil
+func (s *WalletCreateScreen) startWaitingForLND() tea.Cmd {
+	if !s.ctx.walletKnown() || s.ctx.walletExists() {
+		s.step = walletResult
+		s.btnIdx = 0
+		s.result = app.WalletCreationResult{Err: fmt.Errorf("wallet must be known absent before creation")}
+		if s.ctx.walletKnown() {
+			s.result.Presence = app.WalletPresent
+		}
+		return nil
 	}
-	if s.ctx.walletExists() {
-		s.step = walletErr
-		s.resultErr = fmt.Errorf("an LND wallet already exists")
-		return s, nil
+	if owner := s.ctx.walletCreationOwner; owner != nil && owner != s {
+		return nil
 	}
+	s.ctx.walletCreationOwner = s
+	s.ctx.walletRevision++
 	s.step = walletWaiting
-	return s, waitForLNDCmd()
-}
-
-func waitForLNDCmd() tea.Cmd {
+	s.attempt = &walletCreationAttempt{}
+	attempt, network, workflow := s.attempt, s.ctx.Cfg.Network, s.ctx.walletCreation()
 	return func() tea.Msg {
-		err := installer.WaitForLND()
-		return walletLNDReadyMsg{err: err}
+		readyNetwork, err := workflow.Prepare(network)
+		return walletLNDReadyMsg{owner: s, attempt: attempt, network: readyNetwork, err: err}
 	}
 }
 
-// ── HandleMsg ───────────────────────────────────────────
+func (s *WalletCreateScreen) finalizeCmd() tea.Cmd {
+	s.step = walletFinalizing
+	s.attempt.finalization++
+	attempt, revision, execution := s.attempt, s.attempt.finalization, s.attempt.execution
+	workflow := s.ctx.walletCreation()
+	return func() tea.Msg {
+		return walletFinalizedMsg{owner: s, attempt: attempt, revision: revision, result: workflow.Finalize(execution)}
+	}
+}
 
-func (s *WalletCreateScreen) HandleMsg(
-	msg tea.Msg,
-) (Screen, tea.Cmd) {
+func (s *WalletCreateScreen) HandleMsg(msg tea.Msg) (Screen, tea.Cmd) {
 	switch m := msg.(type) {
 	case walletLNDReadyMsg:
-		if m.err != nil {
-			s.step = walletErr
-			s.resultErr = fmt.Errorf(
-				"LND did not respond in time. "+
-					"Make sure bitcoind is running "+
-					"and try again. (%v)", m.err)
+		if m.owner != s || m.attempt != s.attempt || s.step != walletWaiting {
 			return s, nil
 		}
-		// LND is ready — kick off the bash wrapper
+		if m.err != nil {
+			s.step = walletResult
+			s.btnIdx = 0
+			s.result = app.WalletCreationResult{Err: m.err}
+			return s, nil
+		}
 		s.step = walletExec
-		return s, s.startExecProcess()
-
+		attempt := s.attempt
+		terminal := newWalletTerminal(m.network)
+		return s, tea.Exec(terminal, func(err error) tea.Msg {
+			execution := terminal.execution
+			if execution.Err == nil && err != nil {
+				execution.Err = fmt.Errorf("terminal session: %w", err)
+			}
+			return walletExecDoneMsg{owner: s, attempt: attempt, execution: execution}
+		})
 	case walletExecDoneMsg:
-		if m.err != nil {
-			s.step = walletErr
-			s.resultErr = fmt.Errorf(
-				"wallet creation failed: %v", m.err)
+		if m.owner != s || m.attempt != s.attempt || s.step != walletExec {
 			return s, nil
 		}
-		// Success. Wallet creation just minted this node's
-		// admin macaroon — have the helper stage copies for
-		// this TUI BEFORE the Model builds the gRPC
-		// client that reads them.
-		return s, func() tea.Msg {
-			if err := helper.Call(
-				helper.VerbStageLNDMacaroon,
-				nil, nil); err != nil {
-				return walletStageFailedMsg{err: err}
-			}
-			return walletCreatedMsg{}
+		s.attempt.execution = m.execution
+		return s, s.finalizeCmd()
+	case walletFinalizedMsg:
+		if !s.acceptsFinalization(m) {
+			return s, nil
 		}
-
-	case walletStageFailedMsg:
-		s.step = walletErr
-		s.resultErr = fmt.Errorf(
-			"the wallet was created, but its credentials "+
-				"could not be staged for this TUI: %v — "+
-				"the TUI cannot reach the wallet until "+
-				"that is resolved", m.err)
-		return s, nil
+		s.result = m.result
+		s.step = walletResult
+		s.btnIdx = 0
 	}
 	return s, nil
 }
 
-// startExecProcess builds and returns the bash wrapper
-// as a tea.ExecProcess. The wrapper:
-//  1. Runs `lncli create` interactively. The user types
-//     a wallet password, confirms it, chooses 'n' for
-//     a new seed, optionally adds a cipher seed
-//     passphrase, and sees the 24 words.
-//  2. If lncli exits 0, sets `trap ” INT` to ignore
-//     ctrl+c, then loops prompting for "I SAVED MY
-//     SEED" until the user types it exactly.
-//  3. Exits 0 only after the user types the exact
-//     confirmation phrase.
-//
-// ── Asymmetric ctrl+c handling is deliberate ────────
-// Step 1 allows ctrl+c. Step 2 blocks it. This mirrors
-// the atomicity boundary inside lncli itself: until
-// GenSeed completes, no seed exists and no wallet file
-// has been written, so a canceled context leaves the
-// node in a clean state and the user can retry. Once
-// InitWallet has run, the wallet file is on disk and
-// the only remaining risk is a user who aborts before
-// writing down their seed — which would be
-// unrecoverable. Blocking SIGINT in step 2 removes
-// that exit path entirely.
-//
-// A subtlety worth knowing: lncli doesn't make a gRPC
-// call during the password / seed-type / passphrase
-// prompts. Those are local readline-style inputs.
-// The first (and only, for seed generation) RPC is
-// GenSeed, which fires after the cipher passphrase
-// prompt is submitted. If the user ctrl+c's during
-// the earlier prompts, lncli's SIGINT handler arms
-// cancellation on a context that doesn't exist yet,
-// and the terminal appears to swallow the signal. The
-// cancellation then fires the instant GenSeed is
-// called, and LND returns:
-//
-//	unable to generate seed: rpc error:
-//	code = Canceled desc = context canceled
-//
-// This looks like an error but is actually the
-// intended cancellation path — no wallet is written,
-// no seed is displayed, the user is safe to retry.
-// Do not "fix" this by blocking SIGINT in step 1:
-// that would remove a legitimate escape hatch that
-// depends on lncli's atomicity guarantee for its
-// correctness.
-//
-// If the user ctrl+c's during step 2, the trap
-// ignores the signal and the loop continues — the
-// only escape is typing the exact phrase or killing
-// the SSH session.
-func (s *WalletCreateScreen) startExecProcess() tea.Cmd {
-	net, err := s.ctx.Cfg.NetworkConfig()
-	if err != nil {
-		return func() tea.Msg { return walletExecDoneMsg{err: err} }
-	}
-	script := `clear
-echo
-echo "  ==================================================="
-echo "    Lightning Wallet Creation"
-echo "  ==================================================="
-echo
-echo "  You're about to create the Lightning wallet that"
-echo "  will hold your Bitcoin on this node."
-echo
-echo "  In a moment you'll be asked to:"
-echo "    1. Choose a wallet password (you'll use this"
-echo "       to unlock the wallet)"
-echo "    2. Confirm the password"
-echo "    3. Press 'n' to generate a new 24-word seed"
-echo "    4. Skip the cipher seed passphrase by pressing"
-echo "       Enter (most users do)"
-echo
-echo "  Your seed phrase will appear in this terminal."
-echo "  Make sure nobody is looking over your shoulder."
-echo
-/usr/local/bin/lncli ` +
-		`--rpcserver=` + paths.LNDGRPCEndpoint + ` ` +
-		`--tlscertpath=` + paths.StateLNDTLSCert + ` ` +
-		`--network=` + net.LNDNetwork + ` create && {
-  trap '' INT
-  echo
-  echo "  ==================================================="
-  echo "  Your 24-word seed is displayed above."
-  echo "  Write it down NOW."
-  echo
-  echo "  Storage options:"
-  echo "    * Pen and paper, kept somewhere safe"
-  echo "    * An offline password manager (e.g. KeePass)"
-  echo
-  echo "  Digital copies (screenshots, photos, cloud"
-  echo "  storage) are NOT safe."
-  echo
-  while true; do
-    printf "  Type I SAVED MY SEED: "
-    read line
-    [ "$line" = "I SAVED MY SEED" ] && break
-    echo "  Please type exactly: I SAVED MY SEED"
-  done
-  echo
-  echo "  Seed confirmed. Returning to TUI..."
-  sleep 1
-  printf '\033[2J\033[3J\033[H'
-}`
-
-	cmd := exec.Command("bash", "-c", script)
-	return tea.ExecProcess(cmd,
-		func(err error) tea.Msg {
-			return walletExecDoneMsg{err: err}
-		})
+func (s *WalletCreateScreen) acceptsFinalization(m walletFinalizedMsg) bool {
+	return m.owner == s && s.attempt != nil && m.attempt == s.attempt &&
+		s.step == walletFinalizing && m.revision == s.attempt.finalization
 }
 
-// ── View ────────────────────────────────────────────────
+func (s *WalletCreateScreen) canContinue() bool {
+	return s.result.Presence == app.WalletPresent && s.result.CredentialsStaged && s.result.SeedAcknowledged && s.clientErr == nil
+}
 
-func (s *WalletCreateScreen) View(
-	w, h int,
-) string {
+func (s *WalletCreateScreen) retrySetup() bool {
+	return s.result.CanRetryFinalization() || s.clientErr != nil
+}
+
+func (s *WalletCreateScreen) hasRecoveryAction() bool {
+	return s.attempt != nil && s.attempt.finalization > 0 && (s.retrySetup() || s.canContinue())
+}
+
+func (s *WalletCreateScreen) View(w, h int) string {
 	switch s.step {
-	case walletWaiting:
+	case walletWaiting, walletExec:
 		return renderWaitingForLND(w, h)
-	case walletExec:
-		// During exec, bash owns the terminal and the
-		// TUI isn't visible. If something does render
-		// briefly during the handoff, show a neutral
-		// placeholder.
-		return renderWaitingForLND(w, h)
-	case walletErr:
-		return s.viewError(w, h)
+	case walletFinalizing:
+		p := newPane(w)
+		p.title(theme.Header, "Checking Wallet and Credentials")
+		p.dim("Wallet creation will not be repeated.")
+		return p.render()
+	case walletResult:
+		return s.viewResult(w, h)
+	default:
+		return s.viewConfirm(w, h)
 	}
-	return s.viewConfirm(w, h)
 }
 
 func (s *WalletCreateScreen) viewConfirm(
@@ -448,54 +311,37 @@ func (s *WalletCreateScreen) viewConfirm(
 		s.btnIdx, isFocused, h)
 }
 
-func (s *WalletCreateScreen) viewError(
-	w, h int,
-) string {
-	isFocused := s.ctx.ContentFocused
+func (s *WalletCreateScreen) viewResult(w, h int) string {
 	p := newPane(w)
-
-	p.title(theme.Header,
-		"Wallet Creation Failed")
-	p.blank()
-	if s.resultErr != nil {
-		p.warnWrap(s.resultErr.Error())
+	title := "Wallet Creation Not Completed"
+	if s.result.Presence == app.WalletPresent {
+		title = "Wallet Exists"
 	}
-	p.blank()
-	p.line(" " + theme.Value.Render(
-		"You can close this and try again."))
-
-	return p.renderWithBottomButtons(
-		[]string{"Done"}, 0, isFocused, h)
+	if s.result.Presence == app.WalletUnknown {
+		title = "Wallet State Unconfirmed"
+	}
+	p.title(theme.Header, title)
+	if s.result.Err != nil {
+		p.warnWrap(s.result.Err.Error())
+	}
+	if s.hasRecoveryAction() && s.retrySetup() {
+		p.dim("Retry checks wallet state and stages credentials.")
+		p.dim("It does not run wallet creation again.")
+	}
+	buttons := []string{"Done"}
+	if s.hasRecoveryAction() {
+		label := "Continue"
+		if s.retrySetup() {
+			label = "Retry Setup"
+		}
+		buttons = append(buttons, label)
+	}
+	return p.renderWithBottomButtons(buttons, s.btnIdx, s.ctx.ContentFocused, h)
 }
 
-// ── HelpBindings ────────────────────────────────────────
-
 func (s *WalletCreateScreen) HelpBindings() []key.Binding {
-	if s.step == walletWaiting || s.step == walletExec {
-		return []key.Binding{kQuit}
+	if walletCreationBusy(s) {
+		return []key.Binding{kSidebar, kUpTabBar, kQuit}
 	}
-
-	if s.step == walletErr {
-		return resultBindings(s.ctx.HasTabs)
-	}
-
-	// Confirm step
-	var binds []key.Binding
-	if s.btnIdx == 0 {
-		binds = append(binds,
-			kSidebar,
-			kRightButton)
-	} else {
-		binds = append(binds,
-			kLeftRightButtons)
-	}
-	binds = append(binds,
-		kEnter,
-		kBack)
-	if s.ctx.HasTabs {
-		binds = append(binds,
-			kUpTabBar)
-	}
-	binds = append(binds, kQuit)
-	return binds
+	return tabButtonBindings(s.ctx.HasTabs)
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -111,12 +111,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(
 				fetchStatus(m.cfg, m.state, m.lndClient),
 				fetchPaymentHistoryCmd(m.lndClient),
-				fetchWalletStateCmd(),
+				fetchWalletStateCmd(m.screenCtx),
 				fetchKeyVerificationStateCmd())
 		}
 		return m, tea.Batch(
 			fetchStatus(m.cfg, m.state, m.lndClient),
-			fetchWalletStateCmd(),
+			fetchWalletStateCmd(m.screenCtx),
 			fetchKeyVerificationStateCmd())
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
@@ -238,6 +238,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case refreshStatusMsg:
 		return m, fetchStatus(m.cfg, m.state, m.lndClient)
 	case openTabMsg:
+		if msg.Kind == tabWalletCreate {
+			// One wallet belongs to this node, even when opened from another section.
+			for _, tab := range m.tabs {
+				if tab.Kind != tabWalletCreate {
+					continue
+				}
+				m.nav.ActiveItem, m.nav.Cursor = tab.Section, tab.Section
+				for i, visible := range m.effectiveTabs() {
+					if visible.Screen == tab.Screen {
+						m.activeTab = i
+						m.rememberTabPosition()
+						m.focusContent()
+						return m, m.activateTab()
+					}
+				}
+			}
+		}
 		if msg.Kind == tabSSHKeyDetail {
 			detail, ok := msg.Screen.(*SSHKeyDetailScreen)
 			if !ok || msg.Key == "" || detail.keyInfo.Fingerprint != msg.Key || m.nav.ActiveSection() != secSystem {
@@ -294,7 +311,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					t.Section == sec {
 					m.activeTab = i
 					m.rememberTabPosition()
-					if msg.Replace && (onChainSendBusy(t.Screen) || channelOpenBusy(t.Screen) || m.sshTabBusy(t) || m.helperTabBusy(t)) {
+					if msg.Replace && (walletCreationBusy(t.Screen) || onChainSendBusy(t.Screen) || channelOpenBusy(t.Screen) || m.sshTabBusy(t) || m.helperTabBusy(t)) {
 						return m, nil
 					}
 					if msg.Replace &&
@@ -360,6 +377,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// (it recorded which tab kind it lives on).
 		return m.dispatchToTab(msg.tab, msg)
 	case walletStateMsg:
+		if msg.owner != m.screenCtx || msg.revision != m.screenCtx.walletRevision || walletCreationBusy(m.screenCtx.walletCreationOwner) {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.state.WalletKnown = false
 			logger.TUI("read live wallet state: %v", msg.err)
@@ -368,7 +388,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state.WalletExists = msg.state.WalletExists
 		m.state.WalletKnown = true
 		if m.state.WalletExists && m.lndClient == nil &&
-			m.cfg.HasLND() {
+			m.cfg.HasLND() && m.screenCtx.walletCreationOwner == nil {
 			m.lndClient = lndrpc.New()
 			m.screenCtx.LndClient = m.lndClient
 			return m, fetchStatus(m.cfg, m.state, m.lndClient)
@@ -547,43 +567,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case changePwDoneMsg:
 		return m.dispatchToTab(tabSSHChangePassword, msg)
 	case walletLNDReadyMsg:
-		return m.dispatchToTab(tabWalletCreate, msg)
+		return m.routeWalletCreation(msg.owner, msg)
 	case walletExecDoneMsg:
-		return m.dispatchToTab(tabWalletCreate, msg)
-	case walletCreatedMsg:
-		// Wallet was successfully created. Record the live result and create
-		// the lndClient (it didn't
-		// exist before this point because NewModel
-		// only constructs it when the wallet already
-		// exists), and transform the wallet creation
-		// tab in place into an AutoUnlockScreen so
-		// the user goes straight from "I SAVED MY
-		// SEED" into auto-unlock setup.
-		m.state.WalletExists = true
-		m.state.WalletKnown = true
-		if m.lndClient == nil && m.cfg.HasLND() {
-			m.lndClient = lndrpc.New()
-			m.screenCtx.LndClient = m.lndClient
+		return m.routeWalletCreation(msg.owner, msg)
+	case walletFinalizedMsg:
+		return m.finishWalletCreation(msg)
+	case closeWalletCreateMsg:
+		if msg.owner == nil || msg.owner.attempt != msg.attempt || walletCreationBusy(msg.owner) ||
+			(msg.attempt != nil && msg.revision != msg.attempt.finalization) {
+			return m, nil
 		}
-		// Find the wallet creation tab and transform
-		// it. We mutate m.tabs directly because the
-		// effectiveTabs() view is computed on demand.
-		for i := range m.tabs {
-			if m.tabs[i].Kind == tabWalletCreate {
-				newScreen :=
-					NewAutoUnlockScreen(m.screenCtx)
-				m.tabs[i].Kind = tabAutoUnlock
-				m.tabs[i].Label = "Auto-Unlock"
-				m.tabs[i].Screen = newScreen
-				return m, tea.Batch(
-					fetchStatus(m.cfg, m.state, m.lndClient),
-					newScreen.Init(),
-				)
-			}
+		return m.closeScreenTab(msg.owner)
+	case continueWalletCreateMsg:
+		if msg.owner == nil || msg.owner.attempt != msg.attempt || msg.owner.step != walletResult || !msg.owner.canContinue() {
+			return m, nil
 		}
-		// Tab not found (shouldn't happen, but be
-		// defensive). Just refresh status.
-		return m, fetchStatus(m.cfg, m.state, m.lndClient)
+		return m.continueWalletCreation(msg.owner)
 	case adminLoginVerifiedMsg:
 		if msg.err != nil {
 			logger.TUI("verify admin login: %v", msg.err)
@@ -599,7 +598,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.fetchInFlight = true
 		cmds := []tea.Cmd{
 			fetchStatus(m.cfg, m.state, m.lndClient),
-			fetchWalletStateCmd(),
+			fetchWalletStateCmd(m.screenCtx),
 			fetchKeyVerificationStateCmd(),
 			tickEveryCmd(m.pollInterval()),
 		}
@@ -945,6 +944,7 @@ func (m Model) closeScreenTab(screen Screen) (tea.Model, tea.Cmd) {
 				}
 			}
 		} else {
+			m.releaseWalletCreation(tab.Screen)
 			m.tabs = append(m.tabs[:i], m.tabs[i+1:]...)
 			m.sectionFocus[tab.Section] = 0
 			return m, nil
@@ -963,7 +963,7 @@ func (m Model) closeTab(
 
 	closingTab := tabs[tabIdx]
 	// Keep submitted operations reachable until their bounded calls return.
-	if onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) || channelCloseBusy(closingTab.Screen) || m.sshTabBusy(closingTab) || m.helperTabBusy(closingTab) {
+	if walletCreationBusy(closingTab.Screen) || onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) || channelCloseBusy(closingTab.Screen) || m.sshTabBusy(closingTab) || m.helperTabBusy(closingTab) {
 		return m, nil
 	}
 
@@ -992,6 +992,7 @@ func (m Model) closeTab(
 	var newTabs []openTab
 	for _, t := range m.tabs {
 		if shouldRemove(t) {
+			m.releaseWalletCreation(t.Screen)
 			continue
 		}
 		newTabs = append(newTabs, t)

--- a/internal/tui/wallet_creation.go
+++ b/internal/tui/wallet_creation.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+func (m Model) routeWalletCreation(owner *WalletCreateScreen, msg tea.Msg) (Model, tea.Cmd) {
+	if owner == nil {
+		return m, nil
+	}
+	for _, tab := range m.tabs {
+		if tab.Screen == owner {
+			_, cmd := owner.HandleMsg(msg)
+			return m, cmd
+		}
+	}
+	return m, nil
+}
+
+func (m Model) finishWalletCreation(msg walletFinalizedMsg) (Model, tea.Cmd) {
+	s := msg.owner
+	if s == nil || !s.acceptsFinalization(msg) {
+		return m, nil
+	}
+	found := false
+	for _, tab := range m.tabs {
+		if tab.Screen == s {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return m, nil
+	}
+	s.HandleMsg(msg)
+	m.screenCtx.walletRevision++
+	m.state.WalletKnown = msg.result.Presence != app.WalletUnknown
+	if m.state.WalletKnown {
+		m.state.WalletExists = msg.result.Presence == app.WalletPresent
+	}
+	s.clientErr = nil
+	if msg.result.CredentialsStaged && m.lndClient == nil {
+		open := m.screenCtx.openWalletClient
+		if open == nil {
+			open = lndrpc.NewStagedClient
+		}
+		client, err := open()
+		if err != nil {
+			s.clientErr = fmt.Errorf("wallet credentials were staged, but the TUI client could not be initialized: %w", err)
+			s.result.Err = errors.Join(s.result.Err, s.clientErr)
+		} else {
+			m.lndClient, m.screenCtx.LndClient = client, client
+		}
+	}
+	if s.result.Err == nil && s.canContinue() {
+		return m.continueWalletCreation(s)
+	}
+	return m, nil
+}
+
+func (m Model) continueWalletCreation(owner *WalletCreateScreen) (Model, tea.Cmd) {
+	for i, tab := range m.tabs {
+		if tab.Screen != owner {
+			continue
+		}
+		m.releaseWalletCreation(owner)
+		screen := NewAutoUnlockScreen(m.screenCtx)
+		m.tabs[i].Kind, m.tabs[i].Label, m.tabs[i].Screen = tabAutoUnlock, "Auto-Unlock", screen
+		return m, tea.Batch(fetchStatus(m.cfg, m.state, m.lndClient), screen.Init())
+	}
+	return m, nil
+}
+
+func (m *Model) releaseWalletCreation(screen Screen) {
+	if screen == m.screenCtx.walletCreationOwner {
+		m.screenCtx.walletCreationOwner = nil
+		m.screenCtx.walletRevision++
+	}
+}

--- a/internal/tui/wallet_creation_test.go
+++ b/internal/tui/wallet_creation_test.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+func walletCreationFixture(t *testing.T) (Model, *WalletCreateScreen, *int) {
+	t.Helper()
+	ctx := &ScreenContext{Cfg: config.Default(), State: &RuntimeState{WalletKnown: true}}
+	ctx.WalletCreation = app.NewWalletCreation()
+	t.Cleanup(ctx.WalletCreation.Close)
+	opened := new(int)
+	ctx.openWalletClient = func() (*lndrpc.Client, error) { *opened++; return &lndrpc.Client{}, nil }
+	s := NewWalletCreateScreen(ctx)
+	s.attempt = &walletCreationAttempt{finalization: 1, execution: app.WalletExecution{Created: true, SeedAcknowledged: true}}
+	s.step = walletFinalizing
+	ctx.walletCreationOwner = s
+	m := Model{cfg: ctx.Cfg, state: ctx.State, screenCtx: ctx, nav: NewNavSidebar(), activeTab: 1,
+		tabs: []openTab{{Kind: tabWalletCreate, Section: secOnChain, Screen: s}}}
+	m.nav.ActiveItem = secSystem
+	return m, s, opened
+}
+
+func deliverWallet(t *testing.T, m *Model, msg tea.Msg) tea.Cmd {
+	t.Helper()
+	updated, cmd := m.Update(msg)
+	*m = updated.(Model)
+	return cmd
+}
+
+func TestWalletFinalizationRoutesFailureAndRetryToHiddenOwner(t *testing.T) {
+	m, s, opened := walletCreationFixture(t)
+	staleRead := walletStateMsg{owner: m.screenCtx, revision: m.screenCtx.walletRevision, state: helper.WalletStateResult{WalletExists: false}}
+	failure := walletFinalizedMsg{owner: s, attempt: s.attempt, revision: 1,
+		result: app.WalletCreationResult{Presence: app.WalletPresent, SeedAcknowledged: true, Err: errors.New("staging failed")}}
+	deliverWallet(t, &m, failure)
+	if s.step != walletResult || !m.state.WalletExists || !m.state.WalletKnown || *opened != 0 {
+		t.Fatal("staging failure lost or client initialized early")
+	}
+	oldDone := s.closeCmd()()
+	s.btnIdx = 1
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil || s.step != walletFinalizing || s.attempt.finalization != 2 {
+		t.Fatal("retry did not schedule finalization")
+	}
+	// Do not run a helper here. Controlled completions prove dispatch ownership.
+	deliverWallet(t, &m, failure)
+	if s.step != walletFinalizing {
+		t.Fatal("old failure completed a newer retry")
+	}
+	failure.revision = 2
+	deliverWallet(t, &m, failure)
+	// Deliver Done after the retry finishes so the busy guard cannot hide a
+	// missing revision check. This result must stay available for recovery.
+	deliverWallet(t, &m, oldDone)
+	if len(m.tabs) != 1 || s.step != walletResult {
+		t.Fatal("old Done discarded the newer result")
+	}
+	s.btnIdx = 1
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd == nil {
+		t.Fatal("newer failure lost its recovery action")
+	}
+	success := walletFinalizedMsg{owner: s, attempt: s.attempt, revision: 3,
+		result: app.WalletCreationResult{Presence: app.WalletPresent, CredentialsStaged: true, SeedAcknowledged: true}}
+	deliverWallet(t, &m, success)
+	if m.tabs[0].Kind != tabAutoUnlock || m.tabs[0].Section != secOnChain || *opened != 1 || m.screenCtx.walletCreationOwner != nil {
+		t.Fatal("success did not transform its owning tab exactly once")
+	}
+	deliverWallet(t, &m, success)
+	deliverWallet(t, &m, staleRead)
+	if !m.state.WalletExists || !m.state.WalletKnown || *opened != 1 {
+		t.Fatal("stale completion or observation changed the created wallet")
+	}
+}
+
+func TestWalletAttemptsAndNavigation(t *testing.T) {
+	m, s, opened := walletCreationFixture(t)
+	s.step = walletWaiting
+	s.attempt = &walletCreationAttempt{}
+	ready := walletLNDReadyMsg{owner: s, attempt: s.attempt, network: "signet"}
+	if cmd := deliverWallet(t, &m, ready); cmd == nil || s.step != walletExec {
+		t.Fatal("hidden readiness result lost")
+	}
+	if cmd := deliverWallet(t, &m, ready); cmd != nil {
+		t.Fatal("duplicate readiness started another terminal command")
+	}
+	read := walletStateMsg{owner: m.screenCtx, revision: m.screenCtx.walletRevision, state: helper.WalletStateResult{WalletExists: true}}
+	deliverWallet(t, &m, read)
+	if m.state.WalletExists || *opened != 0 {
+		t.Fatal("poll published wallet during creation")
+	}
+	deliverWallet(t, &m, closeWalletCreateMsg{owner: s})
+	if len(m.tabs) != 1 {
+		t.Fatal("active wallet tab closed")
+	}
+	other := NewWalletCreateScreen(m.screenCtx)
+	deliverWallet(t, &m, openTabMsg{Kind: tabWalletCreate, Replace: true, Screen: other})
+	if len(m.tabs) != 1 || m.tabs[0].Screen != s || m.nav.ActiveSection() != secOnChain {
+		t.Fatal("another section replaced or duplicated creation")
+	}
+	deliverWallet(t, &m, closeTabMsg{})
+	if len(m.tabs) != 1 {
+		t.Fatal("tab-bar close removed active creation")
+	}
+	if cmd := deliverWallet(t, &m, walletExecDoneMsg{owner: other, attempt: s.attempt}); cmd != nil {
+		t.Fatal("orphan result reached owner")
+	}
+	oldAttempt := &walletCreationAttempt{}
+	if cmd := deliverWallet(t, &m, walletExecDoneMsg{owner: s, attempt: oldAttempt}); cmd != nil {
+		t.Fatal("old attempt reached owner")
+	}
+	if cmd := deliverWallet(t, &m, walletExecDoneMsg{owner: s, attempt: s.attempt, execution: app.WalletExecution{Created: true, SeedAcknowledged: true}}); cmd == nil || s.step != walletFinalizing {
+		t.Fatal("execution completion did not schedule finalization")
+	}
+	if cmd := deliverWallet(t, &m, walletExecDoneMsg{owner: s, attempt: s.attempt}); cmd != nil {
+		t.Fatal("duplicate execution repeated staging")
+	}
+}
+
+func TestWalletDelayedDoneAndTerminalFailure(t *testing.T) {
+	m, s, _ := walletCreationFixture(t)
+	result := app.WalletCreationResult{Presence: app.WalletPresent, CredentialsStaged: true, SeedAcknowledged: true, Err: errors.New("terminal restoration failed")}
+	deliverWallet(t, &m, walletFinalizedMsg{owner: s, attempt: s.attempt, revision: 1, result: result})
+	if s.step != walletResult || m.tabs[0].Kind != tabWalletCreate || !s.canContinue() {
+		t.Fatal("terminal error hid a created wallet or automatically advanced")
+	}
+	_, done := s.HandleKey("enter", tea.KeyPressMsg{})
+	other := NewWalletCreateScreen(m.screenCtx)
+	m.tabs = append(m.tabs, openTab{Kind: tabSelfUpdate, Section: secSystem, Screen: other})
+	m.activeTab = 1
+	deliverWallet(t, &m, done())
+	deliverWallet(t, &m, done())
+	if len(m.tabs) != 1 || m.tabs[0].Screen != other || m.screenCtx.walletCreationOwner != nil {
+		t.Fatal("delayed Done affected the newly active tab")
+	}
+}
+
+func TestWalletClientFailureDoesNotEraseStagingSuccess(t *testing.T) {
+	m, s, _ := walletCreationFixture(t)
+	m.screenCtx.openWalletClient = func() (*lndrpc.Client, error) { return nil, errors.New("staged file unreadable") }
+	r := app.WalletCreationResult{Presence: app.WalletPresent, CredentialsStaged: true, SeedAcknowledged: true}
+	deliverWallet(t, &m, walletFinalizedMsg{owner: s, attempt: s.attempt, revision: 1, result: r})
+	if !s.result.CredentialsStaged || !s.retrySetup() || s.canContinue() || s.result.Err == nil {
+		t.Fatal("client initialization failure was misclassified")
+	}
+}
+
+func TestWalletReadinessFailureCannotRetryCreationThroughSetup(t *testing.T) {
+	m, s, _ := walletCreationFixture(t)
+	s.step = walletWaiting
+	s.attempt = &walletCreationAttempt{}
+	deliverWallet(t, &m, walletLNDReadyMsg{owner: s, attempt: s.attempt, err: errors.New("wallet already exists")})
+	if s.step != walletResult || s.hasRecoveryAction() {
+		t.Fatal("readiness refusal offered a finalization retry")
+	}
+}

--- a/internal/tui/wallet_terminal.go
+++ b/internal/tui/wallet_terminal.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// walletTerminal implements Bubble Tea's interactive command interface without
+// capturing passwords or seeds. Process outcomes survive a later failure to
+// restore the TUI terminal. Only successful acknowledgement permits continuation.
+type walletTerminal struct {
+	create, acknowledge *exec.Cmd
+	stdin               io.Reader
+	stdout, stderr      io.Writer
+	execution           app.WalletExecution
+}
+
+func newWalletTerminal(network string) *walletTerminal {
+	return &walletTerminal{
+		create: exec.Command("/usr/local/bin/lncli",
+			"--rpcserver="+paths.LNDGRPCEndpoint,
+			"--tlscertpath="+paths.StateLNDTLSCert,
+			"--network="+network, "create"),
+		acknowledge: exec.Command("bash", "-c", walletSeedAcknowledgement),
+	}
+}
+
+func (t *walletTerminal) SetStdin(r io.Reader)  { t.stdin = r }
+func (t *walletTerminal) SetStdout(w io.Writer) { t.stdout = w }
+func (t *walletTerminal) SetStderr(w io.Writer) { t.stderr = w }
+
+func (t *walletTerminal) Run() (err error) {
+	defer func() { t.execution.Err = err }()
+	if _, err := fmt.Fprint(t.stdout, walletCreationIntroduction); err != nil {
+		return fmt.Errorf("display wallet instructions: %w", err)
+	}
+	t.create.Stdin, t.create.Stdout, t.create.Stderr = t.stdin, t.stdout, t.stderr
+	if err := t.create.Start(); err != nil {
+		return fmt.Errorf("start lncli: %w", err)
+	}
+	if err := t.create.Wait(); err != nil {
+		return fmt.Errorf("lncli ended without confirmed success: %w", err)
+	}
+	t.execution.Created = true
+	t.acknowledge.Stdin, t.acknowledge.Stdout, t.acknowledge.Stderr = t.stdin, t.stdout, t.stderr
+	if err := t.acknowledge.Run(); err != nil {
+		return fmt.Errorf("wallet created, but seed acknowledgement did not finish: %w", err)
+	}
+	t.execution.SeedAcknowledged = true
+	return nil
+}
+
+const walletCreationIntroduction = `
+  Lightning Wallet Creation
+
+  Make sure nobody is looking over your shoulder.
+  Password entry is invisible; typing and pasting still work.
+  Choose and confirm a wallet password, then press 'n' for a new seed.
+  The cipher seed passphrase is optional. Keep it with your recovery records
+  if you choose one.
+  Write down the 24-word seed when LND displays it.
+
+`
+
+// SIGINT is ignored only after lncli succeeds. EOF or terminal loss is failure,
+// never acknowledgement, and does not loop forever or imply wallet rollback.
+const walletSeedAcknowledgement = `trap '' INT
+echo
+echo "  Your wallet was created. Preserve the 24-word seed displayed above."
+echo "  Store it securely offline, away from this server."
+while true; do
+  printf "  Type I SAVED MY SEED: "
+  IFS= read -r line || exit 1
+  [ "$line" = "I SAVED MY SEED" ] && break
+  echo "  Please type exactly: I SAVED MY SEED"
+done
+printf '\033[2J\033[3J\033[H'
+`

--- a/internal/tui/wallet_terminal_test.go
+++ b/internal/tui/wallet_terminal_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWalletTerminalCreationAndAcknowledgement(t *testing.T) {
+	for _, tc := range []struct {
+		name, input  string
+		exit         int
+		created, ack bool
+	}{
+		{"acknowledged", "wrong\nI SAVED MY SEED\n", 0, true, true},
+		{"EOF after creation", "", 0, true, false},
+		{"lncli failure", "I SAVED MY SEED\n", 1, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			terminal := newWalletTerminal("signet")
+
+			command := "exit 0"
+			if tc.exit != 0 {
+				command = "exit 1"
+			}
+			terminal.create = exec.CommandContext(ctx, "bash", "-c", command)
+			terminal.acknowledge = exec.CommandContext(ctx, "bash", "-c", walletSeedAcknowledgement)
+			path := filepath.Join(t.TempDir(), "input")
+			if err := os.WriteFile(path, []byte(tc.input), 0600); err != nil {
+				t.Fatal(err)
+			}
+			input, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer input.Close()
+			var output bytes.Buffer
+			terminal.SetStdin(input)
+			terminal.SetStdout(&output)
+			terminal.SetStderr(&output)
+			err = terminal.Run()
+			if terminal.execution.Created != tc.created || terminal.execution.SeedAcknowledged != tc.ack || (err == nil) != tc.ack {
+				t.Fatalf("result=%+v err=%v", terminal.execution, err)
+			}
+			if ctx.Err() != nil {
+				t.Fatal("terminal wrapper hung")
+			}
+			if !tc.created && strings.Contains(output.String(), "Type I SAVED MY SEED") {
+				t.Fatal("acknowledgement prompted after lncli failure")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Wallet creation previously mixed terminal execution, wallet-state decisions and credential staging in the TUI. Interrupted completion could leave an existing wallet without a clear recovery path.

The application layer now owns bounded readiness checks and finalization. The TUI retains interactive `lncli` execution, seed acknowledgement and presentation, with results tied to the initiating attempt. Retry Setup rechecks wallet state and stages credentials without rerunning creation. LND creates the wallet; the privileged helper retains credential-staging authority.

## Validation

- Tested commit: `936ec113f3a59204dd6f490afb655cd2731cfd74`.
- Go 1.26.8: maintainer full tests, race tests, vet and Linux amd64 build passed. Staticcheck found no new diagnostics in affected packages. 
- Fresh, unfunded Debian 13 amd64 public-Signet installation: wallet creation and seed acknowledgement passed. Deliberately stopping the helper socket and service before staging produced the expected wallet-exists error. After administrator restoration, Retry Setup completed staging and reached Auto-Unlock with the same wallet identity.
- Verified staged credential permissions, authenticated access as `vpn`, and inability to read the source macaroon. Auto-unlock, protected password-file permissions, same-wallet operation after reboot, administrator/TUI access and installed binary identity passed.