### PR TITLE
refactor: own syncthing runtime and device workflows

### DIFF
--- a/docs/syncthing.md
+++ b/docs/syncthing.md
@@ -60,7 +60,20 @@ In the Node dashboard:
 4. Paste your local Device ID
 5. Confirm with the Pair button
 
-The Node adds your device and shares the backup folder automatically.
+The Node adds your device and shares the backup folder. Completion confirms the
+Node's configuration; the receiver still needs steps 6 and 7 below. Avoid editing
+the Node's Syncthing configuration in its web UI while pairing or removing a
+device in the TUI.
+
+If pairing reports an incomplete or unconfirmed outcome, inspect the device and
+`lnd-backup` share in the Node's web UI before retrying. A device may have been
+added even when sharing was not confirmed. An explicit pairing retry preserves
+that device's settings and completes a missing backup share. It does not
+reinstall Syncthing or roll back earlier changes.
+
+Removal identifies the selected device by its complete Device ID. It removes
+that device and its folder shares on the Node; remote files remain intact.
+An unconfirmed removal requires checking the current device list before retrying.
 
 ### Step 6 — Add the Node in Your Local Syncthing
 
@@ -127,6 +140,14 @@ the System section.
   (not exposed to clearnet)
 
 ### Troubleshooting
+
+**Privacy or API-key check failed:**
+
+The TUI refuses pairing when it cannot verify the Node's privacy settings or
+send-only backup boundary. Ask the host administrator to inspect the existing
+configuration and staged credentials. Reinstalling over retained Syncthing state
+is not a supported repair. During installation, a failed privacy check triggers
+stop and disable; any failure of those actions is reported separately.
 
 **Devices not connecting:**
 

--- a/internal/app/syncthing.go
+++ b/internal/app/syncthing.go
@@ -1,0 +1,219 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
+)
+
+type SyncthingClient interface {
+	CanonicalID(context.Context, string) (string, error)
+	LocalID(context.Context) (string, error)
+	ListDevices(context.Context) ([]syncthing.Device, error)
+	ConfirmPrivacy(context.Context) error
+	BackupFolder(context.Context, string) (syncthing.BackupFolder, error)
+	AddDevice(context.Context, string) error
+	ShareBackup(context.Context, syncthing.BackupFolder, string) error
+	RemoveDevice(context.Context, string) error
+}
+
+type SyncthingOutcome int
+
+const (
+	SyncthingNotChanged SyncthingOutcome = iota
+	SyncthingComplete
+	SyncthingPartial
+	SyncthingUnknown
+)
+
+type SyncthingResult struct {
+	Outcome  SyncthingOutcome
+	DeviceID string
+	LocalID  string
+	Err      error
+}
+
+// Syncthing owns bounded runtime workflows; the daemon remains configuration
+// authority. A successful pair configures this node, not the remote receiver.
+type Syncthing struct {
+	client func() (SyncthingClient, error)
+	lock   func(func() error) error
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	closed bool
+	calls  sync.WaitGroup
+}
+
+func NewSyncthing() *Syncthing {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Syncthing{ctx: ctx, cancel: cancel, lock: syncthing.WithMutationLock, client: func() (SyncthingClient, error) {
+		key, err := helper.ReadBoardString(paths.StateSyncthingAPIKey)
+		if err != nil {
+			return nil, errors.New("Syncthing credentials unavailable; administrator inspection is required")
+		}
+		return syncthing.NewClient(key), nil
+	}}
+}
+func (s *Syncthing) begin() (context.Context, func(), error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, nil, errors.New("Syncthing workflow is shutting down")
+	}
+	s.calls.Add(1)
+	ctx, cancel := context.WithTimeout(s.ctx, 60*time.Second)
+	return ctx, func() { cancel(); s.calls.Done() }, nil
+}
+
+// Close cancels and joins local calls. Accepted daemon writes are not rolled back.
+func (s *Syncthing) Close() {
+	s.mu.Lock()
+	s.closed = true
+	s.cancel()
+	s.mu.Unlock()
+	s.calls.Wait()
+}
+func (s *Syncthing) ListDevices() ([]syncthing.Device, error) {
+	ctx, done, err := s.begin()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	c, err := s.client()
+	if err != nil {
+		return nil, err
+	}
+	return c.ListDevices(ctx)
+}
+func (s *Syncthing) Pair(input string) SyncthingResult {
+	result := SyncthingResult{}
+	ctx, done, err := s.begin()
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	defer done()
+	result.Err = s.lock(func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		c, err := s.client()
+		if err != nil {
+			return err
+		}
+		id, err := c.CanonicalID(ctx, input)
+		if err != nil {
+			return err
+		}
+		result.DeviceID = id
+		local, err := c.LocalID(ctx)
+		if err != nil {
+			return err
+		}
+		result.LocalID = local
+		if id == local {
+			return errors.New("cannot pair this node with itself")
+		}
+		if err = c.ConfirmPrivacy(ctx); err != nil {
+			return err
+		}
+		folder, err := c.BackupFolder(ctx, local)
+		if err != nil {
+			return err
+		}
+		devices, err := c.ListDevices(ctx)
+		if err != nil {
+			return err
+		}
+		exists := false
+		for _, d := range devices {
+			if d.DeviceID == id {
+				exists = true
+				break
+			}
+		}
+		if exists && folder.HasDevice(id) {
+			return errors.New("device already paired and sharing the backup folder")
+		}
+		if !exists {
+			// Once a write is attempted, an error cannot establish that nothing changed.
+			result.Outcome = SyncthingUnknown
+			if err = c.AddDevice(ctx, id); err != nil {
+				return fmt.Errorf("device addition was not confirmed; inspect current devices before retrying: %w", err)
+			}
+		}
+		result.Outcome = SyncthingPartial
+		// Re-read under the VPN lock; never reuse a screen's older folder snapshot.
+		folder, err = c.BackupFolder(ctx, local)
+		if err != nil {
+			return fmt.Errorf("device is configured, but backup sharing is incomplete: %w", err)
+		}
+		result.Outcome = SyncthingUnknown
+		if err = c.ShareBackup(ctx, folder, id); err != nil {
+			return fmt.Errorf("device is configured; backup sharing was not confirmed: %w", err)
+		}
+		result.Outcome = SyncthingComplete
+		return nil
+	})
+	return result
+}
+
+func (s *Syncthing) Remove(input string) SyncthingResult {
+	result := SyncthingResult{}
+	ctx, done, err := s.begin()
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	defer done()
+	result.Err = s.lock(func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		c, err := s.client()
+		if err != nil {
+			return err
+		}
+		id, err := c.CanonicalID(ctx, input)
+		if err != nil {
+			return err
+		}
+		result.DeviceID = id
+		local, err := c.LocalID(ctx)
+		if err != nil {
+			return err
+		}
+		result.LocalID = local
+		if id == local {
+			return errors.New("cannot remove this node's own Syncthing identity")
+		}
+		devices, err := c.ListDevices(ctx)
+		if err != nil {
+			return err
+		}
+		found := false
+		for _, d := range devices {
+			if d.DeviceID == id {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.New("device is no longer configured; refresh the device list")
+		}
+		result.Outcome = SyncthingUnknown
+		if err = c.RemoveDevice(ctx, id); err != nil {
+			return fmt.Errorf("device removal was not confirmed; inspect the current device list before retrying: %w", err)
+		}
+		result.Outcome = SyncthingComplete
+		return nil
+	})
+	return result
+}

--- a/internal/app/syncthing_test.go
+++ b/internal/app/syncthing_test.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
+)
+
+type syncFake struct {
+	fail        string
+	existing    bool
+	shared      bool
+	self        bool
+	folderReads int
+	writes      []string
+	block       chan struct{}
+	release     chan struct{}
+}
+
+func (f *syncFake) err(at string) error {
+	if f.fail == at {
+		return errors.New("injected " + at)
+	}
+	return nil
+}
+func (f *syncFake) CanonicalID(context.Context, string) (string, error) {
+	if f.self {
+		return "LOCAL", nil
+	}
+	return "REMOTE", f.err("id")
+}
+func (f *syncFake) LocalID(context.Context) (string, error) { return "LOCAL", f.err("local") }
+func (f *syncFake) ListDevices(ctx context.Context) ([]syncthing.Device, error) {
+	if f.block != nil {
+		close(f.block)
+		<-ctx.Done()
+		<-f.release
+		return nil, ctx.Err()
+	}
+	if f.existing {
+		return []syncthing.Device{{DeviceID: "REMOTE"}}, f.err("list")
+	}
+	return nil, f.err("list")
+}
+func (f *syncFake) ConfirmPrivacy(context.Context) error { return f.err("privacy") }
+func (f *syncFake) BackupFolder(context.Context, string) (syncthing.BackupFolder, error) {
+	f.folderReads++
+	if f.folderReads == 2 && f.fail == "reread" {
+		return syncthing.BackupFolder{}, errors.New("injected reread")
+	}
+	folder := syncthing.BackupFolder{}
+	if f.shared {
+		folder.Devices = []json.RawMessage{json.RawMessage(`{"deviceID":"REMOTE"}`)}
+	}
+	return folder, f.err("folder")
+}
+func (f *syncFake) AddDevice(context.Context, string) error {
+	f.writes = append(f.writes, "add")
+	return f.err("add")
+}
+func (f *syncFake) ShareBackup(context.Context, syncthing.BackupFolder, string) error {
+	f.writes = append(f.writes, "share")
+	return f.err("share")
+}
+func (f *syncFake) RemoveDevice(context.Context, string) error {
+	f.writes = append(f.writes, "remove")
+	return f.err("remove")
+}
+func syncService(t *testing.T, f *syncFake) *Syncthing {
+	t.Helper()
+	s := NewSyncthing()
+	t.Cleanup(s.Close)
+	s.client = func() (SyncthingClient, error) { return f, nil }
+	s.lock = func(action func() error) error { return action() }
+	return s
+}
+func TestSyncthingPairOutcomesAndPreservation(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		fail                   string
+		existing, shared, self bool
+		want                   SyncthingOutcome
+		writes                 string
+	}{
+		{name: "new pair", want: SyncthingComplete, writes: "add,share"},
+		{name: "finish existing device", existing: true, want: SyncthingComplete, writes: "share"},
+		{name: "duplicate", existing: true, shared: true, want: SyncthingNotChanged},
+		{name: "self", self: true, want: SyncthingNotChanged},
+		{name: "invalid ID", fail: "id", want: SyncthingNotChanged},
+		{name: "privacy drift", fail: "privacy", want: SyncthingNotChanged},
+		{name: "folder drift", fail: "folder", want: SyncthingNotChanged},
+		{name: "read failure", fail: "list", want: SyncthingNotChanged},
+		{name: "lost addition response", fail: "add", want: SyncthingUnknown, writes: "add"},
+		{name: "folder read after addition", fail: "reread", want: SyncthingPartial, writes: "add"},
+		{name: "lost share response", fail: "share", want: SyncthingUnknown, writes: "add,share"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &syncFake{fail: tc.fail, existing: tc.existing, shared: tc.shared, self: tc.self}
+			result := syncService(t, f).Pair("input")
+			if result.Outcome != tc.want || strings.Join(f.writes, ",") != tc.writes {
+				t.Fatalf("result=%+v writes=%v", result, f.writes)
+			}
+			if (result.Err == nil) != (tc.want == SyncthingComplete) {
+				t.Fatalf("wrong completion/error: %+v", result)
+			}
+		})
+	}
+}
+func TestSyncthingRemovalAndContention(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		fail           string
+		existing, self bool
+		want           SyncthingOutcome
+		writes         string
+	}{
+		{name: "remove", existing: true, want: SyncthingComplete, writes: "remove"},
+		{name: "missing", want: SyncthingNotChanged},
+		{name: "self", self: true, want: SyncthingNotChanged},
+		{name: "lost response", existing: true, fail: "remove", want: SyncthingUnknown, writes: "remove"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &syncFake{existing: tc.existing, self: tc.self, fail: tc.fail}
+			result := syncService(t, f).Remove("input")
+			if result.Outcome != tc.want || strings.Join(f.writes, ",") != tc.writes {
+				t.Fatalf("result=%+v writes=%v", result, f.writes)
+			}
+		})
+	}
+	f := &syncFake{}
+	s := syncService(t, f)
+	s.lock = func(func() error) error { return errors.New("busy") }
+	if result := s.Pair("input"); result.Outcome != SyncthingNotChanged || result.Err == nil || len(f.writes) != 0 {
+		t.Fatalf("contending pair mutated: %+v", result)
+	}
+}
+func TestSyncthingShutdownJoinsAndRefusesNewCalls(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := &syncFake{block: make(chan struct{}), release: make(chan struct{})}
+		s := syncService(t, f)
+		done := make(chan error, 1)
+		go func() { _, err := s.ListDevices(); done <- err }()
+		<-f.block
+		closed := false
+		go func() { s.Close(); closed = true }()
+		synctest.Wait()
+		// Cancellation alone must not let Close return before the call finishes.
+		returnedEarly := closed
+		close(f.release)
+		synctest.Wait()
+		if returnedEarly || !closed {
+			t.Fatal("shutdown did not wait for the active call")
+		}
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatal(err)
+		}
+		if result := s.Pair("input"); result.Err == nil || len(f.writes) != 0 {
+			t.Fatal("shutdown allowed mutation")
+		}
+	})
+}

--- a/internal/helperd/verbs.go
+++ b/internal/helperd/verbs.go
@@ -322,9 +322,8 @@ func verbReadNodeAddresses(_ *verbCtx, _ json.RawMessage) (any, error) {
 			paths.TorLNDGRPC + "/hostname"),
 		LNDRESTOnion:   readHostname(paths.TorLNDRESTHostname),
 		SyncthingOnion: readHostname(paths.TorSyncthingHostname),
-		// Root-side read: parses Syncthing's own config, so it
-		// answers correctly even when the daemon is stopped.
-		SyncthingDeviceID: installer.GetSyncthingDeviceID(),
+		// Read the certificate identity even when the daemon is stopped.
+		SyncthingDeviceID: host.SyncthingDeviceID(),
 	}, nil
 }
 

--- a/internal/host/syncthing.go
+++ b/internal/host/syncthing.go
@@ -1,0 +1,20 @@
+package host
+
+import (
+	"strings"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// SyncthingDeviceID reads the certificate identity with the pinned daemon's
+// read-only command. Configuration device order does not identify the local node.
+// runuser supplies the service HOME required by Syncthing package initialization.
+func SyncthingDeviceID() string {
+	output, err := system.RunContext(10*time.Second, "runuser", "-u", "syncthing", "--", paths.SyncthingBinary, "device-id", "--config="+paths.SyncthingDir)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(output)
+}

--- a/internal/host/syncthing.go
+++ b/internal/host/syncthing.go
@@ -12,7 +12,10 @@ import (
 // read-only command. Configuration device order does not identify the local node.
 // runuser supplies the service HOME required by Syncthing package initialization.
 func SyncthingDeviceID() string {
-	output, err := system.RunContext(10*time.Second, "runuser", "-u", "syncthing", "--", paths.SyncthingBinary, "device-id", "--config="+paths.SyncthingDir)
+	output, err := system.RunContext(10*time.Second,
+		"runuser", "-u", "syncthing", "--", paths.SyncthingBinary,
+		"device-id", "--config="+paths.SyncthingDir,
+		"--data="+paths.SyncthingDataDir)
 	if err != nil {
 		return ""
 	}

--- a/internal/installer/runtime_state_test.go
+++ b/internal/installer/runtime_state_test.go
@@ -68,27 +68,3 @@ func TestSyncthingResidueIncludesStagedCredentials(t *testing.T) {
 		}
 	}
 }
-
-func TestParseSyncthingDevicesUsesCurrentDaemonFacts(t *testing.T) {
-	raw := []byte(`[
-  {"deviceID":"LOCAL","name":"this node"},
-  {"deviceID":"B","name":" Laptop "},
-  {"deviceID":"A","name":""},
-  {"deviceID":"B","name":"stale duplicate"},
-  {"deviceID":" ","name":"invalid"}
-]`)
-	devices, err := parseSyncthingDevices(raw, "LOCAL")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(devices) != 2 {
-		t.Fatalf("devices = %+v", devices)
-	}
-	if devices[0].DeviceID != "B" || devices[0].Name != "Laptop" ||
-		devices[1].DeviceID != "A" || devices[1].Name != "Syncthing device" {
-		t.Fatalf("unexpected current device view: %+v", devices)
-	}
-	if _, err := parseSyncthingDevices([]byte(`{}`), "LOCAL"); err == nil {
-		t.Fatal("malformed device list accepted")
-	}
-}

--- a/internal/installer/syncthing.go
+++ b/internal/installer/syncthing.go
@@ -1,26 +1,28 @@
 // internal/installer/syncthing.go
 
+// Package installer provisions VPN and coordinates fresh or resumed installation.
 package installer
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
-	"github.com/virtualprivatenode/vpn/internal/helper"
+	"github.com/virtualprivatenode/vpn/internal/host"
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
 	"github.com/virtualprivatenode/vpn/internal/system"
 )
 
@@ -454,15 +456,22 @@ ExecStart=%s publish-lnd-backup %s
 	return pathUnit, exportService, nil
 }
 
-// stopSyncthingFailSafe stops AND disables Syncthing. Used on
-// the fail-safe paths (readiness timeout, privacy-confirm
-// failure) so that a later reboot — including the automatic
-// reboot from unattended-upgrades — cannot silently restart a
-// daemon whose privacy state we could not verify. A retried
-// install re-enables via startSyncthing.
-func stopSyncthingFailSafe() {
-	system.SudoRunSilent("systemctl", "stop", "syncthing")
-	system.SudoRunSilent("systemctl", "disable", "syncthing")
+var syncthingServiceCommand = system.SudoRun
+
+// stopSyncthingFailSafe attempts both stop and disable so an unverified daemon
+// cannot silently return on reboot. Failures remain explicit; retained residue
+// is not repaired by retrying installation.
+func stopSyncthingFailSafe() error {
+	stopErr := syncthingServiceCommand("systemctl", "stop", "syncthing")
+	disableErr := syncthingServiceCommand("systemctl", "disable", "syncthing")
+	return errors.Join(stopErr, disableErr)
+}
+
+func failSyncthingPrivacy(cause error) error {
+	if err := stopSyncthingFailSafe(); err != nil {
+		return errors.Join(cause, fmt.Errorf("could not confirm Syncthing stop/disable; administrator action is required: %w", err))
+	}
+	return fmt.Errorf("syncthing stopped and disabled: %w", cause)
 }
 
 func startSyncthing() error {
@@ -473,75 +482,39 @@ func startSyncthing() error {
 		return err
 	}
 	if err := system.SudoRun("systemctl", "start", "syncthing"); err != nil {
-		return err
+		return failSyncthingPrivacy(err)
 	}
 
-	// Readiness probe. /rest/noauth/health is the documented
-	// unauthenticated endpoint; the previous probe hit
-	// /rest/system/status without an API key, got 403 on every
-	// try, and spun the full 30s. Same standard HTTP client as
-	// the REST transport below. Fail-safe: if the daemon never
-	// readies, stop it and fail the install.
+	// Health and privacy reads use the same loopback-only transport as runtime.
 	ready := false
-	probe := &http.Client{Timeout: 3 * time.Second}
+	probe := syncthing.NewClient("")
 	for i := 0; i < 30; i++ {
-		resp, err := probe.Get(
-			syncthingGUIBase + "/rest/noauth/health")
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		_, err := probe.Request(ctx, http.MethodGet, "/rest/noauth/health", "")
+		cancel()
 		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				ready = true
-				break
-			}
+			ready = true
+			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 	if !ready {
-		stopSyncthingFailSafe()
-		return fmt.Errorf(
-			"syncthing did not become ready — stopped")
+		return failSyncthingPrivacy(errors.New("syncthing did not become ready"))
 	}
 
-	// Post-start confirmation (defense in depth): the RUNNING
-	// daemon must report the privacy settings off. This is the
-	// exact check that exposed finding H. Fail-safe on mismatch.
+	// Verify the running daemon accepted the authored privacy settings.
 	return confirmSyncthingPrivacy()
 }
 
-// confirmSyncthingPrivacy reads the effective options from the
-// running daemon and hard-fails (stopping Syncthing) if any
-// announce/relay setting is enabled.
+// confirmSyncthingPrivacy verifies effective network, reporting and GUI settings
+// after startup. Missing or mismatched values trigger stop and disable.
 func confirmSyncthingPrivacy() error {
 	apiKey, err := getSyncthingAPIKey()
+	if err == nil {
+		err = syncthing.NewClient(apiKey).ConfirmPrivacy(context.Background())
+	}
 	if err != nil {
-		stopSyncthingFailSafe()
-		return fmt.Errorf("privacy confirm: get API key: %w", err)
-	}
-	resp, err := syncthingAPIGet(apiKey, "/rest/config/options")
-	if err != nil {
-		stopSyncthingFailSafe()
-		return fmt.Errorf("privacy confirm: get options: %w", err)
-	}
-
-	var opts struct {
-		GlobalAnnounceEnabled bool `json:"globalAnnounceEnabled"`
-		LocalAnnounceEnabled  bool `json:"localAnnounceEnabled"`
-		RelaysEnabled         bool `json:"relaysEnabled"`
-		NATEnabled            bool `json:"natEnabled"`
-	}
-	if err := json.Unmarshal([]byte(resp), &opts); err != nil {
-		stopSyncthingFailSafe()
-		return fmt.Errorf("privacy confirm: parse options: %w", err)
-	}
-	if opts.GlobalAnnounceEnabled || opts.LocalAnnounceEnabled ||
-		opts.RelaysEnabled || opts.NATEnabled {
-		stopSyncthingFailSafe()
-		return fmt.Errorf(
-			"privacy confirm FAILED: running daemon reports "+
-				"announce/relay enabled (global=%t local=%t "+
-				"relays=%t nat=%t) — Syncthing stopped",
-			opts.GlobalAnnounceEnabled, opts.LocalAnnounceEnabled,
-			opts.RelaysEnabled, opts.NATEnabled)
+		return failSyncthingPrivacy(fmt.Errorf("privacy confirmation failed: %w", err))
 	}
 	logger.Install("Syncthing privacy confirmed on running daemon")
 	return nil
@@ -557,12 +530,12 @@ func registerBackupFolder() error {
 	if err != nil {
 		return fmt.Errorf("get API key: %w", err)
 	}
+	client := syncthing.NewClient(apiKey)
 
 	// Check for the exact folder ID. Searching the raw JSON for
 	// a substring can confuse an unrelated label or longer ID
 	// for the required folder.
-	existing, err := syncthingAPIGet(apiKey,
-		"/rest/config/folders")
+	existing, err := client.Request(context.Background(), http.MethodGet, "/rest/config/folders", "")
 	if err != nil {
 		return fmt.Errorf("list folders: %w", err)
 	}
@@ -575,15 +548,14 @@ func registerBackupFolder() error {
 	}
 
 	// Get local device ID to include in folder config
-	localID := GetSyncthingDeviceID()
+	localID := host.SyncthingDeviceID()
 	if localID == "" {
 		return fmt.Errorf("cannot determine local device ID")
 	}
 
 	folder := renderBackupFolderConfig(localID)
 
-	if err := syncthingAPIPost(apiKey,
-		"/rest/config/folders", folder); err != nil {
+	if _, err := client.Request(context.Background(), http.MethodPost, "/rest/config/folders", folder); err != nil {
 		return fmt.Errorf("register folder: %w", err)
 	}
 
@@ -620,159 +592,9 @@ func backupFolderRegistered(foldersJSON string) (bool, error) {
 	return false, nil
 }
 
-// ── Syncthing Device Pairing ─────────────────────────────
-
-type SyncthingDevice struct {
-	Name     string
-	DeviceID string
-}
-
-// ListSyncthingDevices reads the daemon's effective device list at screen
-// cadence. It excludes this node's own identity and returns the current names,
-// including changes made through Syncthing's Web UI.
-func ListSyncthingDevices() ([]SyncthingDevice, error) {
-	apiKey, err := getSyncthingAPIKey()
-	if err != nil {
-		return nil, fmt.Errorf("get API key: %w", err)
-	}
-	raw, err := syncthingAPIGet(apiKey, "/rest/config/devices")
-	if err != nil {
-		return nil, err
-	}
-	localID := GetSyncthingDeviceID()
-	if localID == "" {
-		return nil, fmt.Errorf("local Syncthing device ID unavailable")
-	}
-	return parseSyncthingDevices([]byte(raw), localID)
-}
-
-func parseSyncthingDevices(
-	raw []byte, localID string,
-) ([]SyncthingDevice, error) {
-	seen := make(map[string]bool)
-	var entries []struct {
-		DeviceID string `json:"deviceID"`
-		Name     string `json:"name"`
-	}
-	if err := json.Unmarshal(raw, &entries); err != nil {
-		return nil, fmt.Errorf("decode Syncthing devices: %w", err)
-	}
-	devices := make([]SyncthingDevice, 0, len(entries))
-	for _, entry := range entries {
-		id := strings.TrimSpace(entry.DeviceID)
-		if id == "" || id == localID || seen[id] {
-			continue
-		}
-		seen[id] = true
-		name := strings.TrimSpace(entry.Name)
-		if name == "" {
-			name = "Syncthing device"
-		}
-		devices = append(devices, SyncthingDevice{Name: name, DeviceID: id})
-	}
-	sort.Slice(devices, func(i, j int) bool {
-		if devices[i].Name == devices[j].Name {
-			return devices[i].DeviceID < devices[j].DeviceID
-		}
-		return devices[i].Name < devices[j].Name
-	})
-	return devices, nil
-}
-
-// GetSyncthingDeviceID returns this node's Syncthing device
-// ID. As root it parses Syncthing's config XML (works even
-// with the daemon stopped — the ID derives from the TLS cert);
-// unprivileged it asks the helper's read-node-addresses
-// operation, which performs that same root-side read at the
-// moment of the question. No copy is kept: the ID changes when
-// Syncthing's identity is regenerated (a reinstall, a manual
-// key deletion), a stale copy would fail silently — the remote
-// device just never pairs — and screens need it only at human
-// cadence.
-func GetSyncthingDeviceID() string {
-	if os.Geteuid() != 0 {
-		var res helper.NodeAddressesResult
-		if err := helper.Call(
-			helper.VerbReadNodeAddresses, nil, &res); err != nil {
-			logger.Status("syncthing device ID: %v", err)
-			return ""
-		}
-		return res.SyncthingDeviceID
-	}
-
-	output, err := os.ReadFile(paths.SyncthingConfigXML)
-	if err != nil {
-		return ""
-	}
-
-	type device struct {
-		ID   string `xml:"id,attr"`
-		Name string `xml:"name,attr"`
-	}
-	type syncCfg struct {
-		XMLName xml.Name `xml:"configuration"`
-		Devices []device `xml:"device"`
-	}
-
-	var c syncCfg
-	if xml.Unmarshal(output, &c) != nil {
-		return ""
-	}
-
-	if len(c.Devices) > 0 {
-		return c.Devices[0].ID
-	}
-	return ""
-}
-
-// PairSyncthingDevice adds a remote device to Syncthing and
-// shares the lnd-backup folder with it via the REST API.
-func PairSyncthingDevice(deviceID string) error {
-	apiKey, err := getSyncthingAPIKey()
-	if err != nil {
-		return fmt.Errorf("get API key: %w", err)
-	}
-
-	// Add the device
-	devicePayload := fmt.Sprintf(`{
-        "deviceID": %q,
-        "name": "local-backup",
-        "addresses": ["dynamic"],
-        "autoAcceptFolders": false
-    }`, deviceID)
-
-	if err := syncthingAPIPost(apiKey,
-		"/rest/config/devices", devicePayload); err != nil {
-		return fmt.Errorf("add device: %w", err)
-	}
-
-	// Share the backup folder with the new device
-	folderConfig, err := syncthingAPIGet(apiKey,
-		"/rest/config/folders")
-	if err != nil {
-		return fmt.Errorf("get folders: %w", err)
-	}
-
-	if err := addDeviceToBackupFolder(apiKey,
-		folderConfig, deviceID); err != nil {
-		return fmt.Errorf("share folder: %w", err)
-	}
-
-	logger.Install("Paired Syncthing device: %s...",
-		deviceID[:min(16, len(deviceID))])
-	return nil
-}
-
-// getSyncthingAPIKey returns the REST API key. As root it
-// parses Syncthing's config; unprivileged it reads the staged
-// board copy — which is what makes every runtime device
-// operation (pair, unpair, folder share) plain localhost REST
-// with no privilege involved.
+// getSyncthingAPIKey reads the private configuration for root-side provisioning.
+// Runtime workflows read their staged credentials in the application layer.
 func getSyncthingAPIKey() (string, error) {
-	if os.Geteuid() != 0 {
-		return helper.ReadBoardString(paths.StateSyncthingAPIKey)
-	}
-
 	output, err := os.ReadFile(paths.SyncthingConfigXML)
 	if err != nil {
 		return "", err
@@ -793,173 +615,4 @@ func getSyncthingAPIKey() (string, error) {
 		return "", fmt.Errorf("no API key found")
 	}
 	return cfg.GUI.APIKey, nil
-}
-
-// ── REST transport (fail-noisy) ──────────────────────────
-//
-// Every Syncthing REST call goes through syncthingAPI, which
-// FAILS on any HTTP error status. This is load-bearing: the
-// previous transport shelled out to curl -s, which exits 0 on
-// a 403, and these calls once reported success while the
-// daemon had rejected the request — a pairing "done" that had
-// paired nothing, which for the channel-backup folder means
-// the off-box copy the operator is counting on never starts
-// replicating. A silent false success here is forbidden.
-//
-// The transport is Go's standard HTTP client, not a curl
-// subprocess: the status code arrives as an integer with
-// nothing to parse out of shell output, and this path stops
-// depending on an image-supplied binary nothing of ours
-// installs. Same client choice as the LND readiness probe
-// (waitForLND).
-
-// syncthingGUIBase is the daemon's loopback GUI/REST address.
-// A variable so the transport tests can point it at a local
-// test server.
-var syncthingGUIBase = "http://127.0.0.1:8384"
-
-// syncthingAPI performs one REST call against the local
-// Syncthing daemon and returns the response body. Any non-2xx
-// answer is an error naming the refused call.
-func syncthingAPI(
-	method, apiKey, endpoint, body string,
-) (string, error) {
-	fail := func(err error) (string, error) {
-		return "", fmt.Errorf(
-			"syncthing API %s %s: %w", method, endpoint, err)
-	}
-	var reqBody io.Reader
-	if body != "" {
-		reqBody = strings.NewReader(body)
-	}
-	req, err := http.NewRequest(method,
-		syncthingGUIBase+endpoint, reqBody)
-	if err != nil {
-		return fail(err)
-	}
-	if apiKey != "" {
-		req.Header.Set("X-API-Key", apiKey)
-	}
-	if body != "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fail(err)
-	}
-	defer resp.Body.Close()
-	// The bound exists so a defect cannot balloon memory; real
-	// answers are far smaller.
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
-	if err != nil {
-		return fail(fmt.Errorf("read response: %w", err))
-	}
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		hint := ""
-		if resp.StatusCode == http.StatusForbidden {
-			hint = " — the daemon rejected the API key this " +
-				"node staged; reinstalling Syncthing from " +
-				"the Add-On section refreshes it"
-		}
-		return "", fmt.Errorf(
-			"syncthing API %s %s failed: HTTP %d%s",
-			method, endpoint, resp.StatusCode, hint)
-	}
-	return string(data), nil
-}
-
-func syncthingAPIPost(apiKey, endpoint, body string) error {
-	_, err := syncthingAPI("POST", apiKey, endpoint, body)
-	return err
-}
-
-func syncthingAPIPatch(apiKey, endpoint, body string) error {
-	_, err := syncthingAPI("PATCH", apiKey, endpoint, body)
-	return err
-}
-
-func syncthingAPIDelete(apiKey, endpoint string) error {
-	_, err := syncthingAPI("DELETE", apiKey, endpoint, "")
-	return err
-}
-
-// UnpairSyncthingDevice removes a device from Syncthing
-// via the REST API. The folder sharing is dropped
-// automatically when the device is removed.
-func UnpairSyncthingDevice(deviceID string) error {
-	apiKey, err := getSyncthingAPIKey()
-	if err != nil {
-		return fmt.Errorf("get API key: %w", err)
-	}
-
-	if err := syncthingAPIDelete(apiKey,
-		"/rest/config/devices/"+deviceID); err != nil {
-		return fmt.Errorf("remove device: %w", err)
-	}
-
-	logger.Install("Removed Syncthing device: %s...",
-		deviceID[:min(16, len(deviceID))])
-	return nil
-}
-
-func syncthingAPIGet(apiKey, endpoint string) (string, error) {
-	return syncthingAPI("GET", apiKey, endpoint, "")
-}
-
-func addDeviceToBackupFolder(
-	apiKey, foldersJSON, deviceID string,
-) error {
-	type folderDevice struct {
-		DeviceID     string `json:"deviceID"`
-		IntroducedBy string `json:"introducedBy,omitempty"`
-	}
-	type folder struct {
-		ID      string         `json:"id"`
-		Path    string         `json:"path"`
-		Devices []folderDevice `json:"devices"`
-	}
-
-	var folders []folder
-	if err := json.Unmarshal(
-		[]byte(foldersJSON), &folders); err != nil {
-		return err
-	}
-
-	for i, f := range folders {
-		if f.Path == paths.LNDBackupExport ||
-			f.Path == paths.LNDBackupExport+"/" {
-			// Check if device already added
-			for _, d := range f.Devices {
-				if d.DeviceID == deviceID {
-					return nil
-				}
-			}
-			folders[i].Devices = append(
-				folders[i].Devices,
-				folderDevice{DeviceID: deviceID},
-			)
-
-			// PATCH only the devices array. The previous PUT sent
-			// a 3-field object (id/path/devices) with no "type" —
-			// Syncthing's PUT replaces the WHOLE folder, so
-			// type:"sendonly" reverted to "sendreceive" on every
-			// pairing (finding P, reproduced live).
-			//
-			// WARNING: PATCH replaces child arrays WHOLESALE (v2
-			// Config Endpoints docs) — this MUST send the complete
-			// merged devices array (existing + new), never a
-			// single-element array, or the local device is wiped
-			// and the folder de-shared.
-			devices, err := json.Marshal(folders[i].Devices)
-			if err != nil {
-				return err
-			}
-			return syncthingAPIPatch(apiKey,
-				"/rest/config/folders/"+f.ID,
-				`{"devices":`+string(devices)+`}`)
-		}
-	}
-
-	return fmt.Errorf("backup folder not found")
 }

--- a/internal/installer/syncthing_test.go
+++ b/internal/installer/syncthing_test.go
@@ -4,107 +4,14 @@ package installer
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
-	"net/http/httptest"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/virtualprivatenode/vpn/internal/config"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 )
-
-// The Syncthing REST transport must fail on HTTP errors: the
-// old curl transport exited 0 on a 403, which once reported a
-// pairing as done when the daemon had rejected the API key.
-// These tests run the real transport against a local test
-// server and pin both directions: success passes the body
-// through, and every error status is a named error.
-func TestSyncthingAPI(t *testing.T) {
-	var gotMethod, gotKey, gotType, gotBody string
-	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			gotMethod = r.Method
-			gotKey = r.Header.Get("X-API-Key")
-			gotType = r.Header.Get("Content-Type")
-			b, _ := io.ReadAll(r.Body)
-			gotBody = string(b)
-			switch r.URL.Path {
-			case "/ok":
-				w.Write([]byte(`{"ok":true}`))
-			case "/empty":
-				w.WriteHeader(http.StatusNoContent)
-			case "/forbidden":
-				w.WriteHeader(http.StatusForbidden)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-	defer srv.Close()
-	old := syncthingGUIBase
-	syncthingGUIBase = srv.URL
-	defer func() { syncthingGUIBase = old }()
-
-	// Success: body through, headers set, request body sent.
-	body, err := syncthingAPI("POST", "key123", "/ok", `{"a":1}`)
-	if err != nil {
-		t.Fatalf("POST /ok: %v", err)
-	}
-	if body != `{"ok":true}` {
-		t.Errorf("POST /ok body: got %q", body)
-	}
-	if gotMethod != "POST" || gotKey != "key123" ||
-		gotType != "application/json" || gotBody != `{"a":1}` {
-		t.Errorf("request not as sent: method=%q key=%q type=%q body=%q",
-			gotMethod, gotKey, gotType, gotBody)
-	}
-
-	// A bodyless 2xx (some DELETE/POST answers) is success.
-	if _, err := syncthingAPI(
-		"DELETE", "key123", "/empty", ""); err != nil {
-		t.Errorf("DELETE /empty: %v", err)
-	}
-	if gotBody != "" || gotType != "" {
-		t.Errorf("empty-body request carried body=%q type=%q",
-			gotBody, gotType)
-	}
-
-	// The load-bearing case: an HTTP error IS an error, and a
-	// 403 names the API-key remedy.
-	_, err = syncthingAPI("GET", "stale-key", "/forbidden", "")
-	if err == nil {
-		t.Fatal("403 answer reported as success")
-	}
-	if !strings.Contains(err.Error(), "HTTP 403") ||
-		!strings.Contains(err.Error(), "API key") {
-		t.Errorf("403 error lacks status or hint: %v", err)
-	}
-
-	// Any other error status also fails, naming the call.
-	_, err = syncthingAPI("GET", "key123", "/missing", "")
-	if err == nil {
-		t.Fatal("404 answer reported as success")
-	}
-	if !strings.Contains(err.Error(), "HTTP 404") ||
-		!strings.Contains(err.Error(), "GET /missing") {
-		t.Errorf("404 error lacks status or call name: %v", err)
-	}
-}
-
-// A daemon that is not there is a transport error, not a
-// silent success.
-func TestSyncthingAPIDaemonDown(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {}))
-	srv.Close() // deliberately: the address now refuses
-	old := syncthingGUIBase
-	syncthingGUIBase = srv.URL
-	defer func() { syncthingGUIBase = old }()
-
-	if _, err := syncthingAPI("GET", "k", "/ok", ""); err == nil {
-		t.Error("unreachable daemon reported as success")
-	}
-}
 
 func TestSyncthingServiceIdentityBoundary(t *testing.T) {
 	unit := syncthingServiceUnit()
@@ -281,5 +188,33 @@ func TestBackupFolderConfigUsesReadOnlyProjectExport(t *testing.T) {
 	if strings.HasPrefix(folder.Path, paths.SyncthingDataDir+"/") {
 		t.Errorf("folder path %q is below Syncthing private state",
 			folder.Path)
+	}
+}
+
+func TestSyncthingFailSafeAttemptsStopAndDisableAndReportsFailure(t *testing.T) {
+	original := syncthingServiceCommand
+	t.Cleanup(func() { syncthingServiceCommand = original })
+	for _, failAt := range []string{"stop", "disable", ""} {
+		var actions []string
+		syncthingServiceCommand = func(name string, args ...string) error {
+			if name != "systemctl" || len(args) != 2 || args[1] != "syncthing" {
+				t.Fatalf("unexpected service operation %s %v", name, args)
+			}
+			actions = append(actions, args[0])
+			if args[0] == failAt {
+				return fmt.Errorf("injected %s failure", failAt)
+			}
+			return nil
+		}
+		err := failSyncthingPrivacy(errors.New("privacy mismatch"))
+		if strings.Join(actions, ",") != "stop,disable" {
+			t.Fatal("stop failure prevented disable attempt")
+		}
+		if failAt != "" && !strings.Contains(err.Error(), "administrator action is required") {
+			t.Fatal("stop/disable failure reported as safely stopped:", err)
+		}
+		if failAt == "" && !strings.Contains(err.Error(), "stopped and disabled") {
+			t.Fatal("successful fail-safe omitted:", err)
+		}
 	}
 }

--- a/internal/syncthing/client.go
+++ b/internal/syncthing/client.go
@@ -1,0 +1,189 @@
+// Package syncthing owns loopback access to the pinned Syncthing daemon.
+package syncthing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+	"golang.org/x/sys/unix"
+)
+
+const GUIBase = "http://127.0.0.1:8384"
+const responseLimit = 10 << 20
+
+// Client is immutable after construction and may serve concurrent reads.
+// Credentials are supplied by the caller's existing privilege boundary.
+type Client struct {
+	base string
+	key  string
+	http *http.Client
+}
+
+func NewClient(key string) *Client { return newClient(GUIBase, key) }
+func newClient(base, key string) *Client {
+	return &Client{base: base, key: key, http: &http.Client{
+		Timeout:       10 * time.Second,
+		Transport:     &http.Transport{Proxy: nil, DisableKeepAlives: true, ResponseHeaderTimeout: 10 * time.Second},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}}
+}
+
+// Request never follows redirects or consults proxy environment variables.
+// Error bodies are discarded because they may contain configuration secrets.
+func (c *Client) Request(ctx context.Context, method, endpoint, body string) (string, error) {
+	route, _, _ := strings.Cut(endpoint, "?")
+	fail := func(err error) (string, error) { return "", fmt.Errorf("syncthing API %s %s: %w", method, route, err) }
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.base+endpoint, reader)
+	if err != nil {
+		return fail(err)
+	}
+	if c.key != "" {
+		req.Header.Set("X-API-Key", c.key)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fail(errors.New("local daemon request failed or timed out"))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		hint := ""
+		if resp.StatusCode == http.StatusForbidden {
+			hint = "; API key rejected, administrator inspection is required"
+		}
+		return fail(fmt.Errorf("HTTP %d%s", resp.StatusCode, hint))
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, responseLimit+1))
+	if err != nil {
+		return fail(errors.New("response could not be read"))
+	}
+	if len(data) > responseLimit {
+		return fail(errors.New("response exceeds size limit"))
+	}
+	return string(data), nil
+}
+
+func (c *Client) read(ctx context.Context, endpoint string, result any) error {
+	raw, err := c.Request(ctx, http.MethodGet, endpoint, "")
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal([]byte(raw), result); err != nil {
+		return errors.New("invalid Syncthing response")
+	}
+	return nil
+}
+
+// CanonicalID delegates checksum and protocol parsing to the pinned daemon.
+func (c *Client) CanonicalID(ctx context.Context, input string) (string, error) {
+	if strings.TrimSpace(input) == "" || len(input) > 128 {
+		return "", errors.New("enter a Syncthing device ID")
+	}
+	var result struct {
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}
+	if err := c.read(ctx, "/rest/svc/deviceid?id="+url.QueryEscape(input), &result); err != nil {
+		return "", err
+	}
+	if result.ID == "" || result.Error != "" {
+		return "", errors.New("invalid Syncthing device ID")
+	}
+	return result.ID, nil
+}
+
+func (c *Client) LocalID(ctx context.Context) (string, error) {
+	var result struct {
+		ID string `json:"myID"`
+	}
+	if err := c.read(ctx, "/rest/system/status", &result); err != nil {
+		return "", err
+	}
+	if result.ID == "" {
+		return "", errors.New("local Syncthing identity unavailable")
+	}
+	return result.ID, nil
+}
+
+type Device struct {
+	Name     string
+	DeviceID string
+}
+
+func (c *Client) ListDevices(ctx context.Context) ([]Device, error) {
+	local, err := c.LocalID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.Request(ctx, http.MethodGet, "/rest/config/devices", "")
+	if err != nil {
+		return nil, err
+	}
+	return parseDevices([]byte(raw), local)
+}
+
+func parseDevices(
+	raw []byte, localID string,
+) ([]Device, error) {
+	seen := make(map[string]bool)
+	var entries []struct {
+		DeviceID string `json:"deviceID"`
+		Name     string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("decode Syncthing devices: %w", err)
+	}
+	devices := make([]Device, 0, len(entries))
+	for _, entry := range entries {
+		id := strings.TrimSpace(entry.DeviceID)
+		if id == "" || id == localID || seen[id] {
+			continue
+		}
+		seen[id] = true
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			name = "Syncthing device"
+		}
+		devices = append(devices, Device{Name: name, DeviceID: id})
+	}
+	sort.Slice(devices, func(i, j int) bool {
+		if devices[i].Name == devices[j].Name {
+			return devices[i].DeviceID < devices[j].DeviceID
+		}
+		return devices[i].Name < devices[j].Name
+	})
+	return devices, nil
+}
+
+// WithMutationLock coordinates VPN processes using the stable root-owned board
+// directory. No credential file is locked or written. Contention refuses promptly.
+// External Web UI/API writers do not participate in this advisory lock.
+func WithMutationLock(action func() error) error { return withMutationLock(paths.StateDir, action) }
+func withMutationLock(dir string, action func() error) error {
+	f, err := os.OpenFile(dir, os.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open Syncthing operation lock: %w", err)
+	}
+	defer f.Close()
+	if err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		return errors.New("another VPN Syncthing operation is active or the lock is unavailable; retry after checking its result")
+	}
+	defer unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	return action()
+}

--- a/internal/syncthing/client_test.go
+++ b/internal/syncthing/client_test.go
@@ -1,0 +1,117 @@
+package syncthing
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// HTTP rejection must never become a successful device-management result.
+func TestSyncthingAPI(t *testing.T) {
+	var gotMethod, gotKey, gotType, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotKey = r.Header.Get("X-API-Key")
+			gotType = r.Header.Get("Content-Type")
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+			switch r.URL.Path {
+			case "/ok":
+				w.Write([]byte(`{"ok":true}`))
+			case "/empty":
+				w.WriteHeader(http.StatusNoContent)
+			case "/forbidden":
+				w.WriteHeader(http.StatusForbidden)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+	defer srv.Close()
+	client := newClient(srv.URL, "key123")
+
+	// Success: body through, headers set, request body sent.
+	body, err := client.Request(context.Background(), "POST", "/ok", `{"a":1}`)
+	if err != nil {
+		t.Fatalf("POST /ok: %v", err)
+	}
+	if body != `{"ok":true}` {
+		t.Errorf("POST /ok body: got %q", body)
+	}
+	if gotMethod != "POST" || gotKey != "key123" ||
+		gotType != "application/json" || gotBody != `{"a":1}` {
+		t.Errorf("request not as sent: method=%q key=%q type=%q body=%q",
+			gotMethod, gotKey, gotType, gotBody)
+	}
+
+	// A bodyless 2xx (some DELETE/POST answers) is success.
+	if _, err := client.Request(context.Background(),
+		"DELETE", "/empty", ""); err != nil {
+		t.Errorf("DELETE /empty: %v", err)
+	}
+	if gotBody != "" || gotType != "" {
+		t.Errorf("empty-body request carried body=%q type=%q",
+			gotBody, gotType)
+	}
+
+	// The load-bearing case: an HTTP error IS an error, and a
+	// 403 names the API-key remedy.
+	_, err = client.Request(context.Background(), "GET", "/forbidden", "")
+	if err == nil {
+		t.Fatal("403 answer reported as success")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") ||
+		!strings.Contains(err.Error(), "API key") {
+		t.Errorf("403 error lacks status or hint: %v", err)
+	}
+
+	// Any other error status also fails, naming the call.
+	_, err = client.Request(context.Background(), "GET", "/missing", "")
+	if err == nil {
+		t.Fatal("404 answer reported as success")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") ||
+		!strings.Contains(err.Error(), "GET /missing") {
+		t.Errorf("404 error lacks status or call name: %v", err)
+	}
+}
+
+// A daemon that is not there is a transport error, not a
+// silent success.
+func TestSyncthingAPIDaemonDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // deliberately: the address now refuses
+	client := newClient(srv.URL, "key123")
+
+	if _, err := client.Request(context.Background(), "GET", "/ok", ""); err == nil {
+		t.Error("unreachable daemon reported as success")
+	}
+}
+
+func TestParseSyncthingDevicesUsesCurrentDaemonFacts(t *testing.T) {
+	raw := []byte(`[
+  {"deviceID":"LOCAL","name":"this node"},
+  {"deviceID":"B","name":" Laptop "},
+  {"deviceID":"A","name":""},
+  {"deviceID":"B","name":"stale duplicate"},
+  {"deviceID":" ","name":"invalid"}
+]`)
+	devices, err := parseDevices(raw, "LOCAL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("devices = %+v", devices)
+	}
+	if devices[0].DeviceID != "B" || devices[0].Name != "Laptop" ||
+		devices[1].DeviceID != "A" || devices[1].Name != "Syncthing device" {
+		t.Fatalf("unexpected current device view: %+v", devices)
+	}
+	if _, err := parseDevices([]byte(`{}`), "LOCAL"); err == nil {
+		t.Fatal("malformed device list accepted")
+	}
+}

--- a/internal/syncthing/config.go
+++ b/internal/syncthing/config.go
@@ -1,0 +1,121 @@
+package syncthing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+// ConfirmPrivacy requires explicit fields; missing values are not evidence of
+// disabled discovery or reporting. It observes configuration without repairing it.
+func (c *Client) ConfirmPrivacy(ctx context.Context) error {
+	var opts map[string]json.RawMessage
+	if err := c.read(ctx, "/rest/config/options", &opts); err != nil {
+		return err
+	}
+	for _, key := range []string{"globalAnnounceEnabled", "localAnnounceEnabled", "relaysEnabled", "natEnabled", "announceLANAddresses", "crashReportingEnabled"} {
+		var value *bool
+		if json.Unmarshal(opts[key], &value) != nil || value == nil || *value {
+			return fmt.Errorf("syncthing privacy setting %s is missing or enabled", key)
+		}
+	}
+	for key, want := range map[string]int{"autoUpgradeIntervalH": 0, "urAccepted": -1} {
+		var value *int
+		if json.Unmarshal(opts[key], &value) != nil || value == nil || *value != want {
+			return fmt.Errorf("syncthing privacy setting %s is missing or changed", key)
+		}
+	}
+	var addresses []string
+	if json.Unmarshal(opts["listenAddresses"], &addresses) != nil || len(addresses) != 1 || addresses[0] != "tcp://0.0.0.0:22000" {
+		return errors.New("syncthing sync listener is not the expected direct TCP listener")
+	}
+	var gui struct {
+		Address  string `json:"address"`
+		Enabled  *bool  `json:"enabled"`
+		TLS      *bool  `json:"useTLS"`
+		User     string `json:"user"`
+		Password string `json:"password"`
+		Metrics  *bool  `json:"metricsWithoutAuth"`
+	}
+	if err := c.read(ctx, "/rest/config/gui", &gui); err != nil {
+		return err
+	}
+	if gui.Address != "127.0.0.1:8384" || gui.Enabled == nil || !*gui.Enabled || gui.TLS == nil || *gui.TLS || gui.User == "" || gui.Password == "" || gui.Metrics == nil || *gui.Metrics {
+		return errors.New("syncthing Web UI privacy/authentication configuration has changed")
+	}
+	return nil
+}
+
+// BackupFolder keeps unmodeled per-device fields intact when PATCH replaces the
+// devices array. In particular, encryption passwords and introduction metadata
+// must survive pairing another receiver.
+type BackupFolder struct {
+	ID      string            `json:"id"`
+	Path    string            `json:"path"`
+	Type    string            `json:"type"`
+	Marker  string            `json:"markerName"`
+	Devices []json.RawMessage `json:"devices"`
+}
+
+func (f BackupFolder) HasDevice(id string) bool {
+	for _, raw := range f.Devices {
+		var d struct {
+			ID string `json:"deviceID"`
+		}
+		if json.Unmarshal(raw, &d) == nil && d.ID == id {
+			return true
+		}
+	}
+	return false
+}
+func (c *Client) BackupFolder(ctx context.Context, localID string) (BackupFolder, error) {
+	var f BackupFolder
+	if err := c.read(ctx, "/rest/config/folders/lnd-backup", &f); err != nil {
+		return f, err
+	}
+	if f.ID != "lnd-backup" || filepath.Clean(f.Path) != paths.LNDBackupExport || f.Type != "sendonly" || f.Marker != paths.ExportReadyMarkerName || !f.HasDevice(localID) {
+		return f, errors.New("backup folder boundary differs from the expected send-only export; administrator inspection is required")
+	}
+	for _, raw := range f.Devices {
+		var d struct {
+			ID string `json:"deviceID"`
+		}
+		if json.Unmarshal(raw, &d) != nil || d.ID == "" {
+			return f, errors.New("invalid backup folder device entry")
+		}
+	}
+	return f, nil
+}
+func (c *Client) ShareBackup(ctx context.Context, f BackupFolder, id string) error {
+	if f.HasDevice(id) {
+		return nil
+	}
+	raw, _ := json.Marshal(struct {
+		ID string `json:"deviceID"`
+	}{id})
+	devices := append(append([]json.RawMessage(nil), f.Devices...), raw)
+	body, err := json.Marshal(struct {
+		Devices []json.RawMessage `json:"devices"`
+	}{devices})
+	if err != nil {
+		return err
+	}
+	_, err = c.Request(ctx, http.MethodPatch, "/rest/config/folders/lnd-backup", string(body))
+	return err
+}
+func (c *Client) AddDevice(ctx context.Context, id string) error {
+	// Explicitly disable trust-expanding defaults even if Web UI defaults changed.
+	body, _ := json.Marshal(map[string]any{"deviceID": id, "name": "local-backup", "addresses": []string{"dynamic"}, "autoAcceptFolders": false, "introducer": false, "skipIntroductionRemovals": false, "introducedBy": ""})
+	_, err := c.Request(ctx, http.MethodPost, "/rest/config/devices", string(body))
+	return err
+}
+func (c *Client) RemoveDevice(ctx context.Context, id string) error {
+	_, err := c.Request(ctx, http.MethodDelete, "/rest/config/devices/"+url.PathEscape(id), "")
+	return err
+}

--- a/internal/syncthing/config_test.go
+++ b/internal/syncthing/config_test.go
@@ -1,0 +1,227 @@
+package syncthing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/paths"
+)
+
+func privateOptions() map[string]any {
+	return map[string]any{
+		"globalAnnounceEnabled": false, "localAnnounceEnabled": false, "relaysEnabled": false, "natEnabled": false,
+		"announceLANAddresses": false, "crashReportingEnabled": false, "autoUpgradeIntervalH": 0, "urAccepted": -1,
+		"listenAddresses": []string{"tcp://0.0.0.0:22000"},
+	}
+}
+func privateGUI() map[string]any {
+	return map[string]any{"address": "127.0.0.1:8384", "enabled": true, "useTLS": false, "user": "admin", "password": "test-hash", "metricsWithoutAuth": false}
+}
+func TestPrivacyRejectsMissingAndChangedFields(t *testing.T) {
+	opts, gui := privateOptions(), privateGUI()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Error("privacy check mutated configuration")
+		}
+		if r.URL.Path == "/rest/config/options" {
+			json.NewEncoder(w).Encode(opts)
+		} else {
+			json.NewEncoder(w).Encode(gui)
+		}
+	}))
+	defer srv.Close()
+	c := newClient(srv.URL, "key")
+	if err := c.ConfirmPrivacy(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for name, fields := range map[string]map[string]any{"options": opts, "gui": gui} {
+		for key, original := range fields {
+			for _, mutation := range []string{"missing", "null", "wrong"} {
+				t.Run(name+"/"+key+"/"+mutation, func(t *testing.T) {
+					switch mutation {
+					case "missing":
+						delete(fields, key)
+					case "null":
+						fields[key] = nil
+					case "wrong":
+						switch v := original.(type) {
+						case bool:
+							fields[key] = !v
+						case int:
+							fields[key] = v + 1
+						case string:
+							fields[key] = ""
+						default:
+							fields[key] = []string{"default"}
+						}
+					}
+					if err := c.ConfirmPrivacy(context.Background()); err == nil {
+						t.Fatal("unsafe/missing privacy field accepted")
+					}
+					fields[key] = original
+				})
+			}
+		}
+	}
+}
+func TestSharePreservesCompleteEntriesAndOnlyPatchesDevices(t *testing.T) {
+	existing := json.RawMessage(`{"deviceID":"REMOTE","introducedBy":"INTRODUCER","encryptionPassword":"test-secret","future":{"keep":true}}`)
+	local := json.RawMessage(`{"deviceID":"LOCAL"}`)
+	var patched map[string]json.RawMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/config/folders/lnd-backup" {
+			t.Errorf("wrong folder: %s", r.URL.Path)
+		}
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode(BackupFolder{ID: "lnd-backup", Path: paths.LNDBackupExport, Type: "sendonly", Marker: paths.ExportReadyMarkerName, Devices: []json.RawMessage{local, existing}})
+			return
+		}
+		if r.Method != "PATCH" {
+			t.Errorf("method=%s", r.Method)
+		}
+		json.NewDecoder(r.Body).Decode(&patched)
+	}))
+	defer srv.Close()
+	c := newClient(srv.URL, "key")
+	folder, err := c.BackupFolder(context.Background(), "LOCAL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = c.ShareBackup(context.Background(), folder, "NEW"); err != nil {
+		t.Fatal(err)
+	}
+	if len(patched) != 1 {
+		t.Fatalf("patch changed other settings: %v", patched)
+	}
+	var entries []json.RawMessage
+	if err = json.Unmarshal(patched["devices"], &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("lost existing shares: %s", patched["devices"])
+	}
+	for i, expected := range []json.RawMessage{local, existing, json.RawMessage(`{"deviceID":"NEW"}`)} {
+		var want, got any
+		if err := json.Unmarshal(expected, &want); err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(entries[i], &got); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(want, got) {
+			t.Fatalf("share %d: got %s, want %s", i, entries[i], expected)
+		}
+	}
+	// An already shared device requires no replacement write.
+	patched = nil
+	if err = c.ShareBackup(context.Background(), folder, "REMOTE"); err != nil || patched != nil {
+		t.Fatalf("duplicate share writes configuration: %v", err)
+	}
+}
+func TestBackupBoundaryRejectsDrift(t *testing.T) {
+	f := BackupFolder{ID: "lnd-backup", Path: paths.LNDBackupExport, Type: "sendonly", Marker: paths.ExportReadyMarkerName, Devices: []json.RawMessage{json.RawMessage(`{"deviceID":"LOCAL"}`)}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { json.NewEncoder(w).Encode(f) }))
+	defer srv.Close()
+	c := newClient(srv.URL, "k")
+	for _, mutate := range []func(){func() { f.ID = "other" }, func() { f.Path = "/var/lib/lnd" }, func() { f.Type = "sendreceive" }, func() { f.Marker = ".stfolder" }, func() { f.Devices = nil }} {
+		original := f
+		mutate()
+		if _, err := c.BackupFolder(context.Background(), "LOCAL"); err == nil {
+			t.Fatal("unsafe backup folder accepted")
+		}
+		f = original
+	}
+}
+func TestTransportRefusesRedirectAndOversizedResponse(t *testing.T) {
+	leaked := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { leaked = true }))
+	defer target.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+			return
+		}
+		fmt.Fprint(w, strings.Repeat("x", responseLimit+1))
+	}))
+	defer srv.Close()
+	c := newClient(srv.URL, "secret")
+	for _, path := range []string{"/redirect", "/large"} {
+		if _, err := c.Request(context.Background(), "GET", path, ""); err == nil {
+			t.Fatalf("accepted %s", path)
+		}
+	}
+	if leaked {
+		t.Fatal("followed credential-bearing redirect")
+	}
+	if c.http.Transport.(*http.Transport).Proxy != nil {
+		t.Fatal("transport consults proxy settings")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Request(ctx, "POST", "/cancel", `{}`); err == nil {
+		t.Fatal("canceled request succeeded")
+	}
+}
+func TestMutationLockAcrossProcesses(t *testing.T) {
+	if dir := os.Getenv("VPN_SYNC_LOCK_TEST"); dir != "" {
+		called := false
+		err := withMutationLock(dir, func() error { called = true; return nil })
+		if err == nil || called {
+			t.Fatal("contending process entered mutation")
+		}
+		return
+	}
+	dir := t.TempDir()
+	err := withMutationLock(dir, func() error {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestMutationLockAcrossProcesses$")
+		cmd.Env = append(os.Environ(), "VPN_SYNC_LOCK_TEST="+dir)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("subprocess: %w: %s", err, output)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = withMutationLock(dir, func() error { return nil }); err != nil {
+		t.Fatal("lock not released:", err)
+	}
+}
+func TestIdentityUsesStatusAndDaemonParser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/system/status":
+			fmt.Fprint(w, `{"myID":"LOCAL"}`)
+		case "/rest/config/devices":
+			fmt.Fprint(w, `[{"deviceID":"AAA","name":"first"},{"deviceID":"LOCAL"}]`)
+		case "/rest/svc/deviceid":
+			if r.URL.Query().Get("id") == "invalid" {
+				fmt.Fprint(w, `{"error":"bad checksum"}`)
+			} else {
+				fmt.Fprint(w, `{"id":"CANONICAL"}`)
+			}
+		default:
+			t.Fatalf("unexpected call %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	c := newClient(srv.URL, "k")
+	devices, err := c.ListDevices(context.Background())
+	if err != nil || len(devices) != 1 || devices[0].DeviceID != "AAA" {
+		t.Fatalf("identity depends on order: %v %v", devices, err)
+	}
+	if id, err := c.CanonicalID(context.Background(), "input"); err != nil || id != "CANONICAL" {
+		t.Fatalf("canonical ID: %s %v", id, err)
+	}
+	if _, err := c.CanonicalID(context.Background(), "invalid"); err == nil {
+		t.Fatal("daemon checksum rejection ignored")
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -77,34 +77,27 @@ func fetchNodeAddressesCmd(tab tabKind) tea.Cmd {
 
 // ── Syncthing actions ────────────────────────────────────
 
-func fetchSyncthingDevicesCmd() tea.Cmd {
+func fetchSyncthingDevicesCmd(owner *ScreenContext) tea.Cmd {
+	owner.syncthingRevision++
+	revision := owner.syncthingRevision
+	runtime := owner.syncthing()
 	return func() tea.Msg {
-		devices, err := installer.ListSyncthingDevices()
-		if err != nil {
-			logger.Status("read Syncthing devices: %v", err)
-		}
-		return syncthingDevicesMsg{devices: devices, err: err}
+		devices, err := runtime.ListDevices()
+		return syncthingDevicesMsg{owner: owner, revision: revision, devices: devices, err: err}
 	}
 }
-
-func pairSyncthingDeviceCmd(
-	deviceID string,
-) tea.Cmd {
+func pairSyncthingDeviceCmd(owner *SyncthingPairScreen, deviceID string) tea.Cmd {
+	runtime, attempt := owner.ctx.syncthing(), owner.attempt
 	return func() tea.Msg {
-		err := installer.PairSyncthingDevice(deviceID)
-		return syncthingPairedMsg{
-			deviceID: deviceID, err: err}
+		return syncthingPairedMsg{owner: owner, attempt: attempt, result: runtime.Pair(deviceID)}
 	}
 }
-
-func removeSyncthingDeviceCmd(
-	deviceID string,
-) tea.Cmd {
-	return func() tea.Msg {
-		err := installer.UnpairSyncthingDevice(deviceID)
-		return syncthingRemovedMsg{
-			deviceID: deviceID, err: err}
-	}
+func removeSyncthingDeviceCmd(owner *SyncthingDeviceScreen) tea.Cmd {
+	runtime, attempt, id := owner.ctx.syncthing(), owner.attempt, owner.device.DeviceID
+	return func() tea.Msg { return syncthingRemovedMsg{owner: owner, attempt: attempt, result: runtime.Remove(id)} }
+}
+func closeSyncthingCmd(owner Screen, attempt uint64) tea.Cmd {
+	return func() tea.Msg { return syncthingCloseMsg{owner: owner, attempt: attempt} }
 }
 
 // ── LND queries & fund-moving ────────────────────────────

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/logger"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -128,16 +129,24 @@ type keyVerificationStateMsg struct {
 }
 
 type syncthingPairedMsg struct {
-	deviceID string
-	err      error
+	owner   *SyncthingPairScreen
+	attempt uint64
+	result  app.SyncthingResult
 }
 type syncthingRemovedMsg struct {
-	deviceID string
-	err      error
+	owner   *SyncthingDeviceScreen
+	attempt uint64
+	result  app.SyncthingResult
 }
 type syncthingDevicesMsg struct {
-	devices []installer.SyncthingDevice
-	err     error
+	owner    *ScreenContext
+	revision uint64
+	devices  []syncthing.Device
+	err      error
+}
+type syncthingCloseMsg struct {
+	owner   Screen
+	attempt uint64
 }
 type channelOpenResultMsg struct {
 	attempt *channelOpenAttempt
@@ -342,6 +351,7 @@ func NewModel(
 		nav: NewNavSidebar(),
 	}
 	m.screenCtx = &ScreenContext{
+		Syncthing:       app.NewSyncthing(),
 		HelperWorkflows: app.NewHelperWorkflows(installer.SyncthingVersionStr()),
 		Cfg:             cfg,
 		State:           state,
@@ -406,6 +416,7 @@ func Show(
 			m.screenCtx.WalletCreation.Close()
 		}
 		m.screenCtx.HelperWorkflows.Close()
+		m.screenCtx.Syncthing.Close()
 		if m.screenCtx.LndClient != nil {
 			m.screenCtx.LndClient.Close()
 		}
@@ -442,8 +453,9 @@ func observeRuntimeState(cfg *config.AppConfig) *RuntimeState {
 		state.SSHPasswordAuthKnown = true
 	}
 	if cfg.SyncthingEnabled {
-		state.SyncthingDevices, state.SyncthingDevicesErr =
-			installer.ListSyncthingDevices()
+		runtime := app.NewSyncthing()
+		state.SyncthingDevices, state.SyncthingDevicesErr = runtime.ListDevices()
+		runtime.Close()
 		state.SyncthingDevicesKnown = state.SyncthingDevicesErr == nil
 	}
 	return state

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/config"
-	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
 )
 
 // ── Screen interface ────────────────────────────────────
@@ -50,6 +50,8 @@ type Screen interface {
 // chain — zero refresh plumbing.
 
 type ScreenContext struct {
+	Syncthing           *app.Syncthing
+	syncthingRevision   uint64
 	WalletCreation      *app.WalletCreation
 	walletCreationOwner *WalletCreateScreen
 	walletRevision      uint64
@@ -65,6 +67,13 @@ type ScreenContext struct {
 	ContentFocused      bool   // true when content pane has focus (not tab bar, not sidebar)
 	Version             string // set once at construction
 	LatestVersion       string // updated by latestVersionMsg handler
+}
+
+func (c *ScreenContext) syncthing() *app.Syncthing {
+	if c.Syncthing == nil {
+		c.Syncthing = app.NewSyncthing()
+	}
+	return c.Syncthing
 }
 
 func (c *ScreenContext) walletCreation() *app.WalletCreation {
@@ -84,7 +93,7 @@ type RuntimeState struct {
 	KeyVerificationKnown    bool
 	SSHPasswordAuthDisabled bool
 	SSHPasswordAuthKnown    bool
-	SyncthingDevices        []installer.SyncthingDevice
+	SyncthingDevices        []syncthing.Device
 	SyncthingDevicesErr     error
 	SyncthingDevicesKnown   bool
 }

--- a/internal/tui/screen_addon_syncthing.go
+++ b/internal/tui/screen_addon_syncthing.go
@@ -38,7 +38,7 @@ func NewSyncthingDetailScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *SyncthingDetailScreen) Init() tea.Cmd {
-	return fetchSyncthingDevicesCmd()
+	return fetchSyncthingDevicesCmd(s.ctx)
 }
 
 func (s *SyncthingDetailScreen) HandleKey(
@@ -140,20 +140,19 @@ func (s *SyncthingDetailScreen) handleEnter() (
 
 	// Device list — open device detail
 	devices := s.ctx.State.SyncthingDevices
-	if s.cursor < len(devices) {
+	if s.ctx.State.SyncthingDevicesKnown && s.cursor >= 0 && s.cursor < len(devices) {
 		dev := devices[s.cursor]
 		label := dev.Name
 		if len(label) > 17 {
 			label = label[:17] + "..."
 		}
 		screen := NewSyncthingDeviceScreen(
-			s.ctx, dev, s.cursor)
-		idx := s.cursor
+			s.ctx, dev)
 		return s, func() tea.Msg {
 			return openTabMsg{
 				Kind:   tabSyncthingDevice,
 				Label:  label,
-				Index:  idx,
+				Key:    dev.DeviceID,
 				Screen: screen,
 				Parent: tabSyncthing,
 			}
@@ -165,8 +164,25 @@ func (s *SyncthingDetailScreen) handleEnter() (
 func (s *SyncthingDetailScreen) HandleMsg(
 	msg tea.Msg,
 ) (Screen, tea.Cmd) {
+	if refreshed, ok := msg.(syncthingDevicesMsg); ok {
+		if s.focusZone == syncDetailZoneList {
+			previous := s.ctx.State.SyncthingDevices
+			id := ""
+			if s.cursor >= 0 && s.cursor < len(previous) {
+				id = previous[s.cursor].DeviceID
+			}
+			for i, d := range refreshed.devices {
+				if refreshed.err == nil && d.DeviceID == id {
+					s.cursor = i
+					return s, nil
+				}
+			}
+			s.focusZone = syncDetailZoneButtons
+			s.cursor = 0
+		}
+	}
 	if _, ok := msg.(tabActivatedMsg); ok {
-		return s, fetchSyncthingDevicesCmd()
+		return s, fetchSyncthingDevicesCmd(s.ctx)
 	}
 	return s, nil
 }
@@ -214,7 +230,7 @@ func (s *SyncthingDetailScreen) View(
 				"Cannot read the current device list"))
 		midLines = append(midLines,
 			" "+theme.Dim.Render(
-				"Check: journalctl -u vpn-helperd"))
+				"Reopen this tab to refresh; inspect Syncthing if it persists."))
 	} else if pairedCount == 0 {
 		midLines = append(midLines,
 			" "+theme.Dim.Render(

--- a/internal/tui/screen_addon_syncthing_device.go
+++ b/internal/tui/screen_addon_syncthing_device.go
@@ -4,7 +4,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -17,27 +18,27 @@ type syncDeviceStep int
 const (
 	syncDeviceStepDetail syncDeviceStep = iota
 	syncDeviceStepConfirm
+	syncDeviceStepRemoving
+	syncDeviceStepRemoved
 )
 
 type SyncthingDeviceScreen struct {
 	ctx         *ScreenContext
 	step        syncDeviceStep
-	device      installer.SyncthingDevice // live-read snapshot
-	deviceIndex int                       // index in displayed list
-	viewBtnIdx  int                       // 0=Cancel, 1=Remove
-	confirmIdx  int                       // 0=Go Back, 1=Remove
+	device      syncthing.Device // live-read snapshot
+	attempt     uint64
+	viewBtnIdx  int // 0=Cancel, 1=Remove
+	confirmIdx  int // 0=Go Back, 1=Remove
 	removeError string
 }
 
 func NewSyncthingDeviceScreen(
 	ctx *ScreenContext,
-	device installer.SyncthingDevice,
-	index int,
+	device syncthing.Device,
 ) *SyncthingDeviceScreen {
 	return &SyncthingDeviceScreen{
-		ctx:         ctx,
-		device:      device,
-		deviceIndex: index,
+		ctx:    ctx,
+		device: device,
 	}
 }
 
@@ -51,6 +52,28 @@ func (s *SyncthingDeviceScreen) HandleKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
 	switch s.step {
+	case syncDeviceStepRemoving:
+		if keyStr == "ctrl+c" {
+			return s, tea.Quit
+		}
+		if keyStr == "left" {
+			return s, emitFocusSidebar
+		}
+		if keyStr == "up" || keyStr == "shift+tab" {
+			return s, emitFocusTabBar
+		}
+		return s, nil
+	case syncDeviceStepRemoved:
+		if keyStr == "enter" {
+			return s, closeSyncthingCmd(s, s.attempt)
+		}
+		if keyStr == "ctrl+c" {
+			return s, tea.Quit
+		}
+		if keyStr == "left" {
+			return s, emitFocusSidebar
+		}
+		return s, nil
 	case syncDeviceStepDetail:
 		return s.handleDetailKey(keyStr)
 	case syncDeviceStepConfirm:
@@ -64,13 +87,20 @@ func (s *SyncthingDeviceScreen) HandleMsg(
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
 	case syncthingRemovedMsg:
-		if msg.err != nil {
-			s.removeError = msg.err.Error()
+		if msg.owner != s || msg.attempt != s.attempt || s.step != syncDeviceStepRemoving {
+			return s, nil
+		}
+		if msg.result.Outcome != app.SyncthingComplete {
+			s.removeError = "Removal was not completed."
+			if msg.result.Err != nil {
+				s.removeError = msg.result.Err.Error()
+			}
 			s.step = syncDeviceStepDetail
 			return s, nil
 		}
-		// Success — close tab; the model refreshes the live list.
-		return s, emitCloseTab
+		s.step = syncDeviceStepRemoved
+		s.removeError = ""
+
 	}
 	return s, nil
 }
@@ -79,6 +109,15 @@ func (s *SyncthingDeviceScreen) View(
 	w, h int,
 ) string {
 	switch s.step {
+	case syncDeviceStepRemoving, syncDeviceStepRemoved:
+		p := newPane(w)
+		title, button := "Removing Device...", "Removing..."
+		if s.step == syncDeviceStepRemoved {
+			title, button = "Device Removed", "Done"
+		}
+		p.title(theme.Header, title)
+		p.monoWrap(s.device.DeviceID)
+		return p.renderWithBottomButtons([]string{button}, 0, s.ctx.ContentFocused && s.step == syncDeviceStepRemoved, h)
 	case syncDeviceStepDetail:
 		return s.viewDetail(w, h)
 	case syncDeviceStepConfirm:
@@ -89,6 +128,10 @@ func (s *SyncthingDeviceScreen) View(
 
 func (s *SyncthingDeviceScreen) HelpBindings() []key.Binding {
 	switch s.step {
+	case syncDeviceStepRemoving:
+		return []key.Binding{kSidebar, kShiftTabBar, kQuit}
+	case syncDeviceStepRemoved:
+		return tabButtonBindings(s.ctx.HasTabs)
 	case syncDeviceStepDetail:
 		return detailActionBindings(
 			"remove", s.viewBtnIdx, s.ctx.HasTabs)
@@ -130,7 +173,7 @@ func (s *SyncthingDeviceScreen) handleDetailKey(
 		return s, emitFocusParent
 	case "enter":
 		if s.viewBtnIdx == 0 {
-			return s, emitCloseTab
+			return s, closeSyncthingCmd(s, s.attempt)
 		}
 		s.step = syncDeviceStepConfirm
 		s.confirmIdx = 0
@@ -148,12 +191,10 @@ func (s *SyncthingDeviceScreen) viewDetail(
 	p.title(theme.Header, dev.Name)
 
 	p.labelLine("Device ID:")
-	id := dev.DeviceID
-	if len(id) > w-4 {
-		id = id[:w-7] + "..."
+	p.monoWrap(dev.DeviceID)
+	if s.removeError != "" {
+		p.warnWrapWords(s.removeError)
 	}
-	p.mono(id)
-	p.appendError(s.removeError)
 
 	return p.renderWithBottomButtons(
 		[]string{"Cancel", "Remove"}, s.viewBtnIdx,
@@ -195,8 +236,9 @@ func (s *SyncthingDeviceScreen) handleConfirmKey(
 			s.step = syncDeviceStepDetail
 			return s, nil
 		case 1: // Remove
-			return s, removeSyncthingDeviceCmd(
-				s.device.DeviceID)
+			s.attempt++
+			s.step = syncDeviceStepRemoving
+			return s, removeSyncthingDeviceCmd(s)
 		}
 	}
 	return s, nil
@@ -208,6 +250,7 @@ func (s *SyncthingDeviceScreen) viewConfirm(
 	p := newPane(w)
 	p.title(theme.Warning,
 		"Remove "+s.device.Name+"?")
+	p.monoWrap(s.device.DeviceID)
 	p.line(" " + theme.Value.Render(
 		"• Stop syncing channel backups"+
 			" to this device"))

--- a/internal/tui/screen_addon_syncthing_install.go
+++ b/internal/tui/screen_addon_syncthing_install.go
@@ -116,7 +116,7 @@ func (s *SyncthingInstallScreen) startInstall() (
 func (s *SyncthingInstallScreen) onInstallDone() tea.Cmd {
 	return tea.Batch(
 		func() tea.Msg { return refreshStatusMsg{} },
-		fetchSyncthingDevicesCmd(),
+		fetchSyncthingDevicesCmd(s.ctx),
 	)
 }
 

--- a/internal/tui/screen_addon_syncthing_pair.go
+++ b/internal/tui/screen_addon_syncthing_pair.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -18,6 +19,7 @@ const (
 	syncPairStepInput    syncPairStep = iota // device ID entry
 	syncPairStepPairing                      // waiting for pair
 	syncPairStepPostPair                     // success + instructions
+	syncPairStepResult
 )
 
 // ── Focus zones for input step ─────────────────────────
@@ -30,16 +32,14 @@ const (
 // ── SyncthingPairScreen ────────────────────────────────
 
 type SyncthingPairScreen struct {
+	attempt   uint64
+	result    app.SyncthingResult
 	ctx       *ScreenContext
 	step      syncPairStep
 	input     textinput.Model
 	focusZone int // 0=input, 1=buttons
 	btnIdx    int
 	pairError string
-	// This node's Syncthing device ID, live-read at screen
-	// entry through the helper (no stored copy exists
-	// anywhere) and held only for this screen's lifetime.
-	nodeDeviceID string
 }
 
 func NewSyncthingPairScreen(
@@ -55,7 +55,7 @@ func NewSyncthingPairScreen(
 // ── Screen interface ────────────────────────────────────
 
 func (s *SyncthingPairScreen) Init() tea.Cmd {
-	return fetchNodeAddressesCmd(tabSyncthingPair)
+	return nil
 }
 
 func (s *SyncthingPairScreen) HandleKey(
@@ -68,6 +68,23 @@ func (s *SyncthingPairScreen) HandleKey(
 		return s.handlePairingKey(keyStr)
 	case syncPairStepPostPair:
 		return s.handlePostPairKey(keyStr)
+	case syncPairStepResult:
+		if keyStr == "enter" {
+			s.step = syncPairStepInput
+			s.focusZone = syncPairZoneInput
+			s.input.Focus()
+			return s, nil
+		}
+		if keyStr == "backspace" {
+			return s, closeSyncthingCmd(s, s.attempt)
+		}
+		if keyStr == "left" {
+			return s, emitFocusSidebar
+		}
+		if keyStr == "ctrl+c" {
+			return s, tea.Quit
+		}
+		return s, nil
 	}
 	return s, nil
 }
@@ -83,22 +100,21 @@ func (s *SyncthingPairScreen) HandleMsg(
 			s.input, cmd = s.input.Update(msg)
 			return s, cmd
 		}
-	case tabActivatedMsg:
-		// Re-entering the tab re-asks: screen entry is the
-		// cadence at which live-read facts are read.
-		return s, fetchNodeAddressesCmd(tabSyncthingPair)
-	case nodeAddressesMsg:
-		s.nodeDeviceID = msg.addrs.SyncthingDeviceID
 	case syncthingPairedMsg:
-		if msg.err != nil {
-			s.pairError = msg.err.Error()
-			s.step = syncPairStepInput
+		if msg.owner != s || msg.attempt != s.attempt || s.step != syncPairStepPairing {
 			return s, nil
 		}
-		// Success — the model refreshes the daemon-observed list.
-		s.step = syncPairStepPostPair
-		s.btnIdx = 0
+		s.result = msg.result
 		s.pairError = ""
+		if msg.result.Err != nil {
+			s.pairError = msg.result.Err.Error()
+		}
+		s.step = syncPairStepResult
+		if msg.result.Outcome == app.SyncthingComplete {
+			s.step = syncPairStepPostPair
+		}
+		s.btnIdx = 0
+
 	}
 	return s, nil
 }
@@ -107,6 +123,24 @@ func (s *SyncthingPairScreen) View(
 	w, h int,
 ) string {
 	switch s.step {
+	case syncPairStepResult:
+		p := newPane(w)
+		title := "Pairing Not Completed"
+		if s.result.Outcome == app.SyncthingPartial {
+			title = "Device Configured; Sharing Incomplete"
+		}
+		if s.result.Outcome == app.SyncthingUnknown {
+			title = "Pairing Outcome Unconfirmed"
+		}
+		p.title(theme.Warning, title)
+		id := s.result.DeviceID
+		if id == "" {
+			id = syncthingIDValue(s.input)
+		}
+		p.monoWrap(id)
+		p.warnWrapWords(s.pairError)
+		p.wrappedLines("Review the current device/share state before retrying.", theme.Dim)
+		return p.renderWithBottomButtons([]string{"Review Device ID"}, 0, s.ctx.ContentFocused, h)
 	case syncPairStepInput:
 		return s.viewInput(w, h)
 	case syncPairStepPairing:
@@ -128,7 +162,7 @@ func (s *SyncthingPairScreen) HelpBindings() []key.Binding {
 		}
 		binds = append(binds, kQuit)
 		return binds
-	case syncPairStepPostPair:
+	case syncPairStepPostPair, syncPairStepResult:
 		return tabButtonBindings(s.ctx.HasTabs)
 	}
 	return nil
@@ -256,40 +290,17 @@ func (s *SyncthingPairScreen) submitPair() (
 	Screen, tea.Cmd,
 ) {
 	deviceID := syncthingIDValue(s.input)
-	if !s.ctx.State.SyncthingDevicesKnown {
-		s.pairError = "Current device list unavailable. Reopen Syncthing and try again."
-		return s, nil
-	}
 	if deviceID == "" {
 		s.pairError = "Paste a Device ID"
 		return s, nil
 	}
-	parts := strings.Split(deviceID, "-")
-	if len(parts) != 8 {
-		s.pairError =
-			"Invalid format. Expected 8 groups" +
-				" separated by hyphens."
+	if s.step != syncPairStepInput {
 		return s, nil
 	}
-	for _, p := range parts {
-		if len(p) != 7 {
-			s.pairError =
-				"Invalid format. Each group" +
-					" should be 7 characters."
-			return s, nil
-		}
-	}
-	// Check for duplicate
-	for _, d := range s.ctx.State.SyncthingDevices {
-		if d.DeviceID == deviceID {
-			s.pairError =
-				"Device already paired."
-			return s, nil
-		}
-	}
+	s.attempt++
 	s.pairError = ""
 	s.step = syncPairStepPairing
-	return s, pairSyncthingDeviceCmd(deviceID)
+	return s, pairSyncthingDeviceCmd(s, deviceID)
 }
 
 // ── Pairing (in-flight) step ────────────────────────────
@@ -343,7 +354,7 @@ func (s *SyncthingPairScreen) handlePostPairKey(
 	case "enter":
 		switch s.btnIdx {
 		case 0: // Show QR
-			vpsDeviceID := s.nodeDeviceID
+			vpsDeviceID := s.result.LocalID
 			if vpsDeviceID == "" {
 				return s, nil
 			}
@@ -354,7 +365,7 @@ func (s *SyncthingPairScreen) handlePostPairKey(
 				}
 			}
 		case 1: // Done
-			return s, emitCloseTab
+			return s, closeSyncthingCmd(s, s.attempt)
 		}
 		return s, nil
 	}
@@ -508,7 +519,7 @@ func (s *SyncthingPairScreen) viewPostPair(
 				"Complete Pairing"), w))
 	lines = append(lines, "")
 
-	vpsDeviceID := s.nodeDeviceID
+	vpsDeviceID := s.result.LocalID
 	if vpsDeviceID != "" {
 		lines = append(lines,
 			" "+theme.Dim.Render(

--- a/internal/tui/syncthing_test.go
+++ b/internal/tui/syncthing_test.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/virtualprivatenode/vpn/internal/app"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/syncthing"
+)
+
+func syncModel(t *testing.T) (Model, *SyncthingDeviceScreen, *SyncthingDeviceScreen) {
+	t.Helper()
+	ctx := &ScreenContext{Cfg: config.Default(), State: &RuntimeState{}, Syncthing: app.NewSyncthing()}
+	t.Cleanup(ctx.Syncthing.Close)
+	a := NewSyncthingDeviceScreen(ctx, syncthing.Device{Name: "same", DeviceID: "A"})
+	b := NewSyncthingDeviceScreen(ctx, syncthing.Device{Name: "same", DeviceID: "B"})
+	m := Model{cfg: ctx.Cfg, state: ctx.State, screenCtx: ctx, nav: NewNavSidebar(), tabs: []openTab{
+		{Kind: tabSyncthing, Section: secAddons, Screen: NewSyncthingDetailScreen(ctx)},
+		{Kind: tabSyncthingDevice, Section: secAddons, Key: "A", Parent: tabSyncthing, Screen: a},
+		{Kind: tabSyncthingDevice, Section: secAddons, Key: "B", Parent: tabSyncthing, Screen: b},
+	}}
+	m.nav.ActiveItem = secAddons
+	return m, a, b
+}
+func TestSyncthingRemovalOwnsAttemptAndHiddenResult(t *testing.T) {
+	m, a, b := syncModel(t)
+	b.step = syncDeviceStepConfirm
+	b.confirmIdx = 1
+	_, first := b.HandleKey("enter", tea.KeyPressMsg{})
+	_, second := b.HandleKey("enter", tea.KeyPressMsg{})
+	if first == nil || second != nil {
+		t.Fatal("repeated confirmation queued another removal")
+	}
+	m.nav.ActiveItem = secWallet
+	result := syncthingRemovedMsg{owner: b, attempt: b.attempt, result: app.SyncthingResult{Outcome: app.SyncthingUnknown, Err: errors.New("removal unconfirmed")}}
+	updated, _ := m.Update(result)
+	m = updated.(Model)
+	if b.removeError != "removal unconfirmed" || a.removeError != "" {
+		t.Fatal("hidden result lost or misdelivered")
+	}
+	// A stale result cannot complete a later attempt.
+	b.step = syncDeviceStepRemoving
+	b.attempt++
+	m.Update(result)
+	if b.step != syncDeviceStepRemoving {
+		t.Fatal("stale result changed new attempt")
+	}
+	result.attempt = b.attempt
+	result.result = app.SyncthingResult{Outcome: app.SyncthingComplete}
+	updated, _ = m.Update(result)
+	m = updated.(Model)
+	if b.step != syncDeviceStepRemoved {
+		t.Fatal("hidden success lost")
+	}
+	if len(m.tabs) != 3 {
+		t.Fatal("success silently removed result")
+	}
+	_, done := b.HandleKey("enter", tea.KeyPressMsg{})
+	updated, _ = m.Update(done())
+	m = updated.(Model)
+	if len(m.tabs) != 2 || m.tabs[1].Screen != a || m.nav.ActiveSection() != secWallet {
+		t.Fatal("Done closed another tab or changed section")
+	}
+}
+func TestSyncthingDeviceTabsUseIDsAndProtectBusyParent(t *testing.T) {
+	m, a, b := syncModel(t)
+	other := NewSyncthingDeviceScreen(m.screenCtx, syncthing.Device{Name: "same", DeviceID: "C"})
+	updated, _ := m.Update(openTabMsg{Kind: tabSyncthingDevice, Key: "C", Index: 0, Screen: other, Parent: tabSyncthing})
+	m = updated.(Model)
+	if len(m.tabs) != 4 {
+		t.Fatal("row zero reused another device tab")
+	}
+	updated, _ = m.Update(openTabMsg{Kind: tabSyncthingDevice, Key: "B", Index: 9, Screen: b, Parent: tabSyncthing})
+	m = updated.(Model)
+	if len(m.tabs) != 4 {
+		t.Fatal("reordered device duplicated tab")
+	}
+	a.step = syncDeviceStepRemoving
+	for _, index := range []int{1, 2} {
+		updated, _ = m.closeTab(index)
+		if len(updated.(Model).tabs) != 4 {
+			t.Fatal("busy device or parent closed")
+		}
+	}
+}
+func TestSyncthingPairPartialResultAndStaleDone(t *testing.T) {
+	m, _, _ := syncModel(t)
+	s := NewSyncthingPairScreen(m.screenCtx)
+	s.step = syncPairStepPairing
+	s.attempt = 1
+	m.tabs = append(m.tabs, openTab{Kind: tabSyncthingPair, Section: secAddons, Parent: tabSyncthing, Screen: s})
+	m.nav.ActiveItem = secWallet
+	result := syncthingPairedMsg{owner: s, attempt: 1, result: app.SyncthingResult{Outcome: app.SyncthingPartial, Err: errors.New("device configured; share incomplete")}}
+	updated, _ := m.Update(result)
+	m = updated.(Model)
+	if s.step != syncPairStepResult || s.pairError == "" {
+		t.Fatal("partial pair returned to ordinary input")
+	}
+	oldDone := closeSyncthingCmd(s, s.attempt)()
+	s.attempt++
+	s.step = syncPairStepPairing
+	m.Update(result)
+	if s.step != syncPairStepPairing {
+		t.Fatal("old result completed newer pair")
+	}
+	s.step = syncPairStepResult
+	updated, _ = m.Update(oldDone)
+	if len(updated.(Model).tabs) != 4 {
+		t.Fatal("old Done closed newer completed attempt")
+	}
+}
+func TestSyncthingRefreshKeepsIdentityAndRejectsOlderRead(t *testing.T) {
+	m, _, _ := syncModel(t)
+	detail := m.tabs[0].Screen.(*SyncthingDetailScreen)
+	m.state.SyncthingDevicesKnown = true
+	m.state.SyncthingDevices = []syncthing.Device{{DeviceID: "A"}, {DeviceID: "B"}}
+	detail.focusZone = syncDetailZoneList
+	detail.cursor = 1
+	m.screenCtx.syncthingRevision = 2
+	fresh := syncthingDevicesMsg{owner: m.screenCtx, revision: 2, devices: []syncthing.Device{{DeviceID: "B"}, {DeviceID: "A"}}}
+	m.Update(fresh)
+	if detail.cursor != 0 {
+		t.Fatal("selection changed identity on reorder")
+	}
+	m.Update(syncthingDevicesMsg{owner: m.screenCtx, revision: 1, err: errors.New("late read")})
+	if !m.state.SyncthingDevicesKnown || m.state.SyncthingDevices[0].DeviceID != "B" {
+		t.Fatal("older read overwrote current list")
+	}
+	m.screenCtx.syncthingRevision++
+	fresh.revision++
+	fresh.devices = []syncthing.Device{{DeviceID: "A"}}
+	m.Update(fresh)
+	if detail.focusZone != syncDetailZoneButtons {
+		t.Fatal("missing selection silently substituted another device")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -255,6 +255,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		if msg.Kind == tabSyncthingDevice {
+			detail, ok := msg.Screen.(*SyncthingDeviceScreen)
+			if !ok || msg.Key == "" || detail.device.DeviceID != msg.Key || m.nav.ActiveSection() != secAddons {
+				return m, nil
+			}
+			for i, tab := range m.effectiveTabs() {
+				if tab.Kind == tabSyncthingDevice && tab.Key == msg.Key {
+					m.activeTab = i
+					m.rememberTabPosition()
+					m.focusContent()
+					return m, m.activateTab()
+				}
+			}
+		}
+
 		if msg.Kind == tabSSHKeyDetail {
 			detail, ok := msg.Screen.(*SSHKeyDetailScreen)
 			if !ok || msg.Key == "" || detail.keyInfo.Fingerprint != msg.Key || m.nav.ActiveSection() != secSystem {
@@ -285,7 +300,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Dedup by kind + index if Index is set
-		if msg.Kind != tabChannel && msg.Kind != tabSSHKeyDetail && msg.Index != 0 {
+		if msg.Kind != tabChannel && msg.Kind != tabSSHKeyDetail && msg.Kind != tabSyncthingDevice && msg.Index != 0 {
 			tabs := m.effectiveTabs()
 			for i, t := range tabs {
 				if t.Kind == msg.Kind &&
@@ -303,7 +318,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Dedup flow tabs by kind + section
-		if msg.Kind != tabChannel && msg.Kind != tabSSHKeyDetail && msg.Index == 0 {
+		if msg.Kind != tabChannel && msg.Kind != tabSSHKeyDetail && msg.Kind != tabSyncthingDevice && msg.Index == 0 {
 			sec := m.nav.ActiveSection()
 			tabs := m.effectiveTabs()
 			for i, t := range tabs {
@@ -311,7 +326,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					t.Section == sec {
 					m.activeTab = i
 					m.rememberTabPosition()
-					if msg.Replace && (walletCreationBusy(t.Screen) || onChainSendBusy(t.Screen) || channelOpenBusy(t.Screen) || m.sshTabBusy(t) || m.helperTabBusy(t)) {
+					if msg.Replace && (walletCreationBusy(t.Screen) || onChainSendBusy(t.Screen) || channelOpenBusy(t.Screen) || m.sshTabBusy(t) || m.helperTabBusy(t) || m.syncthingTabBusy(t)) {
 						return m, nil
 					}
 					if msg.Replace &&
@@ -406,18 +421,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case syncthingWebPasswordMsg:
 		return m.dispatchToTab(tabSyncthingWebUI, msg)
 	case syncthingPairedMsg:
-		rm, cmd := m.dispatchToTab(tabSyncthingPair, msg)
-		if msg.err == nil {
-			return rm, tea.Batch(cmd, fetchSyncthingDevicesCmd())
+		if msg.owner == nil || msg.owner.attempt != msg.attempt || msg.owner.step != syncPairStepPairing {
+			return m, nil
 		}
-		return rm, cmd
+		rm, cmd := m.routeSyncthingResult(msg.owner, msg)
+		return rm, tea.Batch(cmd, fetchSyncthingDevicesCmd(m.screenCtx))
 	case syncthingRemovedMsg:
-		rm, cmd := m.dispatchToTab(tabSyncthingDevice, msg)
-		if msg.err == nil {
-			return rm, tea.Batch(cmd, fetchSyncthingDevicesCmd())
+		if msg.owner == nil || msg.owner.attempt != msg.attempt || msg.owner.step != syncDeviceStepRemoving {
+			return m, nil
 		}
-		return rm, cmd
+		rm, cmd := m.routeSyncthingResult(msg.owner, msg)
+		return rm, tea.Batch(cmd, fetchSyncthingDevicesCmd(m.screenCtx))
+	case syncthingCloseMsg:
+		switch owner := msg.owner.(type) {
+		case *SyncthingPairScreen:
+			if owner == nil || owner.attempt != msg.attempt || syncthingBusy(owner) {
+				return m, nil
+			}
+		case *SyncthingDeviceScreen:
+			if owner == nil || owner.attempt != msg.attempt || syncthingBusy(owner) {
+				return m, nil
+			}
+		default:
+			return m, nil
+		}
+		return m.closeScreenTab(msg.owner)
 	case syncthingDevicesMsg:
+		if msg.owner != m.screenCtx || msg.revision != m.screenCtx.syncthingRevision {
+			return m, nil
+		}
+		for _, tab := range m.tabs {
+			if detail, ok := tab.Screen.(*SyncthingDetailScreen); ok {
+				detail.HandleMsg(msg)
+			}
+		}
 		m.state.SyncthingDevices = msg.devices
 		m.state.SyncthingDevicesErr = msg.err
 		m.state.SyncthingDevicesKnown = msg.err == nil
@@ -963,7 +1000,7 @@ func (m Model) closeTab(
 
 	closingTab := tabs[tabIdx]
 	// Keep submitted operations reachable until their bounded calls return.
-	if walletCreationBusy(closingTab.Screen) || onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) || channelCloseBusy(closingTab.Screen) || m.sshTabBusy(closingTab) || m.helperTabBusy(closingTab) {
+	if walletCreationBusy(closingTab.Screen) || onChainSendBusy(closingTab.Screen) || channelOpenBusy(closingTab.Screen) || channelCloseBusy(closingTab.Screen) || m.sshTabBusy(closingTab) || m.helperTabBusy(closingTab) || m.syncthingTabBusy(closingTab) {
 		return m, nil
 	}
 
@@ -1196,4 +1233,35 @@ func (m Model) sshTabBusy(tab openTab) bool {
 		}
 	}
 	return false
+}
+
+func syncthingBusy(screen Screen) bool {
+	switch s := screen.(type) {
+	case *SyncthingPairScreen:
+		return s.step == syncPairStepPairing
+	case *SyncthingDeviceScreen:
+		return s.step == syncDeviceStepRemoving
+	}
+	return false
+}
+func (m Model) syncthingTabBusy(tab openTab) bool {
+	if syncthingBusy(tab.Screen) {
+		return true
+	}
+	for _, child := range m.tabs {
+		if child.Section == tab.Section && child.Parent == tab.Kind && syncthingBusy(child.Screen) {
+			return true
+		}
+	}
+	return false
+}
+func (m Model) routeSyncthingResult(owner Screen, msg tea.Msg) (tea.Model, tea.Cmd) {
+	for i, tab := range m.tabs {
+		if tab.Screen == owner {
+			screen, cmd := owner.HandleMsg(msg)
+			m.tabs[i].Screen = screen
+			return m, cmd
+		}
+	}
+	return m, nil
 }


### PR DESCRIPTION
Syncthing pairing and removal mixed daemon access with installer and TUI code, making configuration preservation and asynchronous results harder to manage across retries and multiple sessions.

This change:
- Separates daemon transport from application-owned pairing/removal and TUI presentation.
- Uses certificate-based local identity with explicit configuration and data paths.
- Preserves existing device settings and shares when completing a missing backup share.
- Coordinates VPN operations across TUIs and routes results to their originating screen and attempt.
- Strengthens runtime privacy checks and reports partial, unconfirmed and failed cleanup outcomes explicitly.

Syncthing remains pinned at v2.1.1; no dependency versions change.

### Validation

- Go 1.26.8 full ordinary/race tests, vet, formatting and Linux build passed. Affected Linux tests and all 17 reviewed privileged tests passed in ordinary/race modes after correcting the harness’s inherited umask.
- Staticcheck reported no new diagnostics; 91 existing findings remain.
- Two unfunded Debian 13 amd64 hosts passed first-start privacy, 51 export/access checks, backup transfer, preservation retry, refusals, cross-TUI contention, service restarts, reboots and removal without backup loss.
- Making the staged API key unreadable caused explicit refusal without configuration or daemon changes.
- Removal results survived section navigation. Automated tests cover hidden completion and stale attempts; deliberate faults verified the share-preservation and shutdown-join assertions.

External Web UI writes remain outside the VPN lock. An HTTP error after a write can leave its outcome unconfirmed. Live transfer used a genuine zero-channel backup; funded-channel restoration and generic installation recovery were not tested.