### PR TITLE
refactor: own on-chain receive requests and results

### DIFF
--- a/internal/app/onchain_receive.go
+++ b/internal/app/onchain_receive.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type OnChainReceiveClient interface {
+	GetNewAddress() (*lndrpc.OnChainAddress, error)
+}
+
+// OnChainReceiveAddress is a validated P2TR address returned by LND.
+type OnChainReceiveAddress struct {
+	text string
+}
+
+func (a OnChainReceiveAddress) Text() string { return a.text }
+
+// CreateOnChainAddress requests once. An error does not prove LND failed to
+// derive an address; an explicit retry requests another, without retiring any
+// previously issued address. Network encoding cannot distinguish signet from
+// testnet4, so the installed daemon remains the authority for chain identity.
+func CreateOnChainAddress(client OnChainReceiveClient, network, previous string) (OnChainReceiveAddress, error) {
+	var params *chaincfg.Params
+	switch network {
+	case config.NetworkMainnet:
+		params = &chaincfg.MainNetParams
+	case config.NetworkTestnet4:
+		params = &chaincfg.TestNet4Params
+	case config.NetworkPublicSignet:
+		params = &chaincfg.SigNetParams
+	default:
+		return OnChainReceiveAddress{}, errors.New("unsupported node network profile")
+	}
+	if client == nil {
+		return OnChainReceiveAddress{}, errors.New("LND not connected")
+	}
+	result, err := client.GetNewAddress()
+	if err != nil {
+		return OnChainReceiveAddress{}, fmt.Errorf("address request not confirmed: %w", err)
+	}
+	if result == nil || result.Address == "" {
+		return OnChainReceiveAddress{}, errors.New("LND returned no address")
+	}
+	decoded, err := btcutil.DecodeAddress(result.Address, params)
+	if err != nil {
+		return OnChainReceiveAddress{}, errors.New("LND returned an invalid address")
+	}
+	address, ok := decoded.(*btcutil.AddressTaproot)
+	if !ok || !address.IsForNet(params) {
+		return OnChainReceiveAddress{}, errors.New("LND returned an unexpected address type or network")
+	}
+	text := address.EncodeAddress()
+	if text == previous {
+		return OnChainReceiveAddress{}, errors.New("LND returned the previous address instead of a new one")
+	}
+	return OnChainReceiveAddress{text: text}, nil
+}

--- a/internal/app/onchain_receive_test.go
+++ b/internal/app/onchain_receive_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type addressClient struct {
+	result *lndrpc.OnChainAddress
+	err    error
+	calls  int
+}
+
+func (c *addressClient) GetNewAddress() (*lndrpc.OnChainAddress, error) {
+	c.calls++
+	return c.result, c.err
+}
+
+func TestCreateOnChainAddressValidatesDaemonResults(t *testing.T) {
+	main, err := btcutil.NewAddressTaproot(make([]byte, 32), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test, err := btcutil.NewAddressTaproot(make([]byte, 32), &chaincfg.TestNet4Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	witness, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lost := errors.New("response lost")
+	for _, tc := range []struct {
+		name, network, address, previous string
+		err                              error
+		nilResult, wantOK                bool
+	}{
+		{name: "mainnet", network: config.NetworkMainnet, address: main.EncodeAddress(), wantOK: true},
+		{name: "testnet4", network: config.NetworkTestnet4, address: test.EncodeAddress(), wantOK: true},
+		{name: "signet", network: config.NetworkPublicSignet, address: test.EncodeAddress(), wantOK: true},
+		{name: "wrong network", network: config.NetworkMainnet, address: test.EncodeAddress()},
+		{name: "wrong type", network: config.NetworkMainnet, address: witness.EncodeAddress()},
+		{name: "malformed", network: config.NetworkMainnet, address: "bc1p-invalid"},
+		{name: "whitespace", network: config.NetworkMainnet, address: main.EncodeAddress() + "\n"},
+		{name: "empty", network: config.NetworkMainnet},
+		{name: "nil", network: config.NetworkMainnet, nilResult: true},
+		{name: "unchanged", network: config.NetworkMainnet, address: main.EncodeAddress(), previous: main.EncodeAddress()},
+		{name: "lost response", network: config.NetworkMainnet, address: main.EncodeAddress(), err: lost},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &addressClient{result: &lndrpc.OnChainAddress{Address: tc.address}, err: tc.err}
+			if tc.nilResult {
+				client.result = nil
+			}
+			result, err := CreateOnChainAddress(client, tc.network, tc.previous)
+			if (err == nil) != tc.wantOK || client.calls != 1 {
+				t.Fatalf("result=%q err=%v calls=%d", result.Text(), err, client.calls)
+			}
+			if tc.wantOK && result.Text() != tc.address || !tc.wantOK && result.Text() != "" {
+				t.Fatalf("unexpected usable address %q", result.Text())
+			}
+			if tc.err != nil && !errors.Is(err, tc.err) {
+				t.Fatal("underlying failure was lost")
+			}
+		})
+	}
+	client := &addressClient{}
+	if _, err := CreateOnChainAddress(client, "regtest", ""); err == nil || client.calls != 0 {
+		t.Fatal("unsupported profile reached LND")
+	}
+	if _, err := CreateOnChainAddress(nil, config.NetworkMainnet, ""); err == nil {
+		t.Fatal("missing client was accepted")
+	}
+}

--- a/internal/lndrpc/receive_test.go
+++ b/internal/lndrpc/receive_test.go
@@ -1,0 +1,46 @@
+package lndrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type addressRPC struct {
+	lnrpc.LightningClient
+	ctx     context.Context
+	request *lnrpc.NewAddressRequest
+}
+
+func (r *addressRPC) NewAddress(ctx context.Context, request *lnrpc.NewAddressRequest, _ ...grpc.CallOption) (*lnrpc.NewAddressResponse, error) {
+	r.ctx, r.request = ctx, request
+	return &lnrpc.NewAddressResponse{Address: "daemon-address"}, nil
+}
+
+func TestNewAddressUsesFreshTaprootDefaultAccountAndBoundedAuthenticatedRPC(t *testing.T) {
+	rpc := &addressRPC{}
+	client := &Client{lightning: rpc, macaroonHex: "test-credential"}
+	started := time.Now()
+	result, err := client.GetNewAddress()
+	if err != nil || result.Address != "daemon-address" {
+		t.Fatalf("result=%v err=%v", result, err)
+	}
+	if rpc.request.Type != lnrpc.AddressType_TAPROOT_PUBKEY || rpc.request.Account != "" {
+		t.Fatalf("unexpected derivation request: %v", rpc.request)
+	}
+	deadline, ok := rpc.ctx.Deadline()
+	if !ok || !deadline.After(started) || deadline.After(time.Now().Add(30*time.Second)) {
+		t.Fatal("RPC lacks the 30-second deadline")
+	}
+	md, _ := metadata.FromOutgoingContext(rpc.ctx)
+	if got := md.Get("macaroon"); len(got) != 1 || got[0] != "test-credential" {
+		t.Fatal("RPC lacks the staged authentication metadata")
+	}
+	if rpc.ctx.Err() != context.Canceled {
+		t.Fatal("completed RPC did not release its context")
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -232,19 +232,15 @@ func fetchPaymentHistoryCmd(
 
 // ── On-chain queries & fund-moving ───────────────────────
 
-func getNewAddressCmd(
-	client *lndrpc.Client,
-) tea.Cmd {
+func getNewAddressCmd(owner *OCReceiveScreen) tea.Cmd {
+	client := owner.addresses
+	if client == nil && owner.ctx.LndClient != nil {
+		client = owner.ctx.LndClient
+	}
+	network, previous, attempt := owner.ctx.Cfg.Network, owner.address, owner.attempt
 	return func() tea.Msg {
-		if client == nil {
-			return newAddressMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		addr, err := client.GetNewAddress()
-		if err != nil {
-			return newAddressMsg{err: err}
-		}
-		return newAddressMsg{address: addr.Address}
+		address, err := app.CreateOnChainAddress(client, network, previous)
+		return newAddressMsg{owner: owner, attempt: attempt, address: address, err: err}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,8 +153,14 @@ type channelOpenResultMsg struct {
 	result  app.ChannelOpenResult
 }
 type newAddressMsg struct {
-	address string
+	owner   *OCReceiveScreen
+	attempt uint64
+	address app.OnChainReceiveAddress
 	err     error
+}
+type receiveAddressQRMsg struct {
+	owner   *OCReceiveScreen
+	attempt uint64
 }
 type invoiceCreatedMsg struct {
 	attempt *invoiceAttempt

--- a/internal/tui/screen_onchain_receive.go
+++ b/internal/tui/screen_onchain_receive.go
@@ -4,42 +4,47 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
-// ── OCReceiveScreen ────────────────────────────────────
-// Displays a fresh on-chain address. Two buttons:
-// "New Address" (generates another) and "Show QR"
-// (opens fullscreen QR overlay).
-
-type ocRecvStep int
-
-const (
-	ocRecvWaiting ocRecvStep = iota // fetching address
-	ocRecvReady                     // address visible
-)
-
+// OCReceiveScreen retains its last address until an explicit request succeeds.
+// Closing the tab discards observation, not addresses already derived by LND.
 type OCReceiveScreen struct {
-	ctx     *ScreenContext
-	step    ocRecvStep
-	address string
-	errMsg  string
-	btnIdx  int // 0=New Address, 1=Show QR
+	ctx        *ScreenContext
+	addresses  app.OnChainReceiveClient
+	attempt    uint64
+	requesting bool
+	address    string
+	errMsg     string
+	btnIdx     int // 0=Show QR, 1=New Address or Retry; only Retry without an address
 }
 
 func NewOCReceiveScreen(
 	ctx *ScreenContext,
 ) *OCReceiveScreen {
 	return &OCReceiveScreen{
-		ctx:  ctx,
-		step: ocRecvWaiting,
+		ctx: ctx,
 	}
 }
 
 // ── Screen interface ────────────────────────────────────
 
 func (s *OCReceiveScreen) Init() tea.Cmd {
-	return getNewAddressCmd(s.ctx.LndClient)
+	if s.attempt != 0 {
+		return nil
+	}
+	return s.requestAddress()
+}
+
+func (s *OCReceiveScreen) requestAddress() tea.Cmd {
+	if s.requesting {
+		return nil
+	}
+	s.attempt++
+	s.requesting = true
+	s.errMsg = ""
+	return getNewAddressCmd(s)
 }
 
 func (s *OCReceiveScreen) HandleKey(
@@ -55,7 +60,7 @@ func (s *OCReceiveScreen) HandleKey(
 		}
 		return s, emitFocusSidebar
 	case "right":
-		if s.step == ocRecvReady && s.btnIdx < 1 {
+		if !s.requesting && s.address != "" && s.btnIdx < 1 {
 			s.btnIdx++
 		}
 		return s, nil
@@ -69,26 +74,20 @@ func (s *OCReceiveScreen) HandleKey(
 	case "backspace":
 		return s, emitFocusParent
 	case "enter":
-		if s.step != ocRecvReady {
+		if s.requesting {
 			return s, nil
+		}
+		if s.address == "" {
+			return s, s.requestAddress()
 		}
 		switch s.btnIdx {
 		case 0: // Show QR
-			if s.address == "" {
-				return s, nil
-			}
-			addr := s.address
+			attempt := s.attempt
 			return s, func() tea.Msg {
-				return showQRMsg{
-					URL:   addr,
-					Label: "On-Chain Address",
-				}
+				return receiveAddressQRMsg{owner: s, attempt: attempt}
 			}
 		case 1: // New Address
-			s.address = ""
-			s.errMsg = ""
-			s.step = ocRecvWaiting
-			return s, getNewAddressCmd(s.ctx.LndClient)
+			return s, s.requestAddress()
 		}
 		return s, nil
 	}
@@ -100,12 +99,16 @@ func (s *OCReceiveScreen) HandleMsg(
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
 	case newAddressMsg:
+		if msg.owner != s || msg.attempt != s.attempt || !s.requesting {
+			return s, nil
+		}
+		s.requesting = false
 		if msg.err != nil {
 			s.errMsg = msg.err.Error()
 			return s, nil
 		}
-		s.address = msg.address
-		s.step = ocRecvReady
+		s.address = msg.address.Text()
+		s.btnIdx = 0
 	}
 	return s, nil
 }
@@ -113,59 +116,39 @@ func (s *OCReceiveScreen) HandleMsg(
 func (s *OCReceiveScreen) View(
 	w, h int,
 ) string {
-	if s.step == ocRecvWaiting {
-		return s.viewWaiting(w, h)
-	}
-	return s.viewReady(w, h)
-}
-
-func (s *OCReceiveScreen) viewWaiting(
-	w, h int,
-) string {
 	p := newPane(w)
 	p.title(theme.Header, "⛓ Receive On-Chain")
-	p.dim("Generating address...")
+	if s.address != "" {
+		p.labelLine("Address:")
+		p.monoWrap(s.address)
+		p.blank()
+		p.dim("Send Bitcoin to this address.")
+		p.dim("Earlier addresses remain valid.")
+	}
 
+	if s.requesting || s.attempt == 0 {
+		p.blank()
+		p.dim("Generating address...")
+		return p.renderWithBottomButtons([]string{"Generating..."}, 0, false, h)
+	}
+
+	buttons := []string{"Show QR", "New Address"}
 	if s.errMsg != "" {
 		p.blank()
 		p.appendError(s.errMsg)
+		p.dim("Retry requests another address.")
+		buttons[1] = "Retry"
+	}
+	if s.address == "" {
+		buttons = []string{"Retry"}
 	}
 
 	return p.renderWithBottomButtons(
-		[]string{"Generating..."}, 0, false, h)
-}
-
-func (s *OCReceiveScreen) viewReady(
-	w, h int,
-) string {
-	p := newPane(w)
-	p.title(theme.Header, "⛓ Receive On-Chain")
-
-	p.labelLine("Address:")
-	p.monoWrap(s.address)
-	p.blank()
-	p.dim("Send Bitcoin to this address.")
-	p.dim("Funds appear after 1 confirmation.")
-
-	if s.ctx.Status != nil && !s.ctx.Status.btcSynced {
-		p.blank()
-		p.line(" " + theme.Warn.Render(
-			"Funds will not appear until IBD is complete."))
-	}
-
-	if s.errMsg != "" {
-		p.blank()
-		p.appendError(s.errMsg)
-	}
-
-	return p.renderWithBottomButtons(
-		[]string{"Show QR", "New Address"},
-		s.btnIdx,
-		s.ctx.ContentFocused, h)
+		buttons, s.btnIdx, s.ctx.ContentFocused, h)
 }
 
 func (s *OCReceiveScreen) HelpBindings() []key.Binding {
-	if s.step == ocRecvReady {
+	if !s.requesting {
 		return tabButtonBindings(s.ctx.HasTabs)
 	}
 	binds := []key.Binding{kSidebar}

--- a/internal/tui/screen_onchain_receive_test.go
+++ b/internal/tui/screen_onchain_receive_test.go
@@ -1,0 +1,169 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type receiveAddressClient struct {
+	address string
+	err     error
+	calls   int
+}
+
+func (c *receiveAddressClient) GetNewAddress() (*lndrpc.OnChainAddress, error) {
+	c.calls++
+	return &lndrpc.OnChainAddress{Address: c.address}, c.err
+}
+
+func receiveAddress(t *testing.T, index byte) string {
+	t.Helper()
+	key := make([]byte, 32)
+	key[0] = index
+	address, err := btcutil.NewAddressTaproot(key, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address.EncodeAddress()
+}
+
+func receiveAddressModel(client *receiveAddressClient) (Model, *OCReceiveScreen) {
+	s := NewOCReceiveScreen(&ScreenContext{Cfg: config.Default(), ContentFocused: true})
+	s.addresses = client
+	m := Model{nav: NewNavSidebar(), screenCtx: s.ctx,
+		tabs: []openTab{{Kind: tabOCReceive, Section: secOnChain, Screen: s}}}
+	return m, s
+}
+
+func updateReceiveWithoutCommand(t *testing.T, m Model, msg tea.Msg) Model {
+	t.Helper()
+	updated, cmd := m.Update(msg)
+	if cmd != nil {
+		t.Fatalf("%T scheduled unexpected follow-up work", msg)
+	}
+	return updated.(Model)
+}
+
+func TestOnChainReceivePreservesAddressAcrossFailureAndExplicitRetry(t *testing.T) {
+	theme.Init(true)
+	first, second := receiveAddress(t, 1), receiveAddress(t, 2)
+	client := &receiveAddressClient{address: first, err: errors.New("wallet locked")}
+	m, s := receiveAddressModel(client)
+	initial := s.Init()
+	if s.Init() != nil {
+		t.Fatal("initialization scheduled a second derivation")
+	}
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd != nil {
+		t.Fatal("repeated Enter scheduled a second derivation")
+	}
+	// Channels is visible; both failure and success must reach the hidden owner.
+	m = updateReceiveWithoutCommand(t, m, initial())
+	if s.requesting || s.errMsg == "" || !strings.Contains(s.View(82, 34), "Retry") {
+		t.Fatal("initial failure did not offer explicit recovery")
+	}
+	client.err = nil
+	_, retry := s.HandleKey("enter", tea.KeyPressMsg{})
+	initialResult := retry()
+	m = updateReceiveWithoutCommand(t, m, initialResult)
+	if s.address != first || s.requesting || client.calls != 2 {
+		t.Fatal("hidden retry did not display its address")
+	}
+	m.nav.SetActive(secOnChain)
+	m.activeTab = 1
+	_, qr := s.HandleKey("enter", tea.KeyPressMsg{})
+	oldQR := qr()
+	m = updateReceiveWithoutCommand(t, m, oldQR)
+	if m.subview != svQR || m.urlTarget != first {
+		t.Fatal("QR differs from the displayed address")
+	}
+	m.subview = svNone
+	s.HandleKey("right", tea.KeyPressMsg{})
+	_, replace := s.HandleKey("enter", tea.KeyPressMsg{})
+	if s.address != first || !strings.Contains(s.View(82, 34), first) {
+		t.Fatal("pending replacement hid the previous address")
+	}
+	m = updateReceiveWithoutCommand(t, m, initialResult)
+	if !s.requesting || s.address != first {
+		t.Fatal("old completion consumed the replacement attempt")
+	}
+	client.err = errors.New("replacement unavailable")
+	failedResult := replace()
+	m = updateReceiveWithoutCommand(t, m, failedResult)
+	if s.requesting || s.address != first || s.errMsg == "" || client.calls != 3 {
+		t.Fatal("failed replacement lost the usable address or retried automatically")
+	}
+	m = updateReceiveWithoutCommand(t, m, oldQR)
+	if m.subview == svQR {
+		t.Fatal("old QR action survived a newer request")
+	}
+	client.address, client.err = second, nil
+	_, retry = s.HandleKey("enter", tea.KeyPressMsg{})
+	m = updateReceiveWithoutCommand(t, m, retry())
+	m = updateReceiveWithoutCommand(t, m, failedResult)
+	if s.address != second || s.errMsg != "" || s.requesting || client.calls != 4 {
+		t.Fatal("late failure replaced the successful explicit retry")
+	}
+	_, qr = s.HandleKey("enter", tea.KeyPressMsg{})
+	m = updateReceiveWithoutCommand(t, m, qr())
+	if m.urlTarget != second {
+		t.Fatal("replacement QR retained the old address")
+	}
+	m.subview = svNone
+	m.nav.SetActive(secWallet)
+	m = updateReceiveWithoutCommand(t, m, qr())
+	if m.subview == svQR {
+		t.Fatal("delayed QR action interrupted another section")
+	}
+}
+
+func TestOnChainReceiveCloseReopenAndNavigationOwnResults(t *testing.T) {
+	client := &receiveAddressClient{address: receiveAddress(t, 1)}
+	m, old := receiveAddressModel(client)
+	pending := old.Init()
+	m.nav.SetActive(secOnChain)
+	updated, _ := m.closeTab(1)
+	m = updated.(Model)
+	if len(m.tabs) != 0 {
+		t.Fatal("address generation prevented deliberate close")
+	}
+	current := NewOCReceiveScreen(old.ctx)
+	current.addresses = client
+	updated, create := m.Update(openTabMsg{Kind: tabOCReceive, Screen: current})
+	m = updated.(Model)
+	m = updateReceiveWithoutCommand(t, m, pending())
+	if current.address != "" || !current.requesting {
+		t.Fatal("closed owner's completion populated the reopened screen")
+	}
+	client.address = receiveAddress(t, 2)
+	result := create()
+	m = updateReceiveWithoutCommand(t, m, result)
+	if current.address != client.address || current.requesting {
+		t.Fatal("reopened screen did not accept its own address")
+	}
+	updated, cmd := m.Update(openTabMsg{Kind: tabOCReceive, Screen: NewOCReceiveScreen(old.ctx)})
+	m = updated.(Model)
+	if cmd != nil || len(m.tabs) != 1 || m.tabs[0].Screen != current || client.calls != 2 {
+		t.Fatal("returning to Receive replaced its address or requested another")
+	}
+	duplicate := result.(newAddressMsg)
+	duplicate.err = errors.New("duplicate completion")
+	m = updateReceiveWithoutCommand(t, m, duplicate)
+	if current.errMsg != "" || current.address != client.address {
+		t.Fatal("duplicate completion changed the finished request")
+	}
+	_, qr := current.HandleKey("enter", tea.KeyPressMsg{})
+	updated, _ = m.closeTab(1)
+	m = updated.(Model)
+	m = updateReceiveWithoutCommand(t, m, qr())
+	if m.subview == svQR {
+		t.Fatal("closed screen's QR action opened an overlay")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -475,7 +475,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case coTxListMsg:
 		return m.dispatchToTab(tabOpenChannel, msg)
 	case newAddressMsg:
-		return m.dispatchToTab(tabOCReceive, msg)
+		for _, tab := range m.tabs {
+			if msg.owner != nil && tab.Screen == msg.owner {
+				_, cmd := msg.owner.HandleMsg(msg)
+				return m, cmd
+			}
+		}
+		return m, nil
+	case receiveAddressQRMsg:
+		tabs := m.effectiveTabs()
+		if msg.owner == nil || m.activeTab <= 0 || m.activeTab >= len(tabs) ||
+			tabs[m.activeTab].Screen != msg.owner || msg.owner.attempt != msg.attempt ||
+			msg.owner.requesting || msg.owner.address == "" {
+			return m, nil
+		}
+		m.subview = svQR
+		m.urlTarget = msg.owner.address
+		m.qrLabel = "On-Chain Address"
+		return m, nil
 	case invoiceCreatedMsg:
 		return m.dispatchToTab(tabReceive, msg)
 	case invoiceCheckMsg, invoiceStatusMsg:


### PR DESCRIPTION
## Summary

On-chain Receive could lose results when another section was visible, accept
an old result after reopening, or remain stuck after failure. Requesting a
replacement also cleared the last usable address before success.

Move address-request orchestration and validation into the application layer.
The TUI owns screen/attempt identity, delivers hidden completions, rejects stale
results and QR actions, and offers explicit retry while preserving the previous
address. LND continues deriving fresh Taproot addresses; automatic rotation and
broader reconnection behavior remain separate.

## Validation

- Go 1.26.8: full tests/race, vet, tidy-diff and Linux build passed.
- Automated coverage includes invalid daemon results, failure/retry,
  address preservation, hidden/stale/duplicate results and QR ownership.
  A deliberately injected automatic-retry bug was caught by the corrected test.
- Exact candidate `49a757a` built and installed on unfunded Debian 13.6
  amd64 public Signet. Live generation, original/replacement QR decoding,
  navigation preservation, tab reuse and close/reopen passed.

Tested tree: `4005cd71c42084f1f506e3fd82415df5962d0761`.