### PR TITLE
refactor: own transaction label edits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.6
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/lightningnetwork/lnd v0.21.2-beta
 	github.com/mdp/qrterminal/v3 v3.2.1
@@ -32,7 +33,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.10 // indirect
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/btcsuite/btcd/v2transport v1.0.1 // indirect
 	github.com/btcsuite/btclog v1.0.0 // indirect
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b // indirect

--- a/internal/app/transaction_label.go
+++ b/internal/app/transaction_label.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type TransactionLabelClient interface {
+	SetTransactionLabel(lndrpc.TransactionLabelRequest) lndrpc.TransactionLabelResult
+}
+
+// PreparedTransactionLabel keeps the transaction and text fixed after Save.
+// Labels belong to a transaction, including all of its wallet outputs.
+type PreparedTransactionLabel struct {
+	txid  *chainhash.Hash
+	label string
+}
+
+func PrepareTransactionLabel(txid, label string) (PreparedTransactionLabel, error) {
+	// NewHashFromStr permits short, zero-padded hashes. User requests must name
+	// the complete transaction instead.
+	if len(txid) != 64 {
+		return PreparedTransactionLabel{}, errors.New("invalid transaction ID")
+	}
+	hash, err := chainhash.NewHashFromStr(txid)
+	if err != nil {
+		return PreparedTransactionLabel{}, errors.New("invalid transaction ID")
+	}
+	if len(label) == 0 || len(label) > 500 {
+		return PreparedTransactionLabel{}, errors.New("enter a transaction label between 1 and 500 bytes")
+	}
+	return PreparedTransactionLabel{txid: hash, label: label}, nil
+}
+
+type TransactionLabelOutcome int
+
+const (
+	TransactionLabelUnknown TransactionLabelOutcome = iota
+	TransactionLabelNotSaved
+	TransactionLabelSaved
+)
+
+type TransactionLabelResult struct {
+	Outcome TransactionLabelOutcome
+	Err     error
+}
+
+// SaveTransactionLabel makes one request. An attempted RPC with a lost response
+// does not establish whether LND saved the label, and is never retried here.
+func SaveTransactionLabel(client TransactionLabelClient, prepared PreparedTransactionLabel) TransactionLabelResult {
+	if prepared.txid == nil || client == nil {
+		return TransactionLabelResult{Outcome: TransactionLabelNotSaved, Err: errors.New("transaction label is not ready to save")}
+	}
+	result := client.SetTransactionLabel(lndrpc.TransactionLabelRequest{Txid: *prepared.txid, Label: prepared.label})
+	if !result.Submitted {
+		if result.Err == nil {
+			result.Err = errors.New("transaction label request was not submitted")
+		}
+		return TransactionLabelResult{Outcome: TransactionLabelNotSaved, Err: result.Err}
+	}
+	if result.Err != nil {
+		return TransactionLabelResult{Outcome: TransactionLabelUnknown, Err: result.Err}
+	}
+	return TransactionLabelResult{Outcome: TransactionLabelSaved}
+}

--- a/internal/app/transaction_label_test.go
+++ b/internal/app/transaction_label_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+)
+
+type labelClient struct {
+	requests []lndrpc.TransactionLabelRequest
+	result   lndrpc.TransactionLabelResult
+}
+
+func (c *labelClient) SetTransactionLabel(request lndrpc.TransactionLabelRequest) lndrpc.TransactionLabelResult {
+	c.requests = append(c.requests, request)
+	return c.result
+}
+
+func TestTransactionLabelValidationBeforeSubmission(t *testing.T) {
+	txid := strings.Repeat("ab", 32)
+	for _, tc := range []struct {
+		name, txid, label string
+	}{
+		{"empty ID", "", "label"},
+		{"short ID", "ab", "label"},
+		{"long ID", txid + "ab", "label"},
+		{"nonhex ID", strings.Repeat("z", 64), "label"},
+		{"empty label", txid, ""},
+		{"501 bytes", txid, strings.Repeat("a", 501)},
+		{"multibyte over limit", txid, strings.Repeat("é", 251)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PrepareTransactionLabel(tc.txid, tc.label)
+			if err == nil {
+				t.Fatal("invalid request prepared")
+			}
+		})
+	}
+	// LND counts bytes, not runes. Exact whitespace is intentional label text.
+	for _, label := range []string{" label ", " ", strings.Repeat("é", 250)} {
+		prepared, err := PrepareTransactionLabel(strings.ToUpper(txid), label)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := &labelClient{result: lndrpc.TransactionLabelResult{Submitted: true}}
+		result := SaveTransactionLabel(client, prepared)
+		if result.Outcome != TransactionLabelSaved || result.Err != nil || len(client.requests) != 1 ||
+			client.requests[0].Txid.String() != txid || client.requests[0].Label != label {
+			t.Fatalf("saved request differs from validated intent: %+v", client.requests)
+		}
+	}
+}
+
+func TestTransactionLabelOutcomesNeverRetry(t *testing.T) {
+	client := &labelClient{}
+	if result := SaveTransactionLabel(client, PreparedTransactionLabel{}); result.Outcome != TransactionLabelNotSaved || result.Err == nil || len(client.requests) != 0 {
+		t.Fatal("unprepared request reached the client or implied success")
+	}
+	failure := errors.New("request failed")
+	prepared, err := PrepareTransactionLabel(strings.Repeat("12", 32), "reviewed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		wire lndrpc.TransactionLabelResult
+		want TransactionLabelOutcome
+	}{
+		{"not attempted", lndrpc.TransactionLabelResult{Err: failure}, TransactionLabelNotSaved},
+		{"lost response", lndrpc.TransactionLabelResult{Submitted: true, Err: failure}, TransactionLabelUnknown},
+		{"acknowledged", lndrpc.TransactionLabelResult{Submitted: true}, TransactionLabelSaved},
+		{"missing adapter result", lndrpc.TransactionLabelResult{}, TransactionLabelNotSaved},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &labelClient{result: tc.wire}
+			result := SaveTransactionLabel(client, prepared)
+			if result.Outcome != tc.want || len(client.requests) != 1 {
+				t.Fatalf("result=%+v calls=%d", result, len(client.requests))
+			}
+			if tc.wire.Err != nil && !errors.Is(result.Err, failure) {
+				t.Fatal("underlying failure lost")
+			}
+			if tc.want != TransactionLabelSaved && result.Err == nil {
+				t.Fatal("unsuccessful result has no error")
+			}
+		})
+	}
+	if result := SaveTransactionLabel(nil, prepared); result.Outcome != TransactionLabelNotSaved || result.Err == nil {
+		t.Fatal("missing client did not refuse")
+	}
+}

--- a/internal/lndrpc/onchain.go
+++ b/internal/lndrpc/onchain.go
@@ -1,7 +1,6 @@
 package lndrpc
 
 import (
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -351,48 +350,6 @@ func (c *Client) GetTransactions() ([]OnChainTx, error) {
 	})
 
 	return txs, nil
-}
-
-// ── Label transaction ───────────────────────────────────
-
-func (c *Client) LabelTransaction(
-	txid string, label string, overwrite bool,
-) error {
-	c.mu.RLock()
-	conn := c.conn
-	c.mu.RUnlock()
-	if conn == nil {
-		return errNotConnected
-	}
-
-	// Convert hex txid to reversed bytes
-	// (LND expects internal byte order)
-	txidBytes, err := hex.DecodeString(txid)
-	if err != nil {
-		return fmt.Errorf("invalid txid: %w", err)
-	}
-	if len(txidBytes) == 32 {
-		for i, j := 0, 31; i < j; i, j = i+1, j-1 {
-			txidBytes[i], txidBytes[j] =
-				txidBytes[j], txidBytes[i]
-		}
-	}
-
-	walletClient := walletrpc.NewWalletKitClient(conn)
-	ctx, cancel := c.callCtx(defaultTimeout)
-	defer cancel()
-
-	_, err = walletClient.LabelTransaction(ctx,
-		&walletrpc.LabelTransactionRequest{
-			Txid:      txidBytes,
-			Label:     label,
-			Overwrite: overwrite,
-		})
-	if err != nil {
-		c.handleError(err)
-		return err
-	}
-	return nil
 }
 
 // ── Helpers for transaction labeling ─────────────────────

--- a/internal/lndrpc/transaction_label.go
+++ b/internal/lndrpc/transaction_label.go
@@ -1,0 +1,39 @@
+package lndrpc
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+)
+
+// TransactionLabelRequest carries app-validated intent in wallet byte order.
+type TransactionLabelRequest struct {
+	Txid  chainhash.Hash
+	Label string
+}
+
+// TransactionLabelResult distinguishes a local refusal from an attempted RPC.
+// Submitted alone does not confirm a wallet write.
+type TransactionLabelResult struct {
+	Submitted bool
+	Err       error
+}
+
+func (c *Client) SetTransactionLabel(input TransactionLabelRequest) TransactionLabelResult {
+	if c == nil {
+		return TransactionLabelResult{Err: errNotConnected}
+	}
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+	if conn == nil {
+		return TransactionLabelResult{Err: errNotConnected}
+	}
+	ctx, cancel := c.callCtx(defaultTimeout)
+	defer cancel()
+	_, err := walletrpc.NewWalletKitClient(conn).LabelTransaction(ctx,
+		&walletrpc.LabelTransactionRequest{Txid: input.Txid[:], Label: input.Label, Overwrite: true})
+	if err != nil {
+		c.handleError(err)
+	}
+	return TransactionLabelResult{Submitted: true, Err: err}
+}

--- a/internal/lndrpc/transaction_label_test.go
+++ b/internal/lndrpc/transaction_label_test.go
@@ -1,0 +1,74 @@
+package lndrpc
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestTransactionLabelRPCBoundary(t *testing.T) {
+	var request *walletrpc.LabelTransactionRequest
+	var rpcContext context.Context
+	calls := 0
+	var rpcErr error
+	// Intercept before transport so this tests the real generated WalletKit
+	// request and authenticated context without contacting a daemon.
+	conn, err := grpc.NewClient("passthrough:///label-test.invalid",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, _ *grpc.ClientConn, _ grpc.UnaryInvoker, _ ...grpc.CallOption) error {
+			if method != "/walletrpc.WalletKit/LabelTransaction" {
+				t.Errorf("unexpected method %q", method)
+			}
+			calls++
+			rpcContext, request = ctx, req.(*walletrpc.LabelTransactionRequest)
+			return rpcErr
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	client := &Client{conn: conn, macaroonHex: "test-only"}
+	txid, err := chainhash.NewHashFromStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := TransactionLabelRequest{
+		Txid:  *txid,
+		Label: " exact label ",
+	}
+	started := time.Now()
+	result := client.SetTransactionLabel(input)
+	if result.Err != nil || !result.Submitted || calls != 1 || request.Label != input.Label || !request.Overwrite {
+		t.Fatalf("result=%+v request=%v calls=%d", result, request, calls)
+	}
+	if got := hex.EncodeToString(request.Txid); got != "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100" {
+		t.Fatalf("incorrect transaction byte order: %s", got)
+	}
+	deadline, ok := rpcContext.Deadline()
+	if !ok || deadline.Before(started.Add(30*time.Second)) || deadline.After(time.Now().Add(30*time.Second)) {
+		t.Fatal("RPC lacks its 30-second deadline")
+	}
+	md, _ := metadata.FromOutgoingContext(rpcContext)
+	if got := md.Get("macaroon"); len(got) != 1 || got[0] != "test-only" || rpcContext.Err() != context.Canceled {
+		t.Fatal("authentication or completed-context release missing")
+	}
+	rpcErr = errors.New("acknowledgement lost")
+	result = client.SetTransactionLabel(input)
+	if !result.Submitted || !errors.Is(result.Err, rpcErr) || calls != 2 {
+		t.Fatal("attempted failure lost its classification or was retried")
+	}
+	for _, unavailable := range []*Client{nil, {}} {
+		result = unavailable.SetTransactionLabel(input)
+		if result.Submitted || !errors.Is(result.Err, errNotConnected) {
+			t.Fatal("missing connection was not a pre-submission refusal")
+		}
+	}
+}

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -265,15 +265,17 @@ func sendCoinsCmd(client app.OnChainSendClient, attempt *onChainSendAttempt) tea
 }
 
 func fetchOnChainTxCmd(
-	client *lndrpc.Client,
+	client *lndrpc.Client, owner *OnChainContext,
 ) tea.Cmd {
+	owner.txRevision++
+	revision := owner.txRevision
 	return func() tea.Msg {
 		if client == nil {
-			return onChainTxMsg{err: fmt.Errorf(
+			return onChainTxMsg{owner: owner, revision: revision, err: fmt.Errorf(
 				"LND not connected")}
 		}
 		txs, err := client.GetTransactions()
-		return onChainTxMsg{txs: txs, err: err}
+		return onChainTxMsg{owner: owner, revision: revision, txs: txs, err: err}
 	}
 }
 
@@ -290,17 +292,10 @@ func fetchFeeTiersCmd(
 
 // ── Transaction labeling ─────────────────────────────────
 
-func labelTxCmd(
-	client *lndrpc.Client, txid, label string,
-) tea.Cmd {
+func labelTxCmd(owner *OnChainHomeScreen, client app.TransactionLabelClient, prepared app.PreparedTransactionLabel) tea.Cmd {
+	attempt := owner.labelAttempt
 	return func() tea.Msg {
-		if client == nil {
-			return labelTxMsg{
-				err: fmt.Errorf("LND not connected")}
-		}
-		err := client.LabelTransaction(
-			txid, label, true)
-		return labelTxMsg{err: err}
+		return labelTxMsg{owner: owner, attempt: attempt, result: app.SaveTransactionLabel(client, prepared)}
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -208,8 +208,10 @@ type feeTiersMsg struct {
 }
 
 type onChainTxMsg struct {
-	txs []lndrpc.OnChainTx
-	err error
+	owner    *OnChainContext
+	revision uint64
+	txs      []lndrpc.OnChainTx
+	err      error
 }
 
 type channelCloseResultMsg struct {
@@ -223,7 +225,9 @@ type closedChannelsMsg struct {
 }
 
 type labelTxMsg struct {
-	err error
+	owner   *OnChainHomeScreen
+	attempt uint64
+	result  app.TransactionLabelResult
 }
 
 type channelInfo struct {

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -133,6 +133,7 @@ func walletUnavailableHelpBindings(c *ScreenContext) []key.Binding {
 // OnChainContext holds wallet data and the selection shared by home and send.
 // Prepared sends own copies of their reviewed inputs.
 type OnChainContext struct {
+	txRevision   uint64
 	Utxos        []lndrpc.UTXO
 	Selection    app.CoinSelection
 	OnChainTxs   []lndrpc.OnChainTx

--- a/internal/tui/screen_onchain_home.go
+++ b/internal/tui/screen_onchain_home.go
@@ -8,7 +8,9 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
+	"github.com/virtualprivatenode/vpn/internal/app"
 	"github.com/virtualprivatenode/vpn/internal/lndrpc"
 	"github.com/virtualprivatenode/vpn/internal/theme"
 )
@@ -48,6 +50,11 @@ type OnChainHomeScreen struct {
 	labelInput   textinput.Model
 	labelOnBtn   bool // true when on Save/Cancel buttons
 	labelBtnIdx  int  // 0=Cancel, 1=Save
+	labelTxid    string
+	labelAttempt uint64
+	labelPending bool
+	labelErr     string
+	labels       app.TransactionLabelClient
 }
 
 func NewOnChainHomeScreen(
@@ -389,6 +396,15 @@ func (s *OnChainHomeScreen) openTxDetail() (
 func (s *OnChainHomeScreen) handleLabelPopupKey(
 	keyStr string, msg tea.KeyPressMsg,
 ) (Screen, tea.Cmd) {
+	if s.labelPending {
+		switch keyStr {
+		case "ctrl+c":
+			return s, tea.Quit
+		case "left":
+			return s, emitFocusSidebar
+		}
+		return s, nil
+	}
 	switch keyStr {
 	case "ctrl+c":
 		return s, tea.Quit
@@ -435,16 +451,19 @@ func (s *OnChainHomeScreen) handleLabelPopupKey(
 				s.closeLabelPopup()
 				return s, nil
 			case 1: // Save
-				if s.utxoCursor <
-					len(s.ocCtx.Utxos) {
-					txid := s.ocCtx.Utxos[s.utxoCursor].Txid
-					label := s.labelInput.Value()
-					return s, labelTxCmd(
-						s.ctx.LndClient,
-						txid, label)
+				prepared, err := app.PrepareTransactionLabel(s.labelTxid, s.labelInput.Value())
+				if err != nil {
+					s.labelErr = err.Error()
+					return s, nil
 				}
-				s.closeLabelPopup()
-				return s, nil
+				s.labelAttempt++
+				s.labelPending = true
+				s.labelErr = ""
+				client := s.labels
+				if client == nil && s.ctx.LndClient != nil {
+					client = s.ctx.LndClient
+				}
+				return s, labelTxCmd(s, client, prepared)
 			}
 		}
 		// On label field — move to buttons, land on Save.
@@ -478,15 +497,32 @@ func (s *OnChainHomeScreen) HandleMsg(
 ) (Screen, tea.Cmd) {
 	switch msg := msg.(type) {
 	case labelTxMsg:
-		if msg.err == nil {
+		if msg.owner != s || msg.attempt != s.labelAttempt || !s.labelPending {
+			return s, nil
+		}
+		s.labelPending = false
+		switch msg.result.Outcome {
+		case app.TransactionLabelSaved:
+			// Publish only the acknowledged label. Invalidate older history reads
+			// before requesting a fresh snapshot, so they cannot undo this result.
+			for i := range s.ocCtx.OnChainTxs {
+				if s.ocCtx.OnChainTxs[i].Txid == s.labelTxid {
+					s.ocCtx.OnChainTxs[i].Label = s.labelInput.Value()
+				}
+			}
 			s.closeLabelPopup()
-			return s, tea.Batch(
-				fetchOnChainTxCmd(s.ctx.LndClient),
-				listUnspentCmd(s.ctx.LndClient))
+			return s, fetchOnChainTxCmd(s.ctx.LndClient, s.ocCtx)
+		case app.TransactionLabelNotSaved:
+			s.labelErr = "Label was not saved."
+			if msg.result.Err != nil {
+				s.labelErr += " " + msg.result.Err.Error()
+			}
+		default:
+			s.labelErr = "Save was not confirmed. Check the transaction label before retrying."
 		}
 		return s, nil
 	case tea.PasteMsg:
-		if s.labelEditing && !s.labelOnBtn {
+		if s.labelEditing && !s.labelPending && !s.labelOnBtn {
 			var cmd tea.Cmd
 			s.labelInput, cmd =
 				s.labelInput.Update(msg)
@@ -501,6 +537,10 @@ func (s *OnChainHomeScreen) HandleMsg(
 func (s *OnChainHomeScreen) View(
 	w, h int,
 ) string {
+	// An active edit survives wallet/status failures and removal of its UTXO.
+	if s.labelEditing {
+		return strings.Join(s.renderLabelPopup(w), "\n")
+	}
 	s.clampCursors()
 	cfg := s.ctx.Cfg
 	status := s.ctx.Status
@@ -722,14 +762,6 @@ func (s *OnChainHomeScreen) View(
 						theme.Dim.Render(uAddrStr)+
 						theme.Value.Render(uValStr))
 			}
-
-			// Label edit popup
-			if s.labelEditing &&
-				s.utxoCursor == i {
-				popLines := s.renderLabelPopup(w)
-				utxoMidLines = append(utxoMidLines,
-					popLines...)
-			}
 		}
 	}
 
@@ -860,15 +892,9 @@ func (s *OnChainHomeScreen) View(
 	txVPH = max(txVPH, 1)
 	utxoVPH = max(utxoVPH, 1)
 
-	// Cursor line accounting for popup
-	utxoCursorLine := s.utxoCursor
-	if s.labelEditing {
-		utxoCursorLine = s.utxoCursor + 4
-	}
-
 	utxoVPRendered := renderViewport(
 		utxoMidContent, w, utxoVPH,
-		utxoCursorLine,
+		s.utxoCursor,
 		len(utxoMidLines),
 		len(utxos) > 0 &&
 			s.focusZone == ocHomeZoneUtxos)
@@ -890,11 +916,12 @@ func (s *OnChainHomeScreen) View(
 // ── Label popup ─────────────────────────────────────────
 
 func (s *OnChainHomeScreen) openLabelPopup() {
-	if s.utxoCursor >= len(s.ocCtx.Utxos) {
+	if s.utxoCursor < 0 || s.utxoCursor >= len(s.ocCtx.Utxos) {
 		return
 	}
-	txLabel := s.utxoTxLabel(
-		s.ocCtx.Utxos[s.utxoCursor].Txid)
+	s.labelTxid = s.ocCtx.Utxos[s.utxoCursor].Txid
+	s.labelErr = ""
+	txLabel := s.utxoTxLabel(s.labelTxid)
 	contentW := tuiWidth - 2 - 12 - 1 // nav width=12
 	fieldW := contentW - 16
 	if fieldW < 20 {
@@ -902,7 +929,7 @@ func (s *OnChainHomeScreen) openLabelPopup() {
 	}
 	s.labelInput = newDetailField(txLabel, fieldW)
 	s.labelInput.Placeholder = "enter label"
-	s.labelInput.CharLimit = 64
+	// app validates LND's byte limit; a rune limit can truncate existing labels.
 	s.labelInput.Focus()
 	s.labelEditing = true
 	s.labelOnBtn = false
@@ -936,6 +963,9 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 	lines = append(lines,
 		"  "+border.Render(
 			"┌"+strings.Repeat("─", boxW)+"┐"))
+	for _, line := range strings.Split(ansi.Wrap("Transaction: "+s.labelTxid, boxW-2, ""), "\n") {
+		lines = append(lines, "  "+border.Render("│")+pad(line, boxW)+border.Render("│"))
+	}
 
 	lblActive := isFocused && !s.labelOnBtn
 	lblStyle := theme.Header
@@ -961,6 +991,9 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 		[]string{"Cancel", "Save"},
 		s.labelBtnIdx,
 		isFocused && s.labelOnBtn, boxW)
+	if s.labelPending {
+		btnStr = theme.Dim.Render("Saving label...")
+	}
 	btnW := lipgloss.Width(btnStr)
 	btnPad := boxW - btnW
 	if btnPad < 0 {
@@ -971,6 +1004,11 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 			btnStr+
 			strings.Repeat(" ", btnPad)+
 			border.Render("│"))
+	if s.labelErr != "" {
+		for _, line := range strings.Split(ansi.Wrap(s.labelErr, boxW-2, ""), "\n") {
+			lines = append(lines, "  "+border.Render("│")+pad(theme.Warning.Render(line), boxW)+border.Render("│"))
+		}
+	}
 
 	lines = append(lines,
 		"  "+border.Render(
@@ -982,11 +1020,11 @@ func (s *OnChainHomeScreen) renderLabelPopup(
 // ── HelpBindings ────────────────────────────────────────
 
 func (s *OnChainHomeScreen) HelpBindings() []key.Binding {
-	if !s.ctx.walletExists() {
-		return walletUnavailableHelpBindings(s.ctx)
-	}
 	if s.labelEditing {
 		return s.labelPopupBindings()
+	}
+	if !s.ctx.walletExists() {
+		return walletUnavailableHelpBindings(s.ctx)
 	}
 	switch s.focusZone {
 	case ocHomeZoneUtxos:
@@ -1020,6 +1058,9 @@ func (s *OnChainHomeScreen) utxoBindings() []key.Binding {
 }
 
 func (s *OnChainHomeScreen) labelPopupBindings() []key.Binding {
+	if s.labelPending {
+		return []key.Binding{kSidebar, kQuit}
+	}
 	if s.labelOnBtn {
 		return []key.Binding{
 			kLeftRightButtons,

--- a/internal/tui/screen_onchain_send.go
+++ b/internal/tui/screen_onchain_send.go
@@ -550,7 +550,7 @@ func (s *OnChainSendScreen) handleSendCoinsResult(msg sendCoinsResultMsg) (Scree
 		s.ocCtx.Selection.Clear()
 	}
 	// Refresh wallet facts even if the RPC outcome is unknown. Never retry here.
-	return s, tea.Batch(listUnspentCmd(s.ctx.LndClient), fetchOnChainTxCmd(s.ctx.LndClient),
+	return s, tea.Batch(listUnspentCmd(s.ctx.LndClient), fetchOnChainTxCmd(s.ctx.LndClient, s.ocCtx),
 		fetchStatus(s.ctx.Cfg, s.ctx.State, s.ctx.LndClient))
 }
 

--- a/internal/tui/transaction_label_test.go
+++ b/internal/tui/transaction_label_test.go
@@ -1,0 +1,205 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/virtualprivatenode/vpn/internal/lndrpc"
+	"github.com/virtualprivatenode/vpn/internal/theme"
+)
+
+type labelSaveClient struct {
+	requests []lndrpc.TransactionLabelRequest
+	result   lndrpc.TransactionLabelResult
+}
+
+func (c *labelSaveClient) SetTransactionLabel(request lndrpc.TransactionLabelRequest) lndrpc.TransactionLabelResult {
+	c.requests = append(c.requests, request)
+	return c.result
+}
+
+func labelModel() (Model, *OnChainHomeScreen, *labelSaveClient) {
+	theme.Init(true)
+	ctx := &ScreenContext{ContentFocused: true}
+	oc := &OnChainContext{
+		Utxos: []lndrpc.UTXO{{Txid: strings.Repeat("01", 32)}, {Txid: strings.Repeat("02", 32)}},
+		OnChainTxs: []lndrpc.OnChainTx{
+			{Txid: strings.Repeat("01", 32), Label: "first"},
+			{Txid: strings.Repeat("02", 32), Label: "second"},
+		},
+	}
+	client := &labelSaveClient{result: lndrpc.TransactionLabelResult{Submitted: true}}
+	s := NewOnChainHomeScreen(ctx, oc)
+	s.labels = client
+	m := Model{nav: NewNavSidebar(), screenCtx: ctx, ocCtx: oc}
+	m.sectionScreens[secOnChain] = s
+	return m, s, client
+}
+
+func saveLabel(t *testing.T, s *OnChainHomeScreen, text string) tea.Cmd {
+	t.Helper()
+	s.labelInput.SetValue(text)
+	s.HandleKey("tab", tea.KeyPressMsg{})
+	_, cmd := s.HandleKey("enter", tea.KeyPressMsg{})
+	if cmd == nil {
+		t.Fatal("Save did not schedule a request")
+	}
+	return cmd
+}
+
+func TestLabelEditKeepsTargetAcrossUTXORefresh(t *testing.T) {
+	for _, disappear := range []bool{false, true} {
+		m, s, client := labelModel()
+		target := s.ocCtx.Utxos[0].Txid
+		s.openLabelPopup()
+		utxos := []lndrpc.UTXO{s.ocCtx.Utxos[1], s.ocCtx.Utxos[0]}
+		if disappear {
+			utxos = nil
+		}
+		updated, _ := m.Update(utxoListMsg{utxos: utxos})
+		m = updated.(Model)
+		// The status and wallet observation are unavailable in this fixture.
+		// Neither that nor an empty UTXO list may hide the active editor.
+		if view := s.View(67, 28); !strings.Contains(view, "Transaction:") || !strings.Contains(view, "Save") {
+			t.Fatal("refresh or unavailable status hid the editor")
+		}
+		command := saveLabel(t, s, " intended ")
+		for _, key := range []tea.KeyPressMsg{
+			{Code: tea.KeyEnter}, {Code: tea.KeyUp}, {Code: tea.KeyDown},
+			{Code: tea.KeyTab}, {Code: tea.KeyRight}, {Code: 'x', Text: "x"},
+		} {
+			if _, duplicate := s.HandleKey(key.String(), key); duplicate != nil {
+				t.Fatalf("pending edit accepted %q", key.String())
+			}
+		}
+		s.HandleMsg(tea.PasteMsg{Content: "replacement"})
+		if !s.labelEditing || !s.labelPending || s.labelInput.Value() != " intended " {
+			t.Fatal("pending edit was closed, replaced or modified")
+		}
+		if _, nav := s.HandleKey("left", tea.KeyPressMsg{}); nav == nil {
+			t.Fatal("pending edit cannot navigate away")
+		}
+		// Deliver through the model while Channels is visible.
+		message := command()
+		_, refresh := m.Update(message)
+		if refresh == nil || s.labelPending || s.labelEditing || len(client.requests) != 1 ||
+			client.requests[0].Txid.String() != target || client.requests[0].Label != " intended " ||
+			s.ocCtx.OnChainTxs[0].Label != " intended " || s.ocCtx.OnChainTxs[1].Label != "second" {
+			t.Fatalf("save changed target/text or lost hidden completion: %+v", client.requests)
+		}
+		if _, duplicate := m.Update(message); duplicate != nil {
+			t.Fatal("duplicate completion scheduled another refresh")
+		}
+	}
+}
+
+func TestLabelEditFailureAndExplicitRetry(t *testing.T) {
+	m, s, client := labelModel()
+	s.openLabelPopup()
+	client.result = lndrpc.TransactionLabelResult{Err: errors.New("not connected")}
+	first := saveLabel(t, s, "draft")()
+	if _, cmd := m.Update(first); cmd != nil || !s.labelEditing || s.labelPending ||
+		!strings.Contains(s.labelErr, "not saved") || s.labelInput.Value() != "draft" {
+		t.Fatal("pre-submission refusal lost draft or scheduled work")
+	}
+	client.result = lndrpc.TransactionLabelResult{Submitted: true, Err: errors.New("lost response")}
+	retry := saveLabel(t, s, "draft")
+	unknown := retry()
+	if _, cmd := m.Update(unknown); cmd != nil || !s.labelEditing || s.labelPending ||
+		!strings.Contains(s.labelErr, "not confirmed") || s.labelInput.Value() != "draft" || len(client.requests) != 2 {
+		t.Fatal("unknown result lost its draft, uncertainty or explicit-retry boundary")
+	}
+	view := s.View(67, 28)
+	if !strings.Contains(view, "not confirmed") || !strings.Contains(view, "retrying") {
+		t.Fatal("outcome guidance is not rendered")
+	}
+	for _, line := range strings.Split(view, "\n") {
+		if lipgloss.Width(line) > 67 {
+			t.Fatal("label result exceeds the content width")
+		}
+	}
+	client.result = lndrpc.TransactionLabelResult{Submitted: true}
+	current := saveLabel(t, s, "corrected label")
+	_, refresh := m.Update(current())
+	if refresh == nil || s.labelEditing || s.ocCtx.OnChainTxs[0].Label != "corrected label" || len(client.requests) != 3 {
+		t.Fatal("explicit retry did not finish the intended edit")
+	}
+}
+
+func TestLabelEditorValidatesBytesWithoutTruncatingText(t *testing.T) {
+	m, s, client := labelModel()
+	label := strings.Repeat("é", 250)
+	s.ocCtx.OnChainTxs[0].Label = label
+	s.openLabelPopup()
+	if s.labelInput.Value() != label {
+		t.Fatal("existing valid label was truncated")
+	}
+	s.labelInput.SetValue(label + "x")
+	s.HandleKey("tab", tea.KeyPressMsg{})
+	if _, cmd := s.HandleKey("enter", tea.KeyPressMsg{}); cmd != nil || s.labelErr == "" || s.labelInput.Value() != label+"x" {
+		t.Fatal("overlong text was truncated or submitted instead of rejected")
+	}
+	command := saveLabel(t, s, label)
+	_, refresh := m.Update(command())
+	if refresh == nil || len(client.requests) != 1 || client.requests[0].Label != label {
+		t.Fatal("valid corrected label did not reach the client intact")
+	}
+}
+
+func TestLabelResultCannotReachReplacementScreenOrRevertHistory(t *testing.T) {
+	m, s, _ := labelModel()
+	oldRead := fetchOnChainTxCmd(nil, m.ocCtx)().(onChainTxMsg)
+	oldRead.err = nil
+	oldRead.txs = []lndrpc.OnChainTx{{Txid: s.ocCtx.Utxos[0].Txid, Label: "obsolete"}}
+	s.openLabelPopup()
+	result := saveLabel(t, s, "acknowledged")()
+	_, refresh := m.Update(result)
+	if refresh == nil {
+		t.Fatal("successful label save did not refresh history")
+	}
+	m.Update(oldRead)
+	if s.ocCtx.OnChainTxs[0].Label != "acknowledged" {
+		t.Fatal("pre-save read undid the acknowledged label")
+	}
+	failed := refresh().(onChainTxMsg)
+	m.Update(failed)
+	if s.ocCtx.OnChainTxs[0].Label != "acknowledged" {
+		t.Fatal("failed refresh erased the acknowledged label")
+	}
+	current := failed
+	current.err = nil
+	current.txs = []lndrpc.OnChainTx{{Txid: s.labelTxid, Label: "external change"}}
+	m.Update(current)
+	if s.ocCtx.OnChainTxs[0].Label != "external change" {
+		t.Fatal("current daemon observation cannot supersede the local acknowledgement")
+	}
+	s.openLabelPopup()
+	s.labelInput.SetValue("another draft")
+	if _, cmd := m.Update(result); cmd != nil || !s.labelEditing || s.labelInput.Value() != "another draft" {
+		t.Fatal("duplicate success closed a newer unsaved edit")
+	}
+	next := saveLabel(t, s, "next label")
+	if _, cmd := m.Update(result); cmd != nil || !s.labelPending {
+		t.Fatal("old success completed a newer submission")
+	}
+	if _, cmd := m.Update(next()); cmd == nil || s.labelPending || s.labelEditing {
+		t.Fatal("current result was not delivered")
+	}
+	_, replacement, replacementClient := labelModel()
+	m.sectionScreens[secOnChain] = replacement
+	replacement.openLabelPopup()
+	saveLabel(t, replacement, "replacement")
+	if _, cmd := m.Update(result); cmd != nil || !replacement.labelPending || len(replacementClient.requests) != 0 {
+		t.Fatal("old owner reached the replacement screen")
+	}
+	foreign := current
+	foreign.owner = &OnChainContext{}
+	foreign.txs = nil
+	m.Update(foreign)
+	if len(m.ocCtx.OnChainTxs) != 1 {
+		t.Fatal("foreign history owner replaced current state")
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -514,7 +514,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case onChainTxMsg:
-		if msg.err == nil {
+		if msg.owner != nil && msg.owner == m.ocCtx && msg.revision == m.ocCtx.txRevision && msg.err == nil {
 			m.ocCtx.OnChainTxs = msg.txs
 		}
 		return m, nil
@@ -539,13 +539,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Route to history screen so it gets the data
 		return m.dispatchToTab(tabChannelHistory, msg)
 	case labelTxMsg:
-		// Route to on-chain home screen
-		if cmd, ok := m.routeToSectionScreen(
-			secOnChain, msg); ok {
+		if msg.owner != nil && m.sectionScreens[secOnChain] == msg.owner {
+			_, cmd := msg.owner.HandleMsg(msg)
 			return m, cmd
-		}
-		if msg.err == nil {
-			return m, fetchOnChainTxCmd(m.lndClient)
 		}
 		return m, nil
 	case feeTiersMsg:
@@ -922,7 +918,7 @@ func (m Model) previewSection(
 	case secOnChain:
 		return m, tea.Batch(
 			listUnspentCmd(m.lndClient),
-			fetchOnChainTxCmd(m.lndClient))
+			fetchOnChainTxCmd(m.lndClient, m.ocCtx))
 	}
 	return m, nil
 }


### PR DESCRIPTION
## Why

Saving a label from a UTXO row could label another UTXO’s transaction if the 
list reordered while the editor was open.
Submissions could overlap, stale results could affect newer edits, and failures
were hidden.

## Changes

- Keep the selected transaction fixed throughout editing.
- Put input validation and submission outcomes in app; pass a typed hash to
  the authenticated LND adapter.
- Give results screen/attempt ownership, prevent duplicate submission, and
  retain drafts with visible failure guidance.
- Prevent older history responses from overwriting acknowledged labels.
- Keep the editor visible independently of UTXO rows. It currently replaces
  the home content; popup presentation is deferred to a UX follow-up.

## Validation

- Go 1.26.8: full local tests, race tests, vet, tidy and diff checks passed.
- Staticcheck 2026.1: no new findings or deprecations in affected packages.
- Deterministic tests cover validation, RPC setup, recovery and result
  ownership; controlled regressions confirmed key assertions detect failures.
- Built and installed exact candidate 55fd3d5. Saved a Signet transaction
  label through the TUI, verified it independently with lncli, and confirmed
  persistence after restarting the TUI.
- Live outage and timing injection were not performed; those cases use
  deterministic automated coverage.