### PR TITLE
refactor: separate installer presentation and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ refuses with a full report before starting durable installation work if the box
 is not one it can trust. It then walks you through access setup and hardware
 fit, installs Bitcoin Core and LND with every download after Tor
 routed through Tor and verified before install, and drops you
-straight into the TUI. If a step fails or you interrupt, run it
-again — when the installer can prove that it is resuming the same recognizable
+straight into the TUI. During interactive installation, Ctrl+C requests a stop
+after the active step and its progress record finish; keep the terminal open
+while it stops. The installer retains its lock until that work settles. This
+does not kill an active subprocess or undo changes. If the last step finishes,
+the installer still publishes completion. Forced process death can leave
+unrecorded work that a later run must repeat.
+
+If a step fails or installation stops, inspect the reported result before
+running it again. When the installer can prove that it is resuming the same recognizable
 fresh-install lifecycle, it continues from the incomplete work. A completed
 base installation reports already installed and stops; optional add-ons and
 later settings remain available through the TUI. Mainnet and testnet4 remain
@@ -127,10 +134,14 @@ mainnet value.
 shows every SSH key it finds on the box — with fingerprints and
 comments, and provider control lines excluded — for you to
 confirm, replace, or extend before they are copied. You also set
-a login password (16 characters minimum) as the provider console
+a login password (16 bytes minimum) as the provider console
 fallback; whether password login over SSH stays enabled is
 preserved exactly as the installer OBSERVED it on your box —
 installing never silently changes it.
+
+Password paste preserves spaces and accepts one trailing newline. Input that
+would be altered or exceed the field's 128-character limit is rejected and
+cleared, rather than silently changing the password.
 
 ### Wallet Creation
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/tui"
+	installui "github.com/virtualprivatenode/vpn/internal/tui/install"
 )
 
 var version = "dev"
@@ -33,7 +34,7 @@ func main() {
 
 	switch cmd {
 	case cmdInstall:
-		if err := installer.RunInstall(opts); err != nil {
+		if err := installer.RunInstall(opts, installui.Run); err != nil {
 			fmt.Fprintf(os.Stderr, "\n  Failed: %v\n", err)
 			os.Exit(1)
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.6
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/lightningnetwork/lnd v0.21.2-beta
 	github.com/mdp/qrterminal/v3 v3.2.1
 	golang.org/x/crypto v0.46.0
@@ -48,7 +49,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260811164956-006e29f97886 // indirect
-	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/installer/engine.go
+++ b/internal/installer/engine.go
@@ -10,13 +10,9 @@ import (
 
 // ── Install engine core ──────────────────────────────────
 //
-// The step model, resume planner, and step executor — with no
-// rendering. Front-ends are thin: the initial-install TUI
-// (setup.go) and the unattended runner (below) both drive the
-// same runner, so ledger recording, skip decisions, and the
-// log trail cannot diverge between them, and a failed or
-// interrupted run reaches /var/log/vpn.log identically from
-// either.
+// The interactive session and unattended loop use the same
+// step runner for resume decisions, ledger recording, and
+// logging. The TUI observes progress without executing steps.
 //
 // Resume rules (one place, ruled 2026-07-16):
 //
@@ -263,11 +259,8 @@ type RunResult struct {
 	Err      error // the failed step's error
 }
 
-// classifyRun folds a front-end's final state into a
-// RunResult. Pure — the TUI passes its flags, tests pass
-// theirs. An exit after done-and-not-failed is COMPLETE even
-// if the operator left with ctrl+c instead of enter: the steps
-// all ran; how the render loop was dismissed is irrelevant.
+// classifyRun describes execution progress. RunComplete means every step
+// finished; terminal lifecycle publication remains a separate requirement.
 func classifyRun(
 	steps []InstallStep, done, failed bool, current int,
 ) RunResult {
@@ -341,4 +334,15 @@ func RunInstallUnattended(
 		}
 	}
 	return classifyRun(steps, true, false, total), nil
+}
+
+// willRun suppresses a decision screen only when the planner proves its
+// step will be skipped. An absent key conservatively keeps the screen.
+func (r *stepRunner) willRun(key string) bool {
+	for i, s := range r.steps {
+		if s.Key == key {
+			return r.plan[i].Run
+		}
+	}
+	return true
 }

--- a/internal/installer/engine_test.go
+++ b/internal/installer/engine_test.go
@@ -405,14 +405,14 @@ func TestWillRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.willRun(steps, "identity.access") {
+	if r.willRun("identity.access") {
 		t.Error("recorded step reported as will-run")
 	}
-	if !r.willRun(steps, "btc.install") {
+	if !r.willRun("btc.install") {
 		t.Error("unrecorded step reported as skip")
 	}
 	// Unknown key: conservative side is "will run" (screen shows).
-	if !r.willRun(steps, "no.such.key") {
+	if !r.willRun("no.such.key") {
 		t.Error("unknown key reported as skip")
 	}
 }

--- a/internal/installer/identity.go
+++ b/internal/installer/identity.go
@@ -23,7 +23,7 @@ package installer
 //
 // This file owns enumeration (pure parts unit-tested) and the
 // step's apply function; the wizard screens that collect the
-// operator's decisions live in wizard.go.
+// operator's decisions live in internal/tui/install.
 
 import (
 	"fmt"

--- a/internal/installer/identity_test.go
+++ b/internal/installer/identity_test.go
@@ -132,24 +132,6 @@ func TestGenerateAdminPassword(t *testing.T) {
 	}
 }
 
-// ── pasteFirstLine ───────────────────────────────────────
-
-func TestPasteFirstLine(t *testing.T) {
-	cases := []struct{ in, want string }{
-		{"secret-password", "secret-password"},
-		{"  padded  ", "padded"},
-		{"line1\nline2\n", "line1"},
-		{"key data comment\n", "key data comment"},
-		{"\n", ""},
-	}
-	for _, tt := range cases {
-		if got := pasteFirstLine(tt.in); got != tt.want {
-			t.Errorf("pasteFirstLine(%q) = %q, want %q",
-				tt.in, got, tt.want)
-		}
-	}
-}
-
 func TestClassifyAuthorizedKeysReportsMalformedKeys(t *testing.T) {
 	keys, excluded := classifyAuthorizedKeys("ssh-ed25519 YQ== malformed\nssh-dss YQ== obsolete\n" + testKeyA + "\n")
 	if len(keys) != 1 || excluded != 2 {

--- a/internal/installer/interactive.go
+++ b/internal/installer/interactive.go
@@ -1,0 +1,221 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/virtualprivatenode/vpn/internal/loginpassword"
+	"github.com/virtualprivatenode/vpn/internal/sshkeys"
+	"github.com/virtualprivatenode/vpn/internal/system"
+)
+
+// InstallFrontend presents one root installation session. Returning requests
+// a graceful stop; the installer joins admitted work before releasing its lock.
+type InstallFrontend func(InstallView, *InstallSession) (openConsole bool, err error)
+
+// InstallView contains observations and presentation data, never ledger access
+// or executable installation steps.
+type InstallView struct {
+	NeedIdentity, NeedHardware, PasswordAuth bool
+	Sources                                  []KeySource
+	Hardware, Minimum                        Hardware
+	DBCacheChoices                           []int
+	RecommendedDBCache                       int
+	Steps                                    []InstallStepView
+	Address                                  string
+}
+
+// InstallStepView describes a step without granting execution authority.
+type InstallStepView struct {
+	Name   string
+	Status StepStatus
+	Err    error
+}
+
+// InteractiveInput contains the operator's confirmed installation choices.
+type InteractiveInput struct {
+	Keys      []sshkeys.Key
+	Password  loginpassword.Password
+	DBCacheMB int
+}
+
+// InstallEvent reports ordered progress or the engine's terminal outcome.
+type InstallEvent struct {
+	Index         int
+	Status        StepStatus
+	Err           error
+	Final         bool
+	Result        RunResult
+	CompletionErr error
+}
+
+// InstallSession owns one execution, independently of progress consumption.
+// Stop prevents admission of another step; it does not kill an active subprocess
+// or undo its changes. Forced process death still relies on lifecycle resume.
+type InstallSession struct {
+	mu                         sync.Mutex
+	started, stopped           bool
+	runner                     *stepRunner
+	dec                        *InstallDecisions
+	persistDBCache             func(int) error
+	complete                   func() error
+	needIdentity, needHardware bool
+	events                     chan InstallEvent
+	done                       chan struct{}
+	result                     RunResult
+	completionErr              error
+}
+
+func newInstallSession(r *stepRunner, dec *InstallDecisions,
+	persistDBCache func(int) error, complete func() error,
+) *InstallSession {
+	return &InstallSession{
+		runner: r, dec: dec, persistDBCache: persistDBCache, complete: complete,
+		needIdentity: r.willRun("identity.access"),
+		needHardware: r.willRun("btc.install") && r.ledger.Context.DbCacheMB == nil,
+		// Each step emits running and finished, followed by one final event.
+		// A closed or failed frontend cannot block the installation worker.
+		events: make(chan InstallEvent, 2*len(r.steps)+1), done: make(chan struct{}),
+		result: classifyRun(r.steps, false, false, 0),
+	}
+}
+
+// Start validates and freezes choices before admitting the first step. It may
+// be retried after a decision error, but a started or stopped session is final.
+func (s *InstallSession) Start(input InteractiveInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return errors.New("installation stop requested")
+	}
+	if s.started {
+		return errors.New("installation already started")
+	}
+	var keys []sshkeys.Key
+	var password loginpassword.Password
+	if s.needIdentity {
+		var err error
+		password, err = loginpassword.New(input.Password.Text())
+		if err != nil {
+			return err
+		}
+		for _, key := range input.Keys {
+			parsed, err := sshkeys.Parse(key.RawLine)
+			if err != nil {
+				return fmt.Errorf("invalid confirmed SSH key: %w", err)
+			}
+			keys = append(keys, parsed)
+		}
+		keys = DedupeKeys([]KeySource{{Keys: keys}})
+		if len(keys) == 0 && !s.dec.Obs.PasswordAuth {
+			return errors.New("select at least one SSH key while password login is disabled")
+		}
+	}
+	if s.needHardware {
+		if !slices.Contains(dbCacheChoices, input.DBCacheMB) {
+			return errors.New("unsupported database cache choice")
+		}
+		if err := s.persistDBCache(input.DBCacheMB); err != nil {
+			return err
+		}
+	}
+	if s.needIdentity {
+		s.dec.Keys = keys
+		s.dec.Password = password
+	}
+	s.started = true
+	go s.run()
+	return nil
+}
+
+// Stop requests a stop after the admitted step and its ledger publication.
+func (s *InstallSession) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return
+	}
+	s.stopped = true
+	if !s.started {
+		s.events <- InstallEvent{Final: true, Result: s.result}
+		close(s.events)
+		close(s.done)
+	}
+}
+
+// Events supplies one ordered stream for the frontend's single observer.
+func (s *InstallSession) Events() <-chan InstallEvent { return s.events }
+
+func (s *InstallSession) close() (RunResult, error) {
+	s.Stop()
+	<-s.done
+	return s.result, s.completionErr
+}
+
+func (s *InstallSession) run() {
+	defer close(s.done)
+	defer close(s.events)
+	defer func() { s.dec.Password = loginpassword.Password{} }()
+	defer func() { s.events <- InstallEvent{Final: true, Result: s.result, CompletionErr: s.completionErr} }()
+	for i := range s.runner.steps {
+		s.mu.Lock()
+		if s.stopped {
+			s.mu.Unlock()
+			s.result = classifyRun(s.runner.steps, false, false, i)
+			return
+		}
+		s.events <- InstallEvent{Index: i, Status: StepRunning}
+		s.mu.Unlock()
+		skipped, err := s.runner.runIndex(i)
+		status := StepDone
+		if skipped {
+			status = StepSkipped
+		}
+		if err != nil {
+			status = StepFailed
+		}
+		s.runner.steps[i].Status = status
+		s.runner.steps[i].Err = err
+		s.events <- InstallEvent{Index: i, Status: status, Err: err}
+		if err != nil {
+			s.result = classifyRun(s.runner.steps, false, true, i)
+			return
+		}
+	}
+	// Once every step is recorded, finish publication even if observation or
+	// a stop request raced with the last step. Completion is engine-owned.
+	s.result = classifyRun(s.runner.steps, true, false, len(s.runner.steps))
+	if err := s.complete(); err != nil {
+		s.completionErr = fmt.Errorf("install steps complete but finalization failed: %w; run sudo vpn install again to retry", err)
+	}
+}
+
+func runInstallInteractive(s *InstallSession, view InstallView, frontend InstallFrontend) (result RunResult, openConsole bool, err error) {
+	// The join also runs on a frontend panic, before the caller releases its lock.
+	defer func() {
+		var completionErr error
+		result, completionErr = s.close()
+		err = errors.Join(err, completionErr)
+		openConsole = openConsole && err == nil && result.Outcome == RunComplete
+	}()
+	openConsole, err = frontend(view, s)
+	return
+}
+
+func installView(s *InstallSession) InstallView {
+	hw := DetectHardware()
+	view := InstallView{
+		NeedIdentity: s.needIdentity, NeedHardware: s.needHardware,
+		PasswordAuth: s.dec.Obs.PasswordAuth,
+		Sources:      SortKeySources(EnumerateKeySources()), Hardware: hw,
+		Minimum:        Hardware{RAMMB: requiredRAMMB, DiskTotalGB: requiredDiskGB, Cores: requiredCores},
+		DBCacheChoices: slices.Clone(dbCacheChoices), RecommendedDBCache: RecommendDbCache(hw.RAMMB),
+		Address: system.PublicIPv4(),
+	}
+	for _, step := range s.runner.steps {
+		view.Steps = append(view.Steps, InstallStepView{Name: step.Name})
+	}
+	return view
+}

--- a/internal/installer/interactive_test.go
+++ b/internal/installer/interactive_test.go
@@ -1,0 +1,372 @@
+package installer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/virtualprivatenode/vpn/internal/loginpassword"
+	"github.com/virtualprivatenode/vpn/internal/sshkeys"
+)
+
+func interactiveFixture(t *testing.T, steps []InstallStep, complete func() error) (*InstallSession, InteractiveInput) {
+	t.Helper()
+	ledger := testLedger()
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	if err := ledger.save(path); err != nil {
+		t.Fatal(err)
+	}
+	runner, err := newStepRunner(steps, "test", ledger, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := &InstallDecisions{Obs: SSHObservation{PasswordAuth: true}}
+	s := newInstallSession(runner, dec, func(int) error { return errors.New("unexpected cache write") }, complete)
+	pw, err := loginpassword.New("exact-test-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, InteractiveInput{Password: pw}
+}
+
+func TestInteractiveExitJoinsAdmittedStep(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		entered, release := make(chan struct{}), make(chan struct{})
+		laterCalls := 0
+		s, input := interactiveFixture(t, []InstallStep{
+			{Key: "binary.install", Name: "Binary", Fn: func() error { close(entered); <-release; return nil }},
+			{Key: "apt.base", Name: "Packages", Fn: func() error { laterCalls++; return nil }},
+		}, func() error { t.Error("interrupted install finalized"); return nil })
+		uiErr := errors.New("terminal lost")
+		returned := make(chan struct{})
+		var result RunResult
+		var err error
+		var open bool
+		go func() {
+			result, open, err = runInstallInteractive(s, InstallView{}, func(_ InstallView, s *InstallSession) (bool, error) {
+				if err := s.Start(input); err != nil {
+					return false, err
+				}
+				<-entered
+				return true, uiErr
+			})
+			close(returned)
+		}()
+		<-entered
+		synctest.Wait()
+		select {
+		case <-returned:
+			t.Error("frontend exit returned before step settled")
+		default:
+		}
+		ledger, readErr := readLedger(s.runner.ledgerPath)
+		if readErr != nil {
+			t.Error(readErr)
+		} else if ledger.done("binary.install") {
+			t.Error("unfinished step recorded")
+		}
+		close(release)
+		<-returned
+		if result.Outcome != RunInterrupted || result.StepNum != 2 || open || !errors.Is(err, uiErr) {
+			t.Fatalf("exit result=%+v open=%v err=%v", result, open, err)
+		}
+		if laterCalls != 0 || !mustReadLedger(t, s.runner.ledgerPath).done("binary.install") {
+			t.Fatal("stop lost the admitted step or ran a later step")
+		}
+		if err := s.Start(input); err == nil {
+			t.Fatal("stopped session restarted")
+		}
+	})
+}
+
+func TestInteractiveFinalizationDoesNotNeedObserver(t *testing.T) {
+	for _, failCompletion := range []bool{false, true} {
+		t.Run(map[bool]string{false: "success", true: "publication failure"}[failCompletion], func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				calls := 0
+				var completionErr error
+				if failCompletion {
+					completionErr = errors.New("completion publication failed")
+				}
+				var s *InstallSession
+				var input InteractiveInput
+				s, input = interactiveFixture(t, []InstallStep{{Key: "binary.install", Name: "Binary", Fn: func() error { return nil }}}, func() error {
+					calls++
+					ledger, err := readLedger(s.runner.ledgerPath)
+					if err != nil {
+						return err
+					}
+					if !ledger.done("binary.install") {
+						return errors.New("finalization preceded durable step")
+					}
+					return completionErr
+				})
+				if err := s.Start(input); err != nil {
+					t.Fatal(err)
+				}
+				// No progress read may be needed to finish or release the worker.
+				<-s.done
+				result, err := s.close()
+				if result.Outcome != RunComplete || calls != 1 || !errors.Is(err, completionErr) {
+					t.Fatalf("result=%+v calls=%d err=%v", result, calls, err)
+				}
+				var events []InstallEvent
+				for e := range s.Events() {
+					events = append(events, e)
+				}
+				if len(events) != 3 || events[0].Status != StepRunning || events[1].Status != StepDone || !events[2].Final {
+					t.Fatalf("expected running, done, final progress; got %+v", events)
+				}
+				if events[2].Result.Outcome != RunComplete || !errors.Is(events[2].CompletionErr, completionErr) {
+					t.Fatal("final event lost execution or publication result")
+				}
+				if s.dec.Password.Text() != "" {
+					t.Fatal("completed session retained password")
+				}
+			})
+		})
+	}
+}
+
+func TestInteractiveFailureAndPublicationStopExecution(t *testing.T) {
+	for _, publicationFailure := range []bool{false, true} {
+		t.Run(map[bool]string{false: "step failure", true: "ledger failure"}[publicationFailure], func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "not-a-directory")
+			failure := errors.New("step failed")
+			later := 0
+			var s *InstallSession
+			s, input := interactiveFixture(t, []InstallStep{
+				{Key: "binary.install", Name: "Binary", Fn: func() error {
+					if !publicationFailure {
+						return failure
+					}
+					// A file cannot act as the ledger's parent directory.
+					if err := os.WriteFile(parent, []byte("x"), 0600); err != nil {
+						return err
+					}
+					s.runner.ledgerPath = filepath.Join(parent, "ledger.json")
+					return nil
+				}},
+				{Key: "apt.base", Name: "Packages", Fn: func() error { later++; return nil }},
+			}, func() error { t.Error("failed run finalized"); return nil })
+			if err := s.Start(input); err != nil {
+				t.Fatal(err)
+			}
+			<-s.done
+			result, err := s.close()
+			if result.Outcome != RunFailed || result.StepNum != 1 || result.StepName != "Binary" || result.Err == nil || err != nil || later != 0 {
+				t.Fatalf("result=%+v err=%v later=%d", result, err, later)
+			}
+			if !publicationFailure && !errors.Is(result.Err, failure) {
+				t.Fatal("step cause lost")
+			}
+			if publicationFailure && !strings.Contains(result.Err.Error(), "ledger publication failed") {
+				t.Fatal("publication uncertainty lost")
+			}
+		})
+	}
+}
+
+func TestInteractiveInputValidationAndRetry(t *testing.T) {
+	calls, writes := 0, 0
+	s, input := interactiveFixture(t, []InstallStep{{Key: "binary.install", Name: "Binary", Fn: func() error { calls++; return nil }}}, func() error { return nil })
+	s.needHardware = true
+	s.dec.Obs.PasswordAuth = false
+	writeErr := errors.New("cache decision not saved")
+	s.persistDBCache = func(int) error { writes++; return writeErr }
+	key, err := sshkeys.Parse(testKeyA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.Keys = []sshkeys.Key{key}
+	input.DBCacheMB = 512
+	for _, invalid := range []InteractiveInput{
+		{Keys: input.Keys, DBCacheMB: 512},
+		{Password: input.Password, DBCacheMB: 512},
+		{Keys: []sshkeys.Key{{RawLine: "ssh-ed25519 YQ=="}}, Password: input.Password, DBCacheMB: 512},
+		{Keys: input.Keys, Password: input.Password, DBCacheMB: 999},
+	} {
+		if err := s.Start(invalid); err == nil {
+			t.Fatal("invalid decisions accepted")
+		}
+	}
+	if writes != 0 || calls != 0 || s.started {
+		t.Fatal("invalid input crossed mutation boundary")
+	}
+	if err := s.Start(input); !errors.Is(err, writeErr) {
+		t.Fatalf("cache error=%v", err)
+	}
+	if s.started || calls != 0 || s.dec.Password.Text() != "" {
+		t.Fatal("failed decision persistence admitted execution")
+	}
+	s.persistDBCache = func(int) error { writes++; return nil }
+	if err := s.Start(input); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Start(input); err == nil {
+		t.Fatal("duplicate start accepted")
+	}
+	<-s.done
+	if calls != 1 || writes != 2 {
+		t.Fatalf("calls=%d writes=%d", calls, writes)
+	}
+}
+
+func TestInteractiveStopBeforeStartAndLastStepCompletion(t *testing.T) {
+	t.Run("before start", func(t *testing.T) {
+		s, input := interactiveFixture(t, []InstallStep{{Key: "binary.install", Name: "Binary", Fn: func() error { t.Error("stopped step ran"); return nil }}}, func() error { t.Error("stopped run finalized"); return nil })
+		result, open, err := runInstallInteractive(s, InstallView{}, func(InstallView, *InstallSession) (bool, error) { return true, nil })
+		if result.Outcome != RunInterrupted || open || err != nil {
+			t.Fatalf("result=%+v open=%v err=%v", result, open, err)
+		}
+		if err := s.Start(input); err == nil {
+			t.Fatal("delayed start accepted after frontend exit")
+		}
+		s.Stop()
+		final, ok := <-s.Events()
+		if !ok || !final.Final || final.Result.Outcome != RunInterrupted {
+			t.Fatal("early exit left an observer without a terminal result")
+		}
+		if _, ok := <-s.Events(); ok {
+			t.Fatal("early-exit result stream stayed open")
+		}
+	})
+	t.Run("last admitted step", func(t *testing.T) {
+		finalized := 0
+		var s *InstallSession
+		s, input := interactiveFixture(t, []InstallStep{{Key: "binary.install", Name: "Binary", Fn: func() error { s.Stop(); return nil }}}, func() error { finalized++; return nil })
+		if err := s.Start(input); err != nil {
+			t.Fatal(err)
+		}
+		<-s.done
+		result, err := s.close()
+		if result.Outcome != RunComplete || finalized != 1 || err != nil {
+			t.Fatalf("last-step result=%+v finalized=%d err=%v", result, finalized, err)
+		}
+	})
+}
+
+func TestInteractiveResumeExecutesGateAndPublishesSkips(t *testing.T) {
+	calls := make(map[string]int)
+	steps := testSteps(calls)
+	ledger := testLedger()
+	// Resume after identity: mutations and the completed pipeline stay saved,
+	// but this pass must recheck its gate before reaching the remaining step.
+	for _, step := range steps[:6] {
+		if err := ledger.markDone(step.Key, "previous"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	if err := ledger.save(path); err != nil {
+		t.Fatal(err)
+	}
+	runner, err := newStepRunner(steps, "candidate", ledger, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalized := 0
+	s := newInstallSession(runner, &InstallDecisions{},
+		func(int) error { t.Error("resume overwrote cache choice"); return nil },
+		func() error { finalized++; return nil })
+	if s.needIdentity || s.needHardware {
+		t.Fatal("resume requested previously recorded choices")
+	}
+	if err := s.Start(InteractiveInput{}); err != nil {
+		t.Fatal(err)
+	}
+	<-s.done
+	result, err := s.close()
+	if err != nil || result.Outcome != RunComplete || finalized != 1 {
+		t.Fatalf("result=%+v finalized=%d err=%v", result, finalized, err)
+	}
+	skips := 0
+	for e := range s.Events() {
+		if !e.Final && e.Status == StepSkipped {
+			skips++
+		}
+	}
+	if skips != 5 || len(calls) != 2 || calls["firewall"] != 1 || calls["service-identities.v1"] != 1 {
+		t.Fatalf("resume skips=%d calls=%v", skips, calls)
+	}
+	if !mustReadLedger(t, path).done("service-identities.v1") {
+		t.Fatal("resume did not publish remaining progress")
+	}
+}
+
+func TestRootRunInstallExitRetainsRunLock(t *testing.T) {
+	requireRootTestEnvironment(t)
+	f := newLifecycleFixture(t)
+	ledger := f.initialize(t)
+	if err := ledger.setDbCache(512); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.save(f.fs.ledger); err != nil {
+		t.Fatal(err)
+	}
+	installStartupFixture(t, f, func() (SSHObservation, error) {
+		return SSHObservation{PasswordAuth: true}, nil
+	})
+	deps := newInstallStartupDependencies()
+	password, err := loginpassword.New("exact-test-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	synctest.Test(t, func(t *testing.T) {
+		entered, release := make(chan struct{}), make(chan struct{})
+		returned := make(chan error, 1)
+		uiErr := errors.New("terminal lost")
+		go func() {
+			returned <- RunInstall(InstallOptions{}, func(_ InstallView, s *InstallSession) (bool, error) {
+				// Exercise the production coordinator and lock, replacing only host
+				// mutations and redirecting progress to the temporary lifecycle.
+				s.runner.ledgerPath = f.fs.ledger
+				s.persistDBCache = func(int) error { return errors.New("unexpected cache write") }
+				s.complete = func() error {
+					t.Error("interrupted install finalized")
+					return errors.New("unexpected finalization")
+				}
+				for i := range s.runner.steps {
+					s.runner.steps[i].Fn = func() error {
+						t.Error("stop admitted a later step")
+						return errors.New("unexpected host step")
+					}
+				}
+				s.runner.steps[0].Fn = func() error { close(entered); <-release; return nil }
+				if err := s.Start(InteractiveInput{Password: password}); err != nil {
+					return false, err
+				}
+				<-entered
+				return false, uiErr
+			})
+		}()
+		select {
+		case <-entered:
+		case err := <-returned:
+			t.Fatalf("installation never entered the held step: %v", err)
+		}
+		synctest.Wait()
+		other, err := acquireRunLock(deps.runtimeDir, deps.installLock)
+		if err == nil {
+			other.Close()
+			t.Error("RunInstall released its lock before admitted work settled")
+		} else if !strings.Contains(err.Error(), "already running") {
+			t.Error(err)
+		}
+		close(release)
+		if err := <-returned; !errors.Is(err, uiErr) {
+			t.Fatalf("frontend error lost: %v", err)
+		}
+		if !mustReadLedger(t, f.fs.ledger).done("binary.install") {
+			t.Fatal("RunInstall returned before publishing admitted work")
+		}
+		other, err = acquireRunLock(deps.runtimeDir, deps.installLock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		other.Close()
+	})
+}

--- a/internal/installer/preflight.go
+++ b/internal/installer/preflight.go
@@ -39,6 +39,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/virtualprivatenode/vpn/internal/logger"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/system"
@@ -433,7 +435,7 @@ func FormatPreflightReport(results []PreflightResult) string {
 		}
 		failed++
 		fmt.Fprintf(&b, "    [FAIL] %s\n", r.Name)
-		for _, line := range wrapText(r.Err.Error(), 56) {
+		for _, line := range strings.Split(ansi.Wordwrap(r.Err.Error(), 56, ""), "\n") {
 			fmt.Fprintf(&b, "           %s\n", line)
 		}
 	}
@@ -442,24 +444,4 @@ func FormatPreflightReport(results []PreflightResult) string {
 			"system has been changed.\n")
 	}
 	return b.String()
-}
-
-// wrapText word-wraps s to width columns. Words longer than width
-// get their own line, unbroken. Pure — unit-tested.
-func wrapText(s string, width int) []string {
-	words := strings.Fields(s)
-	if len(words) == 0 {
-		return nil
-	}
-	var lines []string
-	cur := words[0]
-	for _, w := range words[1:] {
-		if len(cur)+1+len(w) <= width {
-			cur += " " + w
-			continue
-		}
-		lines = append(lines, cur)
-		cur = w
-	}
-	return append(lines, cur)
 }

--- a/internal/installer/preflight_test.go
+++ b/internal/installer/preflight_test.go
@@ -252,35 +252,6 @@ func TestFormatPreflightReportWithFailure(t *testing.T) {
 	}
 }
 
-// ── wrapText ─────────────────────────────────────────────
-
-func TestWrapText(t *testing.T) {
-	lines := wrapText("aa bb cc dd", 5)
-	want := []string{"aa bb", "cc dd"}
-	if len(lines) != len(want) {
-		t.Fatalf("got %d lines %v, want %v", len(lines), lines, want)
-	}
-	for i := range want {
-		if lines[i] != want[i] {
-			t.Errorf("line %d: got %q, want %q", i, lines[i], want[i])
-		}
-	}
-	if got := wrapText("", 10); got != nil {
-		t.Errorf("empty input: got %v, want nil", got)
-	}
-	// A word longer than the width gets its own unbroken line.
-	long := wrapText("short averyverylongword end", 6)
-	found := false
-	for _, l := range long {
-		if l == "averyverylongword" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("long word split or lost: %v", long)
-	}
-}
-
 // ── check names are stable report labels ─────────────────
 
 func TestPreflightCheckNamesNonEmpty(t *testing.T) {

--- a/internal/installer/setup.go
+++ b/internal/installer/setup.go
@@ -43,11 +43,9 @@ func SyncthingVersionStr() string { return syncthingVersion }
 // implicit flow.
 //
 // The step model, resume planner, and step runner live in
-// engine.go; the ledger in ledger.go; the interactive front-end
-// (wizard screens + step renderer) in wizard.go. Front-ends are
-// thin: they render what the runner reports and make no skip or
-// record decisions of their own, so the TUI and the unattended
-// runner cannot diverge.
+// engine.go; the ledger in ledger.go; the interactive session
+// in interactive.go; and presentation in internal/tui/install.
+// The TUI submits choices and observes the engine's progress.
 
 // InstallOptions carries the `vpn install` command line.
 type InstallOptions struct {
@@ -105,7 +103,7 @@ func productionInstallStartupDependencies() installStartupDependencies {
 var newInstallStartupDependencies = productionInstallStartupDependencies
 
 // RunInstall is the `sudo vpn install` entry point.
-func RunInstall(opts InstallOptions) error {
+func RunInstall(opts InstallOptions, frontend InstallFrontend) error {
 	if os.Geteuid() != 0 {
 		return errors.New(
 			"the installer must run as root — run: sudo vpn install")
@@ -146,6 +144,10 @@ func RunInstall(opts InstallOptions) error {
 		!opts.Unattended && passwordPending() {
 		return errors.New(
 			"an interrupted unattended install still owes password delivery — resume with: sudo vpn install --unattended")
+	}
+
+	if !opts.Unattended && frontend == nil {
+		return errors.New("interactive installation requires a frontend")
 	}
 
 	// Preflight is read-only and precedes every durable initialization.
@@ -253,9 +255,12 @@ func RunInstall(opts InstallOptions) error {
 		res, err = RunInstallUnattended(
 			steps, appVersion, ledger, paths.InstallStateFile)
 	} else {
-		res, openConsole, err = runInstallWizard(
-			cfg, steps, dec, appVersion, ledger,
-			persistDbCache, completeInteractive)
+		runner, runnerErr := newStepRunner(steps, appVersion, ledger, paths.InstallStateFile)
+		if runnerErr != nil {
+			return runnerErr
+		}
+		session := newInstallSession(runner, dec, persistDbCache, completeInteractive)
+		res, openConsole, err = runInstallInteractive(session, installView(session), frontend)
 	}
 	if err != nil {
 		return err

--- a/internal/installer/setup_test.go
+++ b/internal/installer/setup_test.go
@@ -170,7 +170,7 @@ func TestRootRunInstallEarlyExitsDoNotMutateProtectedState(t *testing.T) {
 			})
 
 		output, err := captureRunInstallOutput(t, func() error {
-			return RunInstall(InstallOptions{})
+			return RunInstall(InstallOptions{}, unexpectedInstallFrontend(t))
 		})
 		if err != nil {
 			t.Fatalf("completed install refused: %v", err)
@@ -229,7 +229,7 @@ func TestRootRunInstallEarlyExitsDoNotMutateProtectedState(t *testing.T) {
 					return SSHObservation{}, errors.New("unexpected preflight")
 				})
 
-			if err := RunInstall(InstallOptions{}); err == nil {
+			if err := RunInstall(InstallOptions{}, unexpectedInstallFrontend(t)); err == nil {
 				t.Fatal("unsafe or conflicting installation state accepted")
 			}
 			if *preflightCalls != 0 || *initializeCalls != 0 {
@@ -252,7 +252,7 @@ func TestRootRunInstallEarlyExitsDoNotMutateProtectedState(t *testing.T) {
 				return SSHObservation{}, checkArchitecture("arm64")
 			})
 
-		err := RunInstall(InstallOptions{})
+		err := RunInstall(InstallOptions{}, unexpectedInstallFrontend(t))
 		if err == nil || !strings.Contains(err.Error(), "amd64 only") {
 			t.Fatalf("unsupported architecture error=%v", err)
 		}
@@ -425,3 +425,11 @@ func TestShellWrapperNetworkFlags(t *testing.T) {
 // (TestCheckOSRelease*), against the preflight's exactly-13 rule.
 // The NeedsInstall tests died with NeedsInstall itself: commit 6
 // replaced state-sniffing with explicit dispatch (IA-1-8).
+
+func unexpectedInstallFrontend(t *testing.T) InstallFrontend {
+	t.Helper()
+	return func(InstallView, *InstallSession) (bool, error) {
+		t.Error("early exit reached interactive frontend")
+		return false, nil
+	}
+}

--- a/internal/tui/install/wizard.go
+++ b/internal/tui/install/wizard.go
@@ -1,30 +1,5 @@
-// internal/installer/wizard.go
-
-package installer
-
-// The interactive `vpn install` front-end: the ruling-vii
-// identity/access screen, the ruling-viii hardware-fit screen,
-// and the step-progress renderer, flowing into the completion
-// handoff. Born in the unified chrome (ruling xvi(d)): theme
-// styles and the step-renderer visual language of the post-
-// install TUI — but chrome only, NO ScreenContext/lifecycle
-// adoption (the C′ boundary holds; this front-end stays a thin
-// driver of the commit-5 engine, making no skip or record
-// decisions of its own).
-//
-// Step-render semantics (ratified, xvi(d)): DIM rows are
-// believed-from-ledger (a prior pass completed them — [skip]);
-// BRIGHT rows executed or verified THIS pass. Gates always
-// re-run, so gates are always bright.
-//
-// Navigation is buttons-over-keys (operator ruling at the
-// commit-6 live run): every screen that can go back has a Back
-// button; no esc bindings (esc is unmapped in the rest of the
-// TUI); each screen carries a dim hint line naming its keys.
-//
-// Completion is PERSISTED the moment the last step verifies —
-// before the done screen waits for Enter (live-run finding: the
-// terminal ledger status is published before the done screen can sit unattended).
+// Package install presents the root installation workflow.
+package install
 
 import (
 	"fmt"
@@ -33,12 +8,12 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
-	"github.com/virtualprivatenode/vpn/internal/config"
+	"github.com/virtualprivatenode/vpn/internal/installer"
 	"github.com/virtualprivatenode/vpn/internal/loginpassword"
 	"github.com/virtualprivatenode/vpn/internal/paths"
 	"github.com/virtualprivatenode/vpn/internal/sshkeys"
-	"github.com/virtualprivatenode/vpn/internal/system"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
 
@@ -53,121 +28,74 @@ const (
 	wzDone
 )
 
-type wizardStepDoneMsg struct {
-	index   int
-	skipped bool
-	err     error
+type wizardStartMsg struct{ err error }
+type wizardProgressMsg struct {
+	event installer.InstallEvent
+	ok    bool
+}
+type installSession interface {
+	Start(installer.InteractiveInput) error
+	Stop()
+	Events() <-chan installer.InstallEvent
 }
 
 type wizardModel struct {
-	cfg     *config.AppConfig
-	dec     *InstallDecisions
-	steps   []InstallStep
-	runner  *stepRunner
-	version string
-
-	// onComplete persists the completion record; runs once,
-	// as soon as the last step verifies (before the done
-	// screen). Its error renders on the done screen and fails
-	// the run.
-	onComplete     func() error
-	completeErr    string
-	persistDbCache func(int) error
+	info        installer.InstallView
+	session     installSession
+	input       installer.InteractiveInput
+	steps       []installer.InstallStepView
+	completeErr string
+	stopping    bool
 
 	phase         wizardPhase
 	width, height int
 
-	needIdentity bool
-	needHardware bool
-
-	// Access screen
-	sources  []KeySource
 	keys     []sshkeys.Key
 	selected []bool
 	cursor   int // 0..len(keys)-1 = key rows; len(keys) = button row
 	btnIdx   int // 0 = Continue, 1 = Paste a key
 	accErr   string
 
-	// Paste screen
 	pasteInput textinput.Model
 	pasteFocus int // 0 = input, 1 = buttons
 	pasteBtn   int // 0 = Back, 1 = Add key
 	pasteErr   string
 
-	// Password screen
 	pwInput   textinput.Model
 	pwConfirm textinput.Model
 	pwFocus   int // 0 = new, 1 = confirm, 2 = buttons
 	pwBtn     int // 0 = Back, 1 = Continue
 	pwErr     string
 
-	// Hardware screen
-	hw      Hardware
 	dbIdx   int
 	hwFocus int // 0 = dbcache selector, 1 = buttons
 	hwBtn   int // index into hwButtons()
 	hwErr   string
 
-	// Steps
-	current           int
-	stepsDone, failed bool
+	failed bool
 
-	// openConsole records the operator's CHOICE on the done
-	// screen: Enter = open the node TUI (handoff), ctrl+c
-	// = just exit. The live run caught the two paths behaving
-	// identically — the hint promised an exit that handed off
-	// anyway.
 	openConsole bool
 }
 
-func newWizardModel(
-	cfg *config.AppConfig, steps []InstallStep,
-	runner *stepRunner, dec *InstallDecisions, version string,
-	persistDbCache func(int) error, onComplete func() error,
-) wizardModel {
-	m := wizardModel{
-		cfg: cfg, dec: dec, steps: steps,
-		runner: runner, version: version,
-		persistDbCache: persistDbCache,
-		onComplete:     onComplete,
-	}
-
-	// Resume-aware screen skipping: a screen exists to collect
-	// decisions for a step; if the ledger says that step is
-	// complete, re-asking would collect answers nothing will
-	// apply. (Residual, accepted: an interrupted run that
-	// resumes past the btc group keeps bitcoin.conf from the
-	// earlier pass while dbcache is re-persisted only at
-	// completion — present-correctness is the doctor check's
-	// question, not resume's.)
-	m.needIdentity = runner.willRun(steps, "identity.access")
-	m.needHardware = runner.willRun(steps, "btc.install") &&
-		runner.ledger.Context.DbCacheMB == nil
-
-	m.sources = SortKeySources(EnumerateKeySources())
-	m.keys = DedupeKeys(m.sources)
+func newWizardModel(info installer.InstallView, session installSession) wizardModel {
+	m := wizardModel{info: info, session: session, steps: info.Steps}
+	m.keys = installer.DedupeKeys(m.info.Sources)
 	m.selected = make([]bool, len(m.keys))
 	for i := range m.selected {
 		m.selected[i] = true
 	}
-
-	m.pasteInput = newWizardInput(
-		"ssh-ed25519 AAAA... comment", 1000, 56)
+	m.pasteInput = newWizardInput("ssh-ed25519 AAAA... comment", 1000, 56)
 	m.pwInput = newWizardPasswordInput()
 	m.pwConfirm = newWizardPasswordInput()
-
-	m.hw = DetectHardware()
-	rec := RecommendDbCache(m.hw.RAMMB)
-	for i, v := range dbCacheChoices {
-		if v == rec {
+	for i, v := range info.DBCacheChoices {
+		if v == info.RecommendedDBCache {
 			m.dbIdx = i
 		}
 	}
-
 	switch {
-	case m.needIdentity:
+	case m.info.NeedIdentity:
 		m.phase = wzAccess
-	case m.needHardware:
+	case m.info.NeedHardware:
 		m.phase = wzHardware
 	default:
 		m.phase = wzSteps
@@ -194,16 +122,12 @@ func newWizardPasswordInput() textinput.Model {
 	return ti
 }
 
-// pasteFirstLine normalizes pasted text for a single-line
-// input: first line only, trimmed. Pure — unit-tested.
 func pasteFirstLine(content string) string {
 	if idx := strings.IndexByte(content, '\n'); idx >= 0 {
 		content = content[:idx]
 	}
 	return strings.TrimSpace(content)
 }
-
-// ── tea.Model ────────────────────────────────────────────
 
 func (m wizardModel) Init() tea.Cmd {
 	if m.phase == wzSteps {
@@ -212,23 +136,16 @@ func (m wizardModel) Init() tea.Cmd {
 	return nil
 }
 
+// A start resolves before input is enabled again. Success starts one reader
+// of the ordered progress stream; there are no overlapping attempts.
 func (m wizardModel) startSteps() tea.Cmd {
-	if len(m.steps) == 0 {
-		return tea.Quit
-	}
-	m.steps[0].Status = StepRunning
-	return m.runStep(0)
+	session, input := m.session, m.input
+	return func() tea.Msg { return wizardStartMsg{err: session.Start(input)} }
 }
 
-func (m wizardModel) runStep(i int) tea.Cmd {
-	return func() tea.Msg {
-		if i >= len(m.steps) {
-			return wizardStepDoneMsg{index: i}
-		}
-		skipped, err := m.runner.runIndex(i)
-		return wizardStepDoneMsg{
-			index: i, skipped: skipped, err: err}
-	}
+func (m wizardModel) waitProgress() tea.Cmd {
+	events := m.session.Events()
+	return func() tea.Msg { e, ok := <-events; return wizardProgressMsg{event: e, ok: ok} }
 }
 
 func (m wizardModel) Update(
@@ -240,22 +157,40 @@ func (m wizardModel) Update(
 		m.height = msg.Height
 		return m, nil
 
-	case wizardStepDoneMsg:
+	case wizardStartMsg:
+		if m.phase != wzSteps {
+			return m, nil
+		}
+		if msg.err != nil {
+			if m.stopping {
+				return m, tea.Quit
+			}
+			if m.info.NeedHardware {
+				m.phase = wzHardware
+				m.hwErr = msg.err.Error()
+			} else {
+				m.phase = wzPassword
+				m.pwErr = msg.err.Error()
+			}
+			return m, nil
+		}
+		m.input.Password = loginpassword.Password{}
+		m.pwInput.Reset()
+		m.pwConfirm.Reset()
+		return m, m.waitProgress()
+	case wizardProgressMsg:
 		return m.updateSteps(msg)
 
 	case tea.PasteMsg:
-		// Terminal paste — routed to the focused input (the
-		// live-run finding: keypress-only routing silently
-		// dropped pasted keys and passwords).
 		return m.handlePaste(msg)
 
 	case tea.KeyPressMsg:
-		// Quitting is allowed at any instant — an interrupt is
-		// SAFE (the ledger records a step only after it
-		// verified complete) and HONEST (a quit before all
-		// steps ran classifies as interrupted, never complete —
-		// IA-1-9).
 		if msg.String() == "ctrl+c" {
+			if m.phase == wzSteps {
+				m.stopping = true
+				m.session.Stop()
+				return m, nil
+			}
 			return m, tea.Quit
 		}
 		switch m.phase {
@@ -281,22 +216,26 @@ func (m wizardModel) Update(
 func (m wizardModel) handlePaste(
 	msg tea.PasteMsg,
 ) (tea.Model, tea.Cmd) {
-	line := pasteFirstLine(msg.Content)
 	switch {
 	case m.phase == wzPaste && m.pasteFocus == 0:
-		m.pasteInput.SetValue(line)
+		m.pasteInput.SetValue(pasteFirstLine(msg.Content))
 		m.pasteErr = ""
-	case m.phase == wzPassword && m.pwFocus == 0:
-		m.pwInput.SetValue(line)
-		m.pwErr = ""
-	case m.phase == wzPassword && m.pwFocus == 1:
-		m.pwConfirm.SetValue(line)
-		m.pwErr = ""
+	case m.phase == wzPassword && m.pwFocus < 2:
+		input := &m.pwInput
+		if m.pwFocus == 1 {
+			input = &m.pwConfirm
+		}
+		value := strings.TrimSuffix(msg.Content, "\n")
+		input.SetValue(value)
+		if input.Value() != value {
+			input.Reset()
+			m.pwErr = "Paste rejected and field cleared: unsupported characters or more than 128 characters."
+		} else {
+			m.pwErr = ""
+		}
 	}
 	return m, nil
 }
-
-// ── Access screen ────────────────────────────────────────
 
 func (m wizardModel) updateAccess(
 	msg tea.KeyPressMsg,
@@ -312,12 +251,10 @@ func (m wizardModel) updateAccess(
 			m.cursor++
 		}
 	case "left":
-		m.hwErr = ""
 		if m.cursor == last && m.btnIdx > 0 {
 			m.btnIdx--
 		}
 	case "right":
-		m.hwErr = ""
 		if m.cursor == last && m.btnIdx < 1 {
 			m.btnIdx++
 		}
@@ -341,24 +278,20 @@ func (m wizardModel) updateAccess(
 			m.phase = wzPaste
 			return m, nil
 		}
-		// Continue: collect selection; refuse a zero-auth
-		// outcome (no keys AND password auth observed off —
-		// the drop-in will carry that "off" forward, so the
-		// admin user would have no network way in at all).
 		var chosen []sshkeys.Key
 		for i, k := range m.keys {
 			if m.selected[i] {
 				chosen = append(chosen, k)
 			}
 		}
-		if len(chosen) == 0 && !m.dec.Obs.PasswordAuth {
+		if len(chosen) == 0 && !m.info.PasswordAuth {
 			m.accErr = "Password login is disabled on this " +
 				"box. Select or paste at least one key, or " +
 				"the " + paths.AdminUser +
 				" user would have no way in over SSH."
 			return m, nil
 		}
-		m.dec.Keys = chosen
+		m.input.Keys = chosen
 		m.enterPasswordScreen()
 		return m, nil
 	}
@@ -412,7 +345,7 @@ func (m wizardModel) viewAccess(p *wizPane) {
 		detail += "  [" + m.keySourceNames(k.Fingerprint) + "]"
 		p.dim(detail)
 	}
-	for _, s := range m.sources {
+	for _, s := range m.info.Sources {
 		if s.Excluded > 0 {
 			p.dim(fmt.Sprintf(
 				"   %d provider control line(s) in %s excluded,"+
@@ -431,11 +364,9 @@ func (m wizardModel) viewAccess(p *wizPane) {
 		"left/right: choose button   enter: select")
 }
 
-// keySourceNames lists which enumerated files carried this
-// fingerprint (e.g. "root, debian").
 func (m wizardModel) keySourceNames(fingerprint string) string {
 	var names []string
-	for _, s := range m.sources {
+	for _, s := range m.info.Sources {
 		for _, k := range s.Keys {
 			if k.Fingerprint == fingerprint {
 				names = append(names, s.User)
@@ -448,8 +379,6 @@ func (m wizardModel) keySourceNames(fingerprint string) string {
 	}
 	return strings.Join(names, ", ")
 }
-
-// ── Paste screen ─────────────────────────────────────────
 
 func (m wizardModel) updatePaste(
 	msg tea.KeyPressMsg,
@@ -479,11 +408,9 @@ func (m wizardModel) updatePaste(
 		}
 	case "enter":
 		if m.pasteFocus == 1 && m.pasteBtn == 0 {
-			// Back — nothing kept.
 			m.phase = wzAccess
 			return m, nil
 		}
-		// Add key (from the button, or enter in the input).
 		line := strings.TrimSpace(m.pasteInput.Value())
 		info, err := sshkeys.Parse(line)
 		if err != nil {
@@ -531,8 +458,6 @@ func (m wizardModel) viewPaste(p *wizPane) {
 		"left/right: choose button   enter: select")
 }
 
-// ── Password screen ──────────────────────────────────────
-
 func (m wizardModel) updatePassword(
 	msg tea.KeyPressMsg,
 ) (tea.Model, tea.Cmd) {
@@ -566,12 +491,9 @@ func (m wizardModel) updatePassword(
 			return m, nil
 		}
 		if m.pwBtn == 0 {
-			// Back to the access screen (selections kept).
 			m.phase = wzAccess
 			return m, nil
 		}
-		// Continue. Non-skippable by construction: the only
-		// forward button validates.
 		if m.pwInput.Value() != m.pwConfirm.Value() {
 			m.pwErr = "Passwords do not match."
 			return m, nil
@@ -581,9 +503,9 @@ func (m wizardModel) updatePassword(
 			m.pwErr = err.Error() + "."
 			return m, nil
 		}
-		m.dec.Password = pw
+		m.input.Password = pw
 		m.pwErr = ""
-		if m.needHardware {
+		if m.info.NeedHardware {
 			m.hwFocus = 1
 			m.hwBtn = len(m.hwButtons()) - 1
 			m.phase = wzHardware
@@ -619,14 +541,7 @@ func (m *wizardModel) syncPwFocus() {
 func (m wizardModel) viewPassword(p *wizPane) {
 	p.header("Login password")
 	p.blank()
-	// State-aware copy from the preflight observation (ruling
-	// xvi, vii refinement): say what this credential IS on this
-	// box; never assert what cannot be verified (ruling-xi
-	// discipline). The prompt is NON-SKIPPABLE: post-commit-7
-	// the admin user is the box's only interactive identity,
-	// and without a password a broken SSH setup leaves only
-	// rescue mode.
-	if m.dec.Obs.PasswordAuth {
+	if m.info.PasswordAuth {
 		p.text("Set the login password for '" +
 			paths.AdminUser + "'. Password login over SSH is " +
 			"currently enabled on this box, so this password " +
@@ -650,11 +565,11 @@ func (m wizardModel) viewPassword(p *wizPane) {
 
 	p.input("Password:", m.pwInput.View(), m.pwFocus == 0)
 	if n := len(m.pwInput.Value()); n > 0 {
-		p.dim(fmt.Sprintf("   (%d chars)", n))
+		p.dim(fmt.Sprintf("   (%d bytes)", n))
 	}
 	p.input("Confirm: ", m.pwConfirm.View(), m.pwFocus == 1)
 	if n := len(m.pwConfirm.Value()); n > 0 {
-		p.dim(fmt.Sprintf("   (%d chars)", n))
+		p.dim(fmt.Sprintf("   (%d bytes)", n))
 	}
 	if m.pwErr != "" {
 		p.blank()
@@ -668,13 +583,8 @@ func (m wizardModel) viewPassword(p *wizPane) {
 		"enter: select   paste works in both fields")
 }
 
-// ── Hardware screen ──────────────────────────────────────
-
-// hwButtons: Back only exists when the identity flow ran ahead
-// of this screen (otherwise this is the first screen and there
-// is nothing to go back to).
 func (m wizardModel) hwButtons() []string {
-	if m.needIdentity {
+	if m.info.NeedIdentity {
 		return []string{"Back", "Start install"}
 	}
 	return []string{"Start install"}
@@ -702,7 +612,7 @@ func (m wizardModel) updateHardware(
 			m.hwBtn--
 		}
 	case "right":
-		if m.hwFocus == 0 && m.dbIdx < len(dbCacheChoices)-1 {
+		if m.hwFocus == 0 && m.dbIdx < len(m.info.DBCacheChoices)-1 {
 			m.dbIdx++
 		}
 		if m.hwFocus == 1 && m.hwBtn < len(btns)-1 {
@@ -715,19 +625,11 @@ func (m wizardModel) updateHardware(
 			return m, nil
 		}
 		if len(btns) == 2 && m.hwBtn == 0 {
-			// Back to the password screen.
 			m.enterPasswordScreen()
 			return m, nil
 		}
-		selected := dbCacheChoices[m.dbIdx]
-		if m.persistDbCache != nil {
-			if err := m.persistDbCache(selected); err != nil {
-				m.hwErr = err.Error()
-				return m, nil
-			}
-		}
-		m.dec.DbCacheMB = selected
-		m.cfg.DbCache = m.dec.DbCacheMB
+		selected := m.info.DBCacheChoices[m.dbIdx]
+		m.input.DBCacheMB = selected
 		m.phase = wzSteps
 		return m, m.startSteps()
 	}
@@ -751,29 +653,29 @@ func (m wizardModel) viewHardware(p *wizPane) {
 	p.blank()
 
 	ram := "unknown"
-	if m.hw.RAMMB > 0 {
+	if m.info.Hardware.RAMMB > 0 {
 		ram = fmt.Sprintf("%.1f GB, %s",
-			float64(m.hw.RAMMB)/1024,
-			fitMark(m.hw.RAMMB >= requiredRAMMB))
+			float64(m.info.Hardware.RAMMB)/1024,
+			fitMark(m.info.Hardware.RAMMB >= m.info.Minimum.RAMMB))
 	}
 	disk := "unknown"
-	if m.hw.DiskTotalGB > 0 {
+	if m.info.Hardware.DiskTotalGB > 0 {
 		disk = fmt.Sprintf("%d GB total, %d GB free, %s",
-			m.hw.DiskTotalGB, m.hw.DiskFreeGB,
-			fitMark(m.hw.DiskTotalGB >= requiredDiskGB))
+			m.info.Hardware.DiskTotalGB, m.info.Hardware.DiskFreeGB,
+			fitMark(m.info.Hardware.DiskTotalGB >= m.info.Minimum.DiskTotalGB))
 	}
 	p.kv("Memory (RAM)", ram)
 	p.kv("Disk", disk)
-	p.kv("CPU", fmt.Sprintf("%d cores, %s", m.hw.Cores,
-		fitMark(m.hw.Cores >= requiredCores)))
+	p.kv("CPU", fmt.Sprintf("%d cores, %s", m.info.Hardware.Cores,
+		fitMark(m.info.Hardware.Cores >= m.info.Minimum.Cores)))
 	p.blank()
 
-	rec := RecommendDbCache(m.hw.RAMMB)
+	rec := m.info.RecommendedDBCache
 	p.text("Bitcoin Core database cache (dbcache). Larger is " +
 		"faster for the initial sync; it must leave room for " +
 		"LND and Tor.")
 	p.blank()
-	choice := fmt.Sprintf("  ◂ %4d MB ▸", dbCacheChoices[m.dbIdx])
+	choice := fmt.Sprintf("  ◂ %4d MB ▸", m.info.DBCacheChoices[m.dbIdx])
 	sty := theme.Value
 	if m.hwFocus == 0 {
 		sty = theme.Action
@@ -791,72 +693,55 @@ func (m wizardModel) viewHardware(p *wizPane) {
 		"adjust or choose   enter: select")
 }
 
-// ── Steps phase ──────────────────────────────────────────
-
-func (m wizardModel) updateSteps(
-	msg wizardStepDoneMsg,
-) (tea.Model, tea.Cmd) {
-	if msg.index >= len(m.steps) {
+func (m wizardModel) updateSteps(msg wizardProgressMsg) (tea.Model, tea.Cmd) {
+	if m.phase != wzSteps {
 		return m, nil
 	}
-	if msg.err != nil {
-		m.steps[msg.index].Status = StepFailed
-		m.steps[msg.index].Err = msg.err
-		m.failed = true
-		m.stepsDone = true
+	if !msg.ok {
+		m.completeErr = "Installation observation ended without a final result."
 		m.phase = wzDone
 		return m, nil
 	}
-	if msg.skipped {
-		m.steps[msg.index].Status = StepSkipped
-	} else {
-		m.steps[msg.index].Status = StepDone
-	}
-	next := msg.index + 1
-	if next < len(m.steps) {
-		m.current = next
-		m.steps[next].Status = StepRunning
-		return m, m.runStep(next)
-	}
-	// Last step verified — persist completion NOW, before the
-	// done screen waits for the operator (who may be away for
-	// minutes, or whose connection may drop).
-	m.stepsDone = true
-	if m.onComplete != nil {
-		if err := m.onComplete(); err != nil {
-			m.completeErr = err.Error()
+	e := msg.event
+	if e.Final {
+		m.failed = e.Result.Outcome == installer.RunFailed
+		if e.CompletionErr != nil {
+			m.completeErr = e.CompletionErr.Error()
 		}
+		m.phase = wzDone
+		if m.stopping || e.Result.Outcome == installer.RunInterrupted {
+			return m, tea.Quit
+		}
+		return m, nil
 	}
-	m.phase = wzDone
-	return m, nil
+	if e.Index < 0 || e.Index >= len(m.steps) {
+		return m, nil
+	}
+	m.steps[e.Index].Status = e.Status
+	m.steps[e.Index].Err = e.Err
+	return m, m.waitProgress()
 }
 
-// renderStepRows renders the step list in the ratified
-// dim/bright language. Shared shape with the post-install TUI's
-// step renderer: dim = believed-from-ledger, bright = this pass,
-// gates always bright (they always run).
-func renderStepRows(p *wizPane, steps []InstallStep) {
+func renderStepRows(p *wizPane, steps []installer.InstallStepView) {
 	total := len(steps)
 	for i, s := range steps {
 		var sty lipgloss.Style
 		var ind string
 		switch s.Status {
-		case StepDone:
+		case installer.StepDone:
 			sty, ind = theme.Value, "[done]"
-		case StepRunning:
+		case installer.StepRunning:
 			sty, ind = theme.Action, "[....]"
-		case StepFailed:
+		case installer.StepFailed:
 			sty, ind = theme.Warning, "[FAIL]"
-		case StepSkipped:
-			// Believed-from-ledger: completed by an earlier
-			// pass, not executed now.
+		case installer.StepSkipped:
 			sty, ind = theme.Dim, "[skip]"
 		default:
 			sty, ind = theme.Grayed, "[wait]"
 		}
 		p.line(" " + sty.Render(fmt.Sprintf(
 			"%s [%2d/%d] %s", ind, i+1, total, s.Name)))
-		if s.Status == StepFailed && s.Err != nil {
+		if s.Status == installer.StepFailed && s.Err != nil {
 			p.warn("    Error: " + s.Err.Error())
 		}
 	}
@@ -867,15 +752,16 @@ func (m wizardModel) viewSteps(p *wizPane) {
 	p.blank()
 	renderStepRows(p, m.steps)
 	p.blank()
-	p.hint("installing, do not close the terminal " +
-		"(ctrl+c interrupts; a re-run resumes)")
+	if m.stopping {
+		p.hint("Stopping after the current step is recorded; keep this terminal open.")
+	} else {
+		p.hint("ctrl+c: stop after the current step; a later install command resumes")
+	}
 }
 
-// sshTarget renders the everyday login command with the box's
-// address when it is known.
-func sshTarget() string {
-	if ip := system.PublicIPv4(); ip != "" {
-		return "ssh " + paths.AdminUser + "@" + ip
+func (m wizardModel) sshTarget() string {
+	if m.info.Address != "" {
+		return "ssh " + paths.AdminUser + "@" + m.info.Address
 	}
 	return "ssh " + paths.AdminUser + "@<your-server-ip>"
 }
@@ -886,8 +772,7 @@ func (m wizardModel) viewDone(p *wizPane) {
 		p.blank()
 		renderStepRows(p, m.steps)
 		p.blank()
-		p.warn("The install failed. Nothing needs undoing: " +
-			"fix the reported problem and run " +
+		p.warn("Installation stopped after a step failed. Inspect the reported problem before running " +
 			"'sudo vpn install' again; it resumes from the " +
 			"first incomplete step.")
 		p.blank()
@@ -895,13 +780,11 @@ func (m wizardModel) viewDone(p *wizPane) {
 		return
 	}
 	if m.completeErr != "" {
-		p.header("Install steps complete, but not recorded")
+		p.header("Installation needs attention")
 		p.blank()
-		p.warn("Every step finished, but writing the " +
-			"completion record failed: " + m.completeErr)
+		p.warn(m.completeErr)
 		p.blank()
-		p.warn("Run 'sudo vpn install' again; it will skip " +
-			"all finished steps and retry the record.")
+		p.warn("Exit and inspect the reported problem. A later 'sudo vpn install' checks the saved state before resuming.")
 		p.blank()
 		p.hint("ctrl+c: exit")
 		return
@@ -912,7 +795,7 @@ func (m wizardModel) viewDone(p *wizPane) {
 	p.blank()
 	p.text("Your everyday way into the node, from any " +
 		"terminal:")
-	p.line(" " + theme.Action.Render("   "+sshTarget()))
+	p.line(" " + theme.Action.Render("   "+m.sshTarget()))
 	p.blank()
 	p.text("Press Enter to open the node TUI as user '" +
 		paths.AdminUser + "' on this terminal, or run the " +
@@ -924,10 +807,6 @@ func (m wizardModel) viewDone(p *wizPane) {
 		"with the command above)")
 }
 
-// ── View plumbing ────────────────────────────────────────
-
-// wizPane is a minimal line collector in the TUI pane
-// idiom — chrome, not machinery (no ScreenContext).
 type wizPane struct {
 	width int
 	lines []string
@@ -939,22 +818,22 @@ func (p *wizPane) header(s string) {
 	p.line(" " + theme.Header.Render(s))
 }
 func (p *wizPane) dim(s string) {
-	for _, l := range wrapText(s, p.width-4) {
+	for _, l := range strings.Split(ansi.Wordwrap(s, p.width-4, ""), "\n") {
 		p.line(" " + theme.Dim.Render(l))
 	}
 }
 func (p *wizPane) hint(s string) {
-	for _, l := range wrapText(s, p.width-4) {
+	for _, l := range strings.Split(ansi.Wordwrap(s, p.width-4, ""), "\n") {
 		p.line(" " + theme.Grayed.Render(l))
 	}
 }
 func (p *wizPane) warn(s string) {
-	for _, l := range wrapText(s, p.width-4) {
+	for _, l := range strings.Split(ansi.Wordwrap(s, p.width-4, ""), "\n") {
 		p.line(" " + theme.Warning.Render(l))
 	}
 }
 func (p *wizPane) text(s string) {
-	for _, l := range wrapText(s, p.width-4) {
+	for _, l := range strings.Split(ansi.Wordwrap(s, p.width-4, ""), "\n") {
 		p.line(" " + theme.Label.Render(l))
 	}
 }
@@ -1020,54 +899,13 @@ func (m wizardModel) View() tea.View {
 	return v
 }
 
-// willRun reports whether the planner will execute the step with
-// the given key this pass (false = ledger-skip; true also when
-// the key is absent from the list, the conservative side for
-// screen-skipping).
-func (r *stepRunner) willRun(
-	steps []InstallStep, key string,
-) bool {
-	for i, s := range steps {
-		if s.Key == key {
-			return r.plan[i].Run
-		}
-	}
-	return true
-}
-
-// runInstallWizard drives the interactive install: wizard
-// screens, then the engine steps, reporting HOW the run ended via
-// RunResult. onComplete is invoked exactly once, when the
-// last step verifies, BEFORE the done screen blocks on input; a
-// persist failure is surfaced as the run's error.
-func runInstallWizard(
-	cfg *config.AppConfig, steps []InstallStep,
-	dec *InstallDecisions, version string, ledger *installLedger,
-	persistDbCache func(int) error, onComplete func() error,
-) (RunResult, bool, error) {
-	runner, err := newStepRunner(
-		steps, version, ledger, paths.InstallStateFile)
-	if err != nil {
-		return RunResult{}, false, err
-	}
-	// Installation starts with the built-in dark theme. The operator's TUI
-	// preference is user-owned and is not part of root system configuration.
+// Run presents a session; the installer retains execution and lock ownership.
+func Run(info installer.InstallView, session *installer.InstallSession) (bool, error) {
+	// Root installation uses the built-in theme, not user-owned preferences.
 	theme.Init(true)
-	m := newWizardModel(cfg, steps, runner, dec, version,
-		persistDbCache, onComplete)
-	p := tea.NewProgram(m)
-	result, err := p.Run()
+	result, err := tea.NewProgram(newWizardModel(info, session)).Run()
 	if err != nil {
-		return RunResult{}, false, err
+		return false, err
 	}
-	final := result.(wizardModel)
-	if final.completeErr != "" {
-		return RunResult{}, false, fmt.Errorf(
-			"install steps complete but the completion record "+
-				"failed: %s — run sudo vpn install again to retry",
-			final.completeErr)
-	}
-	return classifyRun(final.steps,
-		final.stepsDone && !final.failed,
-		final.failed, final.current), final.openConsole, nil
+	return result.(wizardModel).openConsole, nil
 }

--- a/internal/tui/install/wizard_test.go
+++ b/internal/tui/install/wizard_test.go
@@ -1,0 +1,257 @@
+package install
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/virtualprivatenode/vpn/internal/installer"
+	"github.com/virtualprivatenode/vpn/internal/loginpassword"
+)
+
+type fakeSession struct {
+	input         installer.InteractiveInput
+	starts, stops int
+	err           error
+	events        chan installer.InstallEvent
+}
+
+func (s *fakeSession) Start(in installer.InteractiveInput) error {
+	s.starts++
+	s.input = in
+	return s.err
+}
+func (s *fakeSession) Stop()                                 { s.stops++ }
+func (s *fakeSession) Events() <-chan installer.InstallEvent { return s.events }
+func wizardFixture() (wizardModel, *fakeSession) {
+	session := &fakeSession{events: make(chan installer.InstallEvent, 10)}
+	info := installer.InstallView{NeedIdentity: true, PasswordAuth: true,
+		DBCacheChoices: []int{512, 1024, 2048}, RecommendedDBCache: 1024,
+		Steps: []installer.InstallStepView{{Name: "First"}, {Name: "Second"}}}
+	return newWizardModel(info, session), session
+}
+func updateWizard(t *testing.T, m wizardModel, msg tea.Msg) (wizardModel, tea.Cmd) {
+	t.Helper()
+	next, cmd := m.Update(msg)
+	return next.(wizardModel), cmd
+}
+func enter() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyEnter} }
+func ctrlC() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl} }
+
+func TestWizardPasswordPastePreservesOrRejects(t *testing.T) {
+	cases := []struct {
+		name, value, want string
+	}{
+		{"plain", "abcdefghijklmnop", "abcdefghijklmnop"},
+		{"padding", "  abcdefghijklmnop  ", "  abcdefghijklmnop  "},
+		{"one trailing LF", "abcdefghijklmnop\n", "abcdefghijklmnop"},
+		{"limit", strings.Repeat("x", 128), strings.Repeat("x", 128)},
+		{"unicode byte minimum", strings.Repeat("é", 8), strings.Repeat("é", 8)},
+		{"over limit", strings.Repeat("x", 129), ""},
+		{"second line", "abcdefghijklmnop\nsecond", ""},
+		{"two trailing LF", "abcdefghijklmnop\n\n", ""},
+		{"CRLF", "abcdefghijklmnop\r\n", ""},
+		{"tab", "abcdefghijklmnop\tend", ""},
+		{"NUL", "abcdefghijklmnop\x00", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, session := wizardFixture()
+			m.phase = wzPassword
+			for focus := 0; focus < 2; focus++ {
+				m.pwFocus = focus
+				var cmd tea.Cmd
+				m, cmd = updateWizard(t, m, tea.PasteMsg{Content: tc.value})
+				if cmd != nil || session.starts != 0 {
+					t.Fatal("paste scheduled installation")
+				}
+				input := m.pwInput
+				if focus == 1 {
+					input = m.pwConfirm
+				}
+				if tc.want != "" {
+					if input.Value() != tc.want || m.pwErr != "" {
+						t.Fatal("accepted secret changed")
+					}
+				} else if input.Value() != "" || m.pwErr == "" {
+					t.Fatal("altered input was not rejected and cleared")
+				}
+			}
+			m.pwFocus = 2
+			m.pwBtn = 1
+			m, cmd := updateWizard(t, m, enter())
+			if tc.want != "" {
+				if m.phase != wzSteps || cmd == nil {
+					t.Fatal("valid password could not continue")
+				}
+				result := cmd()
+				m, cmd = updateWizard(t, m, result)
+				if session.starts != 1 || session.input.Password.Text() != tc.want {
+					t.Fatal("submitted password differs from original")
+				}
+				if m.pwInput.Value() != "" || m.pwConfirm.Value() != "" || m.input.Password.Text() != "" || cmd == nil {
+					t.Fatal("submission did not clear input or observe progress")
+				}
+			} else if m.phase != wzPassword || cmd != nil || session.starts != 0 {
+				t.Fatal("invalid input reached installation")
+			}
+		})
+	}
+}
+
+func TestWizardPasswordMinimumMismatchAndRecovery(t *testing.T) {
+	m, session := wizardFixture()
+	m.phase = wzPassword
+	m.pwFocus = 2
+	m.pwBtn = 1
+	for _, values := range [][2]string{{"abcdefghijklmno", "abcdefghijklmno"}, {"abcdefghijklmnop", "abcdefghijklmnopX"}} {
+		m.pwInput.SetValue(values[0])
+		m.pwConfirm.SetValue(values[1])
+		var cmd tea.Cmd
+		m, cmd = updateWizard(t, m, enter())
+		if m.phase != wzPassword || m.pwErr == "" || cmd != nil || session.starts != 0 {
+			t.Fatal("short or mismatched password accepted")
+		}
+	}
+	m.pwInput.SetValue("abcdefghijklmnop")
+	m.pwConfirm.SetValue("abcdefghijklmnop")
+	m, cmd := updateWizard(t, m, enter())
+	if m.phase != wzSteps || cmd == nil {
+		t.Fatal("corrected password could not continue")
+	}
+}
+
+func TestWizardStopWaitsForEngineResult(t *testing.T) {
+	m, session := wizardFixture()
+	m.phase = wzSteps
+	pw, _ := loginpassword.New("abcdefghijklmnop")
+	m.input.Password = pw
+	start := m.Init()
+	m, wait := updateWizard(t, m, start())
+	if wait == nil || session.starts != 1 {
+		t.Fatal("missing observer")
+	}
+	m, cmd := updateWizard(t, m, ctrlC())
+	if cmd != nil || !m.stopping || session.stops != 1 || m.phase != wzSteps {
+		t.Fatal("Ctrl+C exited without waiting for the engine")
+	}
+	for _, msg := range []tea.Msg{enter(), ctrlC()} {
+		m, cmd = updateWizard(t, m, msg)
+		if cmd != nil || session.starts != 1 {
+			t.Fatal("stopping restarted or abandoned work")
+		}
+	}
+	event := installer.InstallEvent{Index: 0, Status: installer.StepDone}
+	session.events <- event
+	m, wait = updateWizard(t, m, wait())
+	if m.steps[0].Status != installer.StepDone || wait == nil {
+		t.Fatal("admitted step result lost")
+	}
+	session.events <- installer.InstallEvent{Final: true, Result: installer.RunResult{Outcome: installer.RunInterrupted}}
+	m, cmd = updateWizard(t, m, wait())
+	assertQuit(t, cmd)
+}
+
+func TestWizardDecisionRetryAndCompletionFailure(t *testing.T) {
+	m, session := wizardFixture()
+	m.phase = wzSteps
+	session.err = errors.New("cache write failed")
+	m.info.NeedHardware = true
+	m, cmd := updateWizard(t, m, m.Init()())
+	if m.phase != wzHardware || m.hwErr == "" || cmd != nil {
+		t.Fatal("decision error not recoverable")
+	}
+	session.err = nil
+	m.hwFocus = 1
+	m.hwBtn = len(m.hwButtons()) - 1
+	m, cmd = updateWizard(t, m, enter())
+	if cmd == nil {
+		t.Fatal("retry not scheduled")
+	}
+	m, wait := updateWizard(t, m, cmd())
+	if wait == nil || session.starts != 2 || session.input.DBCacheMB != 1024 {
+		t.Fatal("retry did not submit selected cache")
+	}
+	event := installer.InstallEvent{Index: 0, Status: installer.StepSkipped}
+	session.events <- event
+	m, wait = updateWizard(t, m, wait())
+	if m.steps[0].Status != installer.StepSkipped || wait == nil {
+		t.Fatal("skip evidence lost")
+	}
+	failure := errors.New("terminal ledger publication failed")
+	session.events <- installer.InstallEvent{Final: true, Result: installer.RunResult{Outcome: installer.RunComplete}, CompletionErr: failure}
+	m, cmd = updateWizard(t, m, wait())
+	if m.phase != wzDone || m.completeErr != failure.Error() || cmd != nil {
+		t.Fatal("finalization failure lost")
+	}
+	m, cmd = updateWizard(t, m, enter())
+	if cmd != nil || m.openConsole {
+		t.Fatal("failed finalization opened console")
+	}
+}
+
+func TestWizardCompletionChoiceAndEarlyExit(t *testing.T) {
+	for _, open := range []bool{false, true} {
+		t.Run(map[bool]string{false: "exit", true: "console"}[open], func(t *testing.T) {
+			m, _ := wizardFixture()
+			m.phase = wzSteps
+			m, cmd := updateWizard(t, m, wizardProgressMsg{ok: true, event: installer.InstallEvent{Final: true, Result: installer.RunResult{Outcome: installer.RunComplete}}})
+			if cmd != nil || m.phase != wzDone {
+				t.Fatal("completion did not wait for operator choice")
+			}
+			key := ctrlC()
+			if open {
+				key = enter()
+			}
+			m, cmd = updateWizard(t, m, key)
+			assertQuit(t, cmd)
+			if m.openConsole != open {
+				t.Fatal("completion choice lost")
+			}
+		})
+	}
+	m, session := wizardFixture()
+	m, cmd := updateWizard(t, m, ctrlC())
+	assertQuit(t, cmd)
+	if session.starts != 0 || m.openConsole {
+		t.Fatal("pre-install exit started work")
+	}
+}
+
+func TestWizardResumeScreensAndObservationFailure(t *testing.T) {
+	for _, tc := range []struct {
+		identity, hardware bool
+		phase              wizardPhase
+	}{{true, true, wzAccess}, {false, true, wzHardware}, {false, false, wzSteps}} {
+		m, session := wizardFixture()
+		info := m.info
+		info.NeedIdentity = tc.identity
+		info.NeedHardware = tc.hardware
+		m = newWizardModel(info, session)
+		if m.phase != tc.phase {
+			t.Fatal("resume requested the wrong input screen")
+		}
+	}
+	m, _ := wizardFixture()
+	m.phase = wzSteps
+	m, cmd := updateWizard(t, m, wizardProgressMsg{ok: false})
+	if m.phase != wzDone || m.completeErr == "" || cmd != nil {
+		t.Fatal("closed stream claimed success")
+	}
+	m, cmd = updateWizard(t, m, enter())
+	if cmd != nil || m.openConsole {
+		t.Fatal("missing completion permitted console handoff")
+	}
+}
+
+func assertQuit(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("missing quit command")
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("exit command returned %T, want tea.QuitMsg", msg)
+	}
+}


### PR DESCRIPTION
Move installer presentation into internal/tui/install while the installer owns execution, step ordering, durable progress and finalization.

Ctrl+C now waits for admitted work and its progress record before releasing the installation lock. Installer password paste rejects input that would be silently altered or truncated. Text wrapping uses the existing Charm ANSI dependency.

Validation:
- Full tests, race tests, vet and tidy checks passed.
- Four focused Debian root tests passed in normal and race modes.
- Public-Signet installation passed password recovery, graceful interruption, durable resume, completion and both TUI entry routes.
- Network and daemon-permission validators passed.
- Repeating installation reported already installed; contents and metadata of 12 installation files remained unchanged.